### PR TITLE
Increase maximum wait time value to omit intermittent timeout exceptions

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -68,7 +68,7 @@ class ArtifactWithFileStorageActivationStoreTests()
     super.afterAll()
   }
 
-  private def await[T](awaitable: Future[T], timeout: FiniteDuration = 10.seconds) = Await.result(awaitable, timeout)
+  private def await[T](awaitable: Future[T], timeout: FiniteDuration = 30.seconds) = Await.result(awaitable, timeout)
 
   def responsePermutations = {
     val message = JsObject("result key" -> JsString("result value"))


### PR DESCRIPTION
In our tests we encounter every now and then failing tests that fail because `Futures timed out after 10 seconds` (java.util.concurrent.TimeoutException).

## Description
This code change increases the timeout value from 10 to 30 seconds. Intention is to avoid the following error for awaiting results in `ArtifactWithFileStorageActivationStoreTests` class: `java.util.concurrent.TimeoutException: Futures timed out after [10 seconds]`

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

