### PR TITLE
fix certificate generation to support domain name length > 64

### DIFF
--- a/ansible/files/genssl.sh
+++ b/ansible/files/genssl.sh
@@ -42,7 +42,8 @@ function gen_csr(){
   openssl req -new \
       -key "$SCRIPTDIR/${NAME_PREFIX}openwhisk-server-key.pem" \
       -nodes \
-      -subj "/C=US/ST=NY/L=Yorktown/O=OpenWhisk/CN=$CN" \
+      -subj "/C=US/ST=NY/L=Yorktown/O=OpenWhisk/CN=openwhisk" \
+      -addext "subjectAltName=DNS:$CN" \
       -out "$SCRIPTDIR/${NAME_PREFIX}openwhisk-server-request.csr"
 }
 function gen_cert(){
@@ -101,7 +102,8 @@ else
     openssl req -new \
     -key "$SCRIPTDIR/openwhisk-client-ca-key.pem" \
     -passin pass:$PASSWORD \
-    -subj "/C=US/ST=NY/L=Yorktown/O=OpenWhisk/CN=$CN" \
+    -subj "/C=US/ST=NY/L=Yorktown/O=OpenWhisk/CN=openwhisk" \
+    -addext "subjectAltName=DNS:$CN" \
     -out "$SCRIPTDIR/openwhisk-client-ca.csr"
 
     echo generating client ca pem


### PR DESCRIPTION
fix certificate generation to support domain name length > 64

## Description
New IKS clusters have an ingress subdomain name length greater than 64 .
When generating server or client certificates with a CN > than 64 chars, the following error is raised:
```
"problems making Certificate Request", "140418214810048:error:0D07A097:asn1 encoding routines:ASN1_mbstring_ncopy:string too long:../crypto/asn1/a_mbstr.c:107:maxsize=64"
```
openssl limits the CN to maximum of 64 chars.

## Solution
When creating the certificates with the openssl req command, use a short CN and add the long domain names into the field `subjectAltName`.
This is an example out of the openssl man page:
```
openssl req -new -subj "/C=GB/CN=foo" \
                 -addext "subjectAltName = DNS:foo.co.uk" \
                 -addext "certificatePolicies = 1.2.3.4" \
                 -newkey rsa:2048 -keyout key.pem -out req.pem
```

## My changes affect the following components
Affects certificate generation of the following components
- [ ] API
- [x] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [x] nginx
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

