### PR TITLE
Retry for all WskActionTests to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -19,6 +19,7 @@ package system.basic
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -27,6 +28,8 @@ import common.rest.WskRestOperations
 import org.apache.openwhisk.core.entity.Annotations
 import org.apache.commons.io.FileUtils
 import org.apache.openwhisk.core.FeatureFlags
+
+import scala.concurrent.duration._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -45,316 +48,438 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
   behavior of "Whisk actions"
 
   it should "create an action with an empty file" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "empty"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "empty-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should create an action with an empty file not successful, retrying.."))
   }
 
   it should "invoke an action returning a promise" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "hello promise"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("helloPromise.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "hello promise-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("helloPromise.js")))
+          }
 
-    val run = wsk.action.invoke(name)
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.status shouldBe "success"
-      activation.response.result shouldBe Some(JsObject("done" -> true.toJson))
-      activation.logs.get.mkString(" ") shouldBe empty
-    }
+          val run = wsk.action.invoke(name)
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            activation.response.result shouldBe Some(JsObject("done" -> true.toJson))
+            activation.logs.get.mkString(" ") shouldBe empty
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should invoke an action returning a promise not successful, retrying.."))
   }
 
   it should "invoke an action with a space in the name" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "hello Async"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "hello Async-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
+          }
 
-    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.status shouldBe "success"
-      activation.response.result shouldBe Some(testResult)
-      activation.logs.get.mkString(" ") should include(testString)
-    }
+          val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            activation.response.result shouldBe Some(testResult)
+            activation.logs.get.mkString(" ") should include(testString)
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should invoke an action with a space in the name not successful, retrying.."))
   }
 
   it should "invoke an action that throws an uncaught exception and returns correct status code" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
-    val name = "throwExceptionAction"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("runexception.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "throwExceptionAction-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("runexception.js")))
+          }
 
-    withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-      val response = activation.response
-      activation.response.status shouldBe "action developer error"
-      activation.response.result shouldBe Some(
-        JsObject("error" -> "An error has occurred: Extraordinary exception".toJson))
-    }
+          withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+            val response = activation.response
+            activation.response.status shouldBe "action developer error"
+            activation.response.result shouldBe Some(
+              JsObject("error" -> "An error has occurred: Extraordinary exception".toJson))
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should invoke an action that throws an uncaught exception and returns correct status code not successful, retrying.."))
   }
 
   it should "pass parameters bound on creation-time to the action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "printParams"
-    val params = Map("param1" -> "test1", "param2" -> "test2")
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "printParams-" + UUID.randomUUID().toString()
+          val params = Map("param1" -> "test1", "param2" -> "test2")
 
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(
-        name,
-        Some(TestUtils.getTestActionFilename("printParams.js")),
-        parameters = params.mapValues(_.toJson))
-    }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(
+              name,
+              Some(TestUtils.getTestActionFilename("printParams.js")),
+              parameters = params.mapValues(_.toJson))
+          }
 
-    val invokeParams = Map("payload" -> testString)
-    val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson))
-    withActivation(wsk.activation, run) { activation =>
-      val logs = activation.logs.get.mkString(" ")
+          val invokeParams = Map("payload" -> testString)
+          val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson))
+          withActivation(wsk.activation, run) { activation =>
+            val logs = activation.logs.get.mkString(" ")
 
-      (params ++ invokeParams).foreach {
-        case (key, value) =>
-          logs should include(s"params.$key: $value")
-      }
-    }
+            (params ++ invokeParams).foreach {
+              case (key, value) =>
+                logs should include(s"params.$key: $value")
+            }
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should pass parameters bound on creation-time to the action not successful, retrying.."))
   }
 
   it should "copy an action and invoke it successfully" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "copied"
-    val packageName = "samples"
-    val actionName = "wordcount"
-    val fullQualifiedName = s"/$guestNamespace/$packageName/$actionName"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "copied-" + UUID.randomUUID().toString()
+          val packageName = "samples-" + UUID.randomUUID().toString()
+          val actionName = "wordcount"
+          val fullQualifiedName = s"/$guestNamespace/$packageName/$actionName"
 
-    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
-      pkg.create(packageName, shared = Some(true))
-    }
+          assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+            pkg.create(packageName, shared = Some(true))
+          }
 
-    assetHelper.withCleaner(wsk.action, fullQualifiedName) {
-      val file = Some(TestUtils.getTestActionFilename("wc.js"))
-      (action, _) =>
-        action.create(fullQualifiedName, file)
-    }
+          assetHelper.withCleaner(wsk.action, fullQualifiedName) {
+            val file = Some(TestUtils.getTestActionFilename("wc.js"))
+            (action, _) =>
+              action.create(fullQualifiedName, file)
+          }
 
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(fullQualifiedName), Some("copy"))
-    }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(fullQualifiedName), Some("copy"))
+          }
 
-    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.status shouldBe "success"
-      activation.response.result shouldBe Some(testResult)
-      activation.logs.get.mkString(" ") should include(testString)
-    }
+          val run = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            activation.response.result shouldBe Some(testResult)
+            activation.logs.get.mkString(" ") should include(testString)
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should copy an action and invoke it successfully not successful, retrying.."))
   }
 
   it should "copy an action and ensure exec, parameters, and annotations copied" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val origActionName = "origAction"
-      val copiedActionName = "copiedAction"
-      val params = Map("a" -> "A".toJson)
-      val annots = Map("b" -> "B".toJson)
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val origActionName = "origAction-" + UUID.randomUUID().toString()
+            val copiedActionName = "copiedAction-" + UUID.randomUUID().toString()
+            val params = Map("a" -> "A".toJson)
+            val annots = Map("b" -> "B".toJson)
 
-      assetHelper.withCleaner(wsk.action, origActionName) {
-        val file = Some(TestUtils.getTestActionFilename("wc.js"))
-        (action, _) =>
-          action.create(origActionName, file, parameters = params, annotations = annots)
-      }
+            assetHelper.withCleaner(wsk.action, origActionName) {
+              val file = Some(TestUtils.getTestActionFilename("wc.js"))
+              (action, _) =>
+                action.create(origActionName, file, parameters = params, annotations = annots)
+            }
 
-      assetHelper.withCleaner(wsk.action, copiedActionName) { (action, _) =>
-        action.create(copiedActionName, Some(origActionName), Some("copy"))
-      }
+            assetHelper.withCleaner(wsk.action, copiedActionName) { (action, _) =>
+              action.create(copiedActionName, Some(origActionName), Some("copy"))
+            }
 
-      val copiedAction = wsk.parseJsonString(wsk.action.get(copiedActionName).stdout)
-      val origAction = wsk.parseJsonString(wsk.action.get(copiedActionName).stdout)
+            val copiedAction = wsk.parseJsonString(wsk.action.get(copiedActionName).stdout)
+            val origAction = wsk.parseJsonString(wsk.action.get(copiedActionName).stdout)
 
-      copiedAction.fields("annotations") shouldBe origAction.fields("annotations")
-      copiedAction.fields("parameters") shouldBe origAction.fields("parameters")
-      copiedAction.fields("exec") shouldBe origAction.fields("exec")
-      copiedAction.fields("version") shouldBe JsString("0.0.1")
+            copiedAction.fields("annotations") shouldBe origAction.fields("annotations")
+            copiedAction.fields("parameters") shouldBe origAction.fields("parameters")
+            copiedAction.fields("exec") shouldBe origAction.fields("exec")
+            copiedAction.fields("version") shouldBe JsString("0.0.1")
+          },
+          10,
+          Some(1.second),
+          Some(
+            s"system.basic.WskActionTests.Whisk actions.should copy an action and ensure exec, parameters, and annotations copied not successful, retrying.."))
   }
 
   it should "add new parameters and annotations while copying an action" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val runtime = "nodejs:default"
-      val origName = "origAction"
-      val copiedName = "copiedAction"
-      val origParams = Map("origParam1" -> "origParamValue1".toJson, "origParam2" -> 999.toJson)
-      val copiedParams = Map("copiedParam1" -> "copiedParamValue1".toJson, "copiedParam2" -> 123.toJson)
-      val origAnnots = Map("origAnnot1" -> "origAnnotValue1".toJson, "origAnnot2" -> true.toJson)
-      val copiedAnnots = Map("copiedAnnot1" -> "copiedAnnotValue1".toJson, "copiedAnnot2" -> false.toJson)
-      val resParams = Seq(
-        JsObject("key" -> JsString("copiedParam1"), "value" -> JsString("copiedParamValue1")),
-        JsObject("key" -> JsString("copiedParam2"), "value" -> JsNumber(123)),
-        JsObject("key" -> JsString("origParam1"), "value" -> JsString("origParamValue1")),
-        JsObject("key" -> JsString("origParam2"), "value" -> JsNumber(999)))
-      val baseAnnots = Seq(
-        JsObject("key" -> JsString("origAnnot1"), "value" -> JsString("origAnnotValue1")),
-        JsObject("key" -> JsString("copiedAnnot2"), "value" -> JsFalse),
-        JsObject("key" -> JsString("copiedAnnot1"), "value" -> JsString("copiedAnnotValue1")),
-        JsObject("key" -> JsString("origAnnot2"), "value" -> JsTrue),
-        JsObject("key" -> Annotations.ProvideApiKeyAnnotationName.toJson, "value" -> JsFalse))
-      val resAnnots: Seq[JsObject] = if (FeatureFlags.requireApiKeyAnnotation) {
-        baseAnnots ++ Seq(JsObject("key" -> Annotations.ProvideApiKeyAnnotationName.toJson, "value" -> JsFalse))
-      } else baseAnnots
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val runtime = "nodejs:default"
+            val origName = "origAction-" + UUID.randomUUID().toString()
+            val copiedName = "copiedAction-" + UUID.randomUUID().toString()
+            val origParams = Map("origParam1" -> "origParamValue1".toJson, "origParam2" -> 999.toJson)
+            val copiedParams = Map("copiedParam1" -> "copiedParamValue1".toJson, "copiedParam2" -> 123.toJson)
+            val origAnnots = Map("origAnnot1" -> "origAnnotValue1".toJson, "origAnnot2" -> true.toJson)
+            val copiedAnnots = Map("copiedAnnot1" -> "copiedAnnotValue1".toJson, "copiedAnnot2" -> false.toJson)
+            val resParams = Seq(
+              JsObject("key" -> JsString("copiedParam1"), "value" -> JsString("copiedParamValue1")),
+              JsObject("key" -> JsString("copiedParam2"), "value" -> JsNumber(123)),
+              JsObject("key" -> JsString("origParam1"), "value" -> JsString("origParamValue1")),
+              JsObject("key" -> JsString("origParam2"), "value" -> JsNumber(999)))
+            val baseAnnots = Seq(
+              JsObject("key" -> JsString("origAnnot1"), "value" -> JsString("origAnnotValue1")),
+              JsObject("key" -> JsString("copiedAnnot2"), "value" -> JsFalse),
+              JsObject("key" -> JsString("copiedAnnot1"), "value" -> JsString("copiedAnnotValue1")),
+              JsObject("key" -> JsString("origAnnot2"), "value" -> JsTrue),
+              JsObject("key" -> Annotations.ProvideApiKeyAnnotationName.toJson, "value" -> JsFalse))
+            val resAnnots: Seq[JsObject] = if (FeatureFlags.requireApiKeyAnnotation) {
+              baseAnnots ++ Seq(JsObject("key" -> Annotations.ProvideApiKeyAnnotationName.toJson, "value" -> JsFalse))
+            } else baseAnnots
 
-      assetHelper.withCleaner(wsk.action, origName) {
-        val file = Some(TestUtils.getTestActionFilename("echo.js"))
-        (action, _) =>
-          action.create(origName, file, parameters = origParams, annotations = origAnnots, kind = Some(runtime))
-      }
+            assetHelper.withCleaner(wsk.action, origName) {
+              val file = Some(TestUtils.getTestActionFilename("echo.js"))
+              (action, _) =>
+                action.create(origName, file, parameters = origParams, annotations = origAnnots, kind = Some(runtime))
+            }
 
-      assetHelper.withCleaner(wsk.action, copiedName) { (action, _) =>
-        println("created copied ")
-        action.create(copiedName, Some(origName), Some("copy"), parameters = copiedParams, annotations = copiedAnnots)
-      }
+            assetHelper.withCleaner(wsk.action, copiedName) { (action, _) =>
+              println("created copied ")
+              action
+                .create(copiedName, Some(origName), Some("copy"), parameters = copiedParams, annotations = copiedAnnots)
+            }
 
-      val copiedAction = wsk.parseJsonString(wsk.action.get(copiedName).stdout)
+            val copiedAction = wsk.parseJsonString(wsk.action.get(copiedName).stdout)
 
-      // first we check the returned execution runtime for 'nodejs:*'
-      copiedAction
-        .fields("annotations")
-        .convertTo[Seq[JsObject]]
-        .find(_.fields("key").convertTo[String] == "exec")
-        .map(_.fields("value"))
-        .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
-        .getOrElse(fail())
+            // first we check the returned execution runtime for 'nodejs:*'
+            copiedAction
+              .fields("annotations")
+              .convertTo[Seq[JsObject]]
+              .find(_.fields("key").convertTo[String] == "exec")
+              .map(_.fields("value"))
+              .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
+              .getOrElse(fail())
 
-      // CLI does not guarantee order of annotations and parameters so do a diff to compare the values
-      copiedAction.fields("parameters").convertTo[Seq[JsObject]] diff resParams shouldBe List.empty
+            // CLI does not guarantee order of annotations and parameters so do a diff to compare the values
+            copiedAction.fields("parameters").convertTo[Seq[JsObject]] diff resParams shouldBe List.empty
 
-      // for the anotations we ignore the exec field here, since we already compared it above
-      copiedAction
-        .fields("annotations")
-        .convertTo[Seq[JsObject]]
-        .filter(annotation => annotation.fields("key").convertTo[String] != "exec") diff resAnnots shouldBe List.empty
+            // for the anotations we ignore the exec field here, since we already compared it above
+            copiedAction
+              .fields("annotations")
+              .convertTo[Seq[JsObject]]
+              .filter(annotation => annotation.fields("key").convertTo[String] != "exec") diff resAnnots shouldBe List.empty
+          },
+          10,
+          Some(1.second),
+          Some(
+            s"system.basic.WskActionTests.Whisk actions.should add new parameters and annotations while copying an action not successful, retrying.."))
 
   }
 
   it should "recreate and invoke a new action with different code" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "recreatedAction"
-    assetHelper.withCleaner(wsk.action, name, false) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "recreatedAction-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name, false) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
+          }
 
-    val run1 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-    withActivation(wsk.activation, run1) { activation =>
-      activation.response.status shouldBe "success"
-      activation.logs.get.mkString(" ") should include(s"The message '$testString' has")
-    }
+          val run1 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+          withActivation(wsk.activation, run1) { activation =>
+            activation.response.status shouldBe "success"
+            activation.logs.get.mkString(" ") should include(s"The message '$testString' has")
+          }
 
-    wsk.action.delete(name)
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
-    }
+          wsk.action.delete(name)
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
+          }
 
-    val run2 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
-    withActivation(wsk.activation, run2) { activation =>
-      activation.response.status shouldBe "success"
-      activation.logs.get.mkString(" ") should include(s"hello, $testString")
-    }
+          val run2 = wsk.action.invoke(name, Map("payload" -> testString.toJson))
+          withActivation(wsk.activation, run2) { activation =>
+            activation.response.status shouldBe "success"
+            activation.logs.get.mkString(" ") should include(s"hello, $testString")
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should recreate and invoke a new action with different code not successful, retrying.."))
   }
 
   it should "fail to invoke an action with an empty file" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "empty"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
-    }
-    val run = wsk.action.invoke(name)
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.status shouldBe "action developer error"
-      activation.response.result shouldBe Some(JsObject("error" -> "Missing main/no code to execute.".toJson))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "empty-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
+          }
+          val run = wsk.action.invoke(name)
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "action developer error"
+            activation.response.result shouldBe Some(JsObject("error" -> "Missing main/no code to execute.".toJson))
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should fail to invoke an action with an empty file not successful, retrying.."))
   }
 
   it should "blocking invoke of nested blocking actions" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "nestedBlockingAction"
-    val child = "wc"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nestedBlockingAction-" + UUID.randomUUID().toString()
+          val child = "wc"
 
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      val annotations =
-        if (FeatureFlags.requireApiKeyAnnotation) Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue)
-        else Map.empty[String, JsValue]
-      action.create(name, Some(TestUtils.getTestActionFilename("wcbin.js")), annotations = annotations)
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            val annotations =
+              if (FeatureFlags.requireApiKeyAnnotation) Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue)
+              else Map.empty[String, JsValue]
+            action.create(name, Some(TestUtils.getTestActionFilename("wcbin.js")), annotations = annotations)
 
-    }
-    assetHelper.withCleaner(wsk.action, child) { (action, _) =>
-      action.create(child, Some(TestUtils.getTestActionFilename("wc.js")))
-    }
+          }
+          assetHelper.withCleaner(wsk.action, child) { (action, _) =>
+            action.create(child, Some(TestUtils.getTestActionFilename("wc.js")))
+          }
 
-    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
-    val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
+          val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
+          val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
 
-    withClue(s"check failed for activation: $activation") {
-      val wordCount = testString.split(" ").length
-      activation.response.result.get shouldBe JsObject("binaryCount" -> s"${wordCount.toBinaryString} (base 2)".toJson)
-    }
+          withClue(s"check failed for activation: $activation") {
+            val wordCount = testString.split(" ").length
+            activation.response.result.get shouldBe JsObject(
+              "binaryCount" -> s"${wordCount.toBinaryString} (base 2)".toJson)
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should blocking invoke of nested blocking actions not successful, retrying.."))
   }
 
   it should "blocking invoke an asynchronous action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "helloAsync"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "helloAsync-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
+          }
 
-    val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
-    val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
+          val run = wsk.action.invoke(name, Map("payload" -> testString.toJson), blocking = true)
+          val activation = wsk.parseJsonString(run.stdout).convertTo[ActivationResult]
 
-    withClue(s"check failed for activation: $activation") {
-      activation.response.status shouldBe "success"
-      activation.response.result shouldBe Some(testResult)
-      activation.logs shouldBe Some(List.empty)
-    }
+          withClue(s"check failed for activation: $activation") {
+            activation.response.status shouldBe "success"
+            activation.response.result shouldBe Some(testResult)
+            activation.logs shouldBe Some(List.empty)
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should blocking invoke an asynchronous action not successful, retrying.."))
   }
 
   it should "not be able to use 'ping' in an action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "ping"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("ping.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "ping-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("ping.js")))
+          }
 
-    val run = wsk.action.invoke(name, Map("payload" -> "google.com".toJson))
-    withActivation(wsk.activation, run) { activation =>
-      val result = activation.response.result.get
-      result.getFields("stdout", "code") match {
-        case Seq(JsString(stdout), JsNumber(code)) =>
-          stdout should not include "bytes from"
-          code.intValue should not be 0
-        case _ => fail(s"fields 'stdout' or 'code' where not of the expected format, was $result")
-      }
-    }
+          val run = wsk.action.invoke(name, Map("payload" -> "google.com".toJson))
+          withActivation(wsk.activation, run) { activation =>
+            val result = activation.response.result.get
+            result.getFields("stdout", "code") match {
+              case Seq(JsString(stdout), JsNumber(code)) =>
+                stdout should not include "bytes from"
+                code.intValue should not be 0
+              case _ => fail(s"fields 'stdout' or 'code' where not of the expected format, was $result")
+            }
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should not be able to use 'ping' in an action not successful, retrying.."))
   }
 
   it should "support UTF-8 as input and output format" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "utf8Test"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "utf8Test-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
+          }
 
-    val utf8 = "«ταБЬℓσö»: 1<2 & 4+1>³, now 20%€§$ off!"
-    val run = wsk.action.invoke(name, Map("payload" -> utf8.toJson))
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.status shouldBe "success"
-      activation.logs.get.mkString(" ") should include(s"hello, $utf8")
-    }
+          val utf8 = "«ταБЬℓσö»: 1<2 & 4+1>³, now 20%€§$ off!"
+          val run = wsk.action.invoke(name, Map("payload" -> utf8.toJson))
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            activation.logs.get.mkString(" ") should include(s"hello, $utf8")
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should support UTF-8 as input and output format not successful, retrying.."))
   }
 
   it should "invoke action with large code" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "big-hello"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      val filePath = TestUtils.getTestActionFilename("hello.js")
-      val code = FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8)
-      val largeCode = code + " " * (WhiskProperties.getMaxActionSizeMB * FileUtils.ONE_MB).toInt
-      val tmpFile = File.createTempFile("whisk", ".js")
-      FileUtils.write(tmpFile, largeCode, StandardCharsets.UTF_8)
-      val result = action.create(name, Some(tmpFile.getAbsolutePath))
-      tmpFile.delete()
-      result
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "big-hello-" + UUID.randomUUID().toString()
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            val filePath = TestUtils.getTestActionFilename("hello.js")
+            val code = FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8)
+            val largeCode = code + " " * (WhiskProperties.getMaxActionSizeMB * FileUtils.ONE_MB).toInt
+            val tmpFile = File.createTempFile("whisk", ".js")
+            FileUtils.write(tmpFile, largeCode, StandardCharsets.UTF_8)
+            val result = action.create(name, Some(tmpFile.getAbsolutePath))
+            tmpFile.delete()
+            result
+          }
 
-    val hello = "hello"
-    val run = wsk.action.invoke(name, Map("payload" -> hello.toJson))
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.status shouldBe "success"
-      activation.logs.get.mkString(" ") should include(s"hello, $hello")
-    }
+          val hello = "hello"
+          val run = wsk.action.invoke(name, Map("payload" -> hello.toJson))
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            activation.logs.get.mkString(" ") should include(s"hello, $hello")
+          }
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"system.basic.WskActionTests.Whisk actions.should invoke action with large code not successful, retrying.."))
   }
 
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

