### PR TITLE
Make sure database is deleted in tests to avoid error on create

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/DatabaseScriptTestUtils.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/DatabaseScriptTestUtils.scala
@@ -94,6 +94,11 @@ trait DatabaseScriptTestUtils extends ScalaFutures with Matchers with WaitFor wi
       val delete = db.deleteDb().futureValue
       if (!ignoreFailure) delete shouldBe 'right
     }
+    // make sure database is deleted
+    retry {
+      val exist = db.doesDbExist().futureValue
+      exist shouldBe false
+    }
     db
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
@@ -59,6 +59,16 @@ class ExtendedCouchDbRestClient(protocol: String,
   def deleteDb(): Future[Either[StatusCode, JsObject]] =
     requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db), headers = baseHeaders))
 
+  // http://docs.couchdb.org/en/1.6.1/api/database/common.html#head--db
+  def doesDbExist(): Future[Boolean] = {
+    requestJson[JsObject](mkRequest(HttpMethods.HEAD, uri(db), headers = baseHeaders))
+      .map {
+        case Right(_)                   => true
+        case Left(StatusCodes.NotFound) => false
+        case Left(s)                    => throw new IllegalStateException("Unknown status code while checking db:" + s)
+      }
+  }
+
   // http://docs.couchdb.org/en/1.6.1/api/database/bulk-api.html#get--db-_all_docs
   def getAllDocs(skip: Option[Int] = None,
                  limit: Option[Int] = None,


### PR DESCRIPTION
In our tests we encounter every now and then failing tests that fail because `412 Precondition Failed (details: {"error":"file_exists","reason":"The database could not be created, the file already exists."}`.

## Description
This code change checks in addition that a delete database request gets really effective before continuing to create the same database. Intention is to avoid the following error when creating a database: `org.scalatest.exceptions.TestFailedException: Left(412 Precondition Failed (details: {"error":"file_exists","reason":"The database could not be created, the file already exists."}))`

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

