### PR TITLE
Don't evaluate limit to not store activations for limitted namespaces in ActivationStore class

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationStore.scala
@@ -45,11 +45,7 @@ trait ActivationStore {
   def storeAfterCheck(activation: WhiskActivation, context: UserContext)(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
-    if (context.user.limits.storeActivations.getOrElse(true)) {
-      store(activation, context)
-    } else {
-      Future.successful(DocInfo(activation.docid))
-    }
+    store(activation, context)
   }
 
   /**

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactActivationStore.scala
@@ -40,6 +40,11 @@ class ArtifactActivationStore(actorSystem: ActorSystem, actorMaterializer: Actor
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
 
+    if (!(context.user.limits.storeActivations.getOrElse(true))) {
+      // only store activation if limit is not set to false
+      return Future.successful(DocInfo(activation.docid))
+    }
+
     logging.debug(this, s"recording activation '${activation.activationId}'")
 
     val res = WhiskActivation.put(artifactStore, activation)


### PR DESCRIPTION
This PR removes the check for the store activations limit from class _ActivationStore_. Reason is that by implementing the switch here not only storing the activations is disabled, but also the logdna support for user logs is omitted which isn't intended by setting this limit. 
The check for store activations limit will moved to the _ArtifactActivationStore_ class where the activation store is implemented

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

