### PR TITLE
Add activity tracker audit logs

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/FileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/FileStorage.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database
+
+import java.nio.file.attribute.PosixFilePermission._
+import java.nio.file.{Files, Path}
+import java.time.Instant
+import java.util.EnumSet
+
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.file.scaladsl.LogRotatorSink
+import akka.stream.scaladsl.{MergeHub, RestartSink, Sink, Source}
+import akka.util.ByteString
+import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.core.entity.size._
+
+import scala.concurrent.duration._
+
+class FileStorage(logFilePrefix: String, logPath: Path, actorMaterializer: ActorMaterializer, logging: Logging) {
+
+  implicit val materializer = actorMaterializer
+
+  private var logFile = logPath
+  private val bufferSize = 25.MB
+  private val perms = EnumSet.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE, OTHERS_READ, OTHERS_WRITE)
+  private val writeToFile: Sink[ByteString, _] = MergeHub
+    .source[ByteString]
+    .batchWeighted(bufferSize.toBytes, _.length, identity)(_ ++ _)
+    .to(RestartSink.withBackoff(minBackoff = 1.seconds, maxBackoff = 60.seconds, randomFactor = 0.2) { () =>
+      LogRotatorSink(() => {
+        val maxSize = bufferSize.toBytes
+        var bytesRead = maxSize
+        element =>
+          {
+            val size = element.size
+
+            if (bytesRead + size > maxSize) {
+              logFile = logPath.resolve(s"$logFilePrefix-${Instant.now.toEpochMilli}.log")
+
+              logging.info(this, s"Rotating log file to '$logFile'")
+              createLogFile(logFile)
+              bytesRead = size
+              Some(logFile)
+            } else {
+              bytesRead += size
+              None
+            }
+          }
+      })
+    })
+    .run()
+
+  private def createLogFile(path: Path) =
+    try {
+      Files.createFile(path)
+      Files.setPosixFilePermissions(path, perms)
+    } catch {
+      case t: Throwable =>
+        logging.error(this, s"Couldn't create user log file '$t'")
+        throw t
+    }
+
+  def store(line: String): Unit = {
+    Source.single(ByteString(line + "\n")).runWith(writeToFile)
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
@@ -1,0 +1,502 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.entity
+
+import java.text.SimpleDateFormat
+
+import org.apache.openwhisk.common.{Logging, TransactionId}
+
+import scala.collection.immutable
+import spray.json.{JsBoolean, JsNumber, JsObject, JsString}
+import java.net.URL
+import java.util.Base64
+
+import scala.util.matching.Regex
+import scala.util.Try
+
+/**
+ * Activity Tracker event definition and json serialization
+ *
+ * @param logSourceCRN logDNA target crn
+ * @param saveServiceCopy logDNA flag for storing a copy in the cloud functions system log
+ */
+case class ActivityEvent(initiator: Initiator,
+                         target: Target,
+                         action: String,
+                         outcome: String,
+                         reason: Reason,
+                         severity: String,
+                         message: String,
+                         logSourceCRN: String,
+                         saveServiceCopy: Boolean,
+                         dataEvent: Boolean,
+                         id: String,
+                         requestData: RequestData)
+    extends ActivityUtils {
+
+  private def eventTimeFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS+0000")
+
+  def toJson =
+    JsObject(
+      Map(
+        "initiator" -> initiator.toJson,
+        "target" -> target.toJson,
+        "action" -> getJsString(action),
+        "outcome" -> getJsString(outcome),
+        "reason" -> reason.toJson,
+        "severity" -> getJsString(severity), // normal, warning, critical
+        "eventTime" -> getJsString(eventTimeFormatter.format(System.currentTimeMillis)),
+        "message" -> getJsString(message),
+        "logSourceCRN" -> getJsString(logSourceCRN),
+        "saveServiceCopy" -> JsBoolean(saveServiceCopy),
+        "observer" -> Observer().toJson,
+        "dataEvent" -> JsBoolean(dataEvent),
+        "id" -> getJsString(id),
+        "requestData" -> requestData.toJson,
+        "responseData" -> JsObject()))
+}
+
+case class RequestData(method: String, url: String, userAgent: String, failure: String, resourceGroupCrn: String)
+    extends ActivityUtils {
+  def toJson =
+    JsObject(
+      if (failure.isEmpty)
+        Map(
+          "method" -> getJsString(method),
+          "url" -> getJsString(url),
+          "userAgent" -> getJsString(userAgent),
+          "resourceGroupId" -> getJsString(resourceGroupCrn)) // misleading field name, resourceGroupId is a CRN
+      else
+        Map(
+          "method" -> getJsString(method),
+          "url" -> getJsString(url),
+          "userAgent" -> getJsString(userAgent),
+          "reasonForFailure" -> getJsString(failure),
+          "resourceGroupId" -> getJsString(resourceGroupCrn))) // misleading field name, resourceGroupId is a CRN
+}
+
+case class Observer() extends ActivityUtils {
+  def toJson = JsObject(Map("name" -> getJsString("ActivityTracker")))
+}
+
+case class Target(id: String, name: String, typeURI: String) extends ActivityUtils {
+  def toJson =
+    JsObject(Map("id" -> getJsString(id), "name" -> getJsString(name), "typeURI" -> getJsString(typeURI)))
+}
+
+case class TargetHost(address: String) extends ActivityUtils {
+  def toJson = JsObject(Map("address" -> getJsString(address)))
+}
+
+case class Initiator(id: String, name: String, typeURI: String, credential: InitiatorCredential, host: InitiatorHost)
+    extends ActivityUtils {
+  def toJson =
+    JsObject(
+      Map(
+        "id" -> getJsString(id),
+        "name" -> getJsString(name),
+        "typeURI" -> getJsString(typeURI),
+        "credential" -> credential.toJson,
+        "host" -> host.toJson))
+}
+
+// agent is no official field but contains helpful information
+case class InitiatorHost(address: String) extends ActivityUtils {
+  def toJson = JsObject(Map("address" -> getJsString(address)))
+}
+
+case class InitiatorCredential(typeURI: String) extends ActivityUtils {
+  def toJson = JsObject(Map("type" -> getJsString(typeURI)))
+}
+
+case class Reason(reasonCode: String, reasonType: String) extends ActivityUtils {
+  def toJson =
+    JsObject(Map("reasonCode" -> getJsNumber(reasonCode), "reasonType" -> getJsString(reasonType)))
+}
+
+case class ApiMatcherResult(actionType: String, logMessage: String, targetName: String, targetType: String)
+
+trait ActivityUtils {
+
+  def getJsString(s: String): JsString = { if (s == null) JsString("(null)") else JsString(s) }
+  def getJsNumber(s: String): JsNumber = { if (s == null) JsNumber("0") else JsNumber(s) }
+
+  // fast path from reasonCode to short description
+  def getReasonType(reasonCode: String): String = reasonTypes.getOrElse(reasonCode, "Unassigned")
+
+  private val reasonTypes = immutable.HashMap(
+    "0" -> "Not Set",
+    "100" -> "Continue",
+    "101" -> "Switching Protocols",
+    "102" -> "Processing",
+    "103" -> "Early Hints",
+    "200" -> "OK",
+    "201" -> "Created",
+    "202" -> "Accepted",
+    "203" -> "Non-Authoritative Information",
+    "204" -> "No Content",
+    "205" -> "Reset Content",
+    "206" -> "Partial Content",
+    "207" -> "Multi-Status",
+    "208" -> "Already Reported",
+    "226" -> "IM Used",
+    "300" -> "Multiple Choices",
+    "301" -> "Moved Permanently",
+    "302" -> "Found",
+    "303" -> "See Other",
+    "304" -> "Not Modified",
+    "305" -> "Use Proxy",
+    "307" -> "Temporary Redirect",
+    "308" -> "Permanent Redirect",
+    "400" -> "Bad Request",
+    "401" -> "Unauthorized",
+    "402" -> "Payment Required",
+    "403" -> "Forbidden",
+    "404" -> "Not Found",
+    "405" -> "Method Not Allowed",
+    "406" -> "Not Acceptable",
+    "407" -> "Proxy Authentication Required",
+    "408" -> "Request Timeout",
+    "409" -> "Conflict",
+    "410" -> "Gone",
+    "411" -> "Length Required",
+    "412" -> "Precondition Failed",
+    "413" -> "Payload Too Large",
+    "414" -> "URI Too Long",
+    "415" -> "Unsupported Media Type",
+    "416" -> "Range Not Satisfiable",
+    "417" -> "Expectation Failed",
+    "421" -> "Misdirected Request",
+    "422" -> "Unprocessable Entity",
+    "423" -> "Locked",
+    "424" -> "Failed Dependency",
+    "425" -> "Too Early",
+    "426" -> "Upgrade Required",
+    "428" -> "Precondition Required",
+    "429" -> "Too Many Requests",
+    "430" -> "Unassigned",
+    "431" -> "Request Header Fields Too Large",
+    "451" -> "Unavailable For Legal Reasons",
+    "500" -> "Internal Server Error",
+    "501" -> "Not Implemented",
+    "502" -> "Bad Gateway",
+    "503" -> "Service Unavailable",
+    "504" -> "Gateway Timeout",
+    "505" -> "HTTP Version Not Supported",
+    "506" -> "Variant Also Negotiates",
+    "507" -> "Insufficient Storage",
+    "508" -> "Loop Detected",
+    "509" -> "Unassigned",
+    "510" -> "Not Extended",
+    "511" -> "Network Authentication Required")
+
+  private val ignoredUsers = List("lime@us.ibm.com", "whisk.system")
+
+  def isIgnoredUser(name: String): Boolean = ignoredUsers.contains(name)
+
+  private val grantTypes = immutable.HashMap(
+    "urn:ibm:params:oauth:grant-type:apikey" -> "apikey",
+    "urn:ibm:params:oauth:grant-type:delegated-refresh-token" -> "token",
+    "urn:ibm:params:oauth:grant-type:passcode" -> "user",
+    "authorization_code" -> "user",
+    "password" -> "user")
+
+  def getGrantType(reasonCode: String): String = grantTypes.getOrElse(reasonCode, "unknown")
+
+  /**
+   * Returns the position of the n-th occurrence of a substring within a string.
+   *
+   * @param str string
+   * @param substr substring to search for
+   * @param n occurrence number, starting with 1
+   * @return position of the n-th occurrence of substr, or -1 if not found
+   */
+  def posN(str: String, substr: String, n: Int): Int = {
+    if (n > 0) {
+      if (substr.isEmpty) 0
+      else {
+        var pos = str.indexOf(substr)
+        var i = n - 1
+        while (i > 0 && pos != -1) {
+          pos = str.indexOf(substr, pos + 1)
+          i -= 1
+        }
+        pos
+      }
+    } else -1
+  }
+
+  /**
+   * Reduces string input if it is too long.
+   *
+   * @param s input string
+   * @param maxlen max length allowed
+   * @return s reduced to first maxlen chars, or empty string if s is null
+   */
+  def getString(s: String, maxlen: Int): String = {
+    if (s == null) ""
+    else if (s.length > maxlen) s.substring(0, maxlen) + "..."
+    else s
+  }
+
+  // API matchers
+
+  // no audit events for: activations API, action invocations, list all resources of a type
+
+  /**
+   * Returns the ApiMatcherResult (= actionType, logMessage, entityName) for the given uri and http method
+   * if event should be logged. Returns null, otherwise.
+   *
+   * @param httpMethod http method of the request
+   * @param uri uri of the request
+   * @return instance of ApiMatcherResult, or null if event should not be logged
+   */
+  def getServiceAction(transid: TransactionId, httpMethod: String, uri: String, logger: Logging): ApiMatcherResult = {
+    val url = Try { new URL(uri) }.getOrElse(null)
+    if (url == null) {
+      logger.error(this, "audit.log - invalid or emtpy URL: " + uri)(id = transid)
+      null
+    } else {
+      val urlPath = url.getPath
+      if (urlPath == "/ping")
+        null
+      else {
+        val method = if (httpMethod == null) "UNKNOWN" else httpMethod.toUpperCase
+        matchAPI("action", actionsAPIMatcher, method, urlPath) // actions API
+          .getOrElse(
+            matchAPI("package", packagesAPIMatcher, method, urlPath) // packages API
+              .getOrElse(
+                matchRulesAPI(transid, method, urlPath, logger) // rules API
+                  .getOrElse(matchAPI("trigger", triggersAPIMatcher, method, urlPath) // triggers API
+                    .getOrElse(matchOther(transid, method, urlPath, logger).orNull)))) // nothing to add to the log
+      }
+    }
+  }
+
+  private val thisService = "functions"
+  private val messagePrefix = "IBM Cloud Functions: "
+
+  /**
+   * Converts a target crn to a logSourceCRN (removes all sections after account scope section)
+   * Example:
+   * in:  crn:v1:bluemix:public:functions:us-south:a/eb2ee6585c91a27a709a44e2652a381a:94d7acb2-0604-403e-a2bb-eb4d34fbf154::
+   * out: crn:v1:bluemix:public:functions:us-south:a/eb2ee6585c91a27a709a44e2652a381a:::
+   *
+   * @param crn target crn
+   * @return logsourceCRN for LogDNA
+   */
+  def convertToLogSourceCRN(crn: String): String = {
+    val endOfAccountPos = posN(crn, ":", 7)
+    if (endOfAccountPos > 0) crn.substring(0, endOfAccountPos) + ":::" else crn
+  }
+
+  /**
+   * Extract service instance segment from crn
+   * in:  crn:v1:bluemix:public:functions:us-south:a/eb2ee6585c91a27a709a44e2652a381a:94d7acb2-0604-403e-a2bb-eb4d34fbf154::
+   * out: 94d7acb2-0604-403e-a2bb-eb4d34fbf154
+   * @param crn target crn
+   * @return content of service instance segment or empty string if error
+   */
+  def extractInstance(crn: String): String = {
+    val startOfInstancePos = posN(crn, ":", 7) + 1
+    val endOfInstancePos = posN(crn, ":", 8)
+    if (startOfInstancePos > 0 && endOfInstancePos > 0) crn.substring(startOfInstancePos, endOfInstancePos) else ""
+  }
+
+  /**
+   * Extract scope segment from crn
+   * in:  crn:v1:bluemix:public:functions:us-south:a/eb2ee6585c91a27a709a44e2652a381a:94d7acb2-0604-403e-a2bb-eb4d34fbf154::
+   * out: a/eb2ee6585c91a27a709a44e2652a381a
+   * @param crn target crn
+   * @return content of scope segment without prefix a/ or empty string if error
+   */
+  def extractScope(crn: String): String = {
+    if (crn == null)
+      ""
+    else {
+      val startOfScopePos = posN(crn, ":", 6) + 1
+      val endOfScopePos = posN(crn, ":", 7)
+      if (startOfScopePos > 0 && endOfScopePos > 0 && startOfScopePos < endOfScopePos)
+        crn.substring(startOfScopePos, endOfScopePos)
+      else ""
+    }
+  }
+
+  /**
+   * Retrieve targetId from transaction id meta tags tagTargetIdEncoded and tagTargetId.
+   *
+   * If tagTargetIdEncoded is defined then basic authentication was applied that stored the base64-encoded targetId
+   * in tagTargetIdEncoded. Otherwise, iam token authentication was applied and the targetId is stored in tagTargetId.
+   *
+   * @param transid TransactionId
+   * @return
+   */
+  def getTargetId(transid: TransactionId): String = {
+    val targetIdEncoded = transid.getTag(TransactionId.tagTargetIdEncoded)
+
+    val result = if (targetIdEncoded.isEmpty) {
+      transid.getTag(TransactionId.tagTargetId)
+    } else
+      Try { new String(Base64.getDecoder.decode(targetIdEncoded)) }.getOrElse("")
+
+    if (result == null) "null" else result
+  }
+
+  // uri example:
+  // https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/hello10?blocking=true&result=false
+  private val actionsAPIMatcher = """/api/v1/namespaces/.*/actions/.*""".r
+  private val triggersAPIMatcher = """/api/v1/namespaces/.*/triggers/.*""".r
+  private val packagesAPIMatcher = """/api/v1/namespaces/.*/packages/.*""".r
+  private val rulesAPIMatcher = """/api/v1/namespaces/.*/rules/.*""".r
+
+  private val namespacePos = "/api/v1/namespaces/".length
+
+  private def getEntityName(path: String, entityType: String) = {
+    val pos = path.indexOf("/" + entityType + "/") + ("/" + entityType + "/").length
+    path.substring(pos)
+  }
+
+  /**
+   * a matcher used for the APIs of actions, triggers and packages
+   *
+   * @param entityType action, trigger, package
+   * @param matcher actionsAPIMatcher, triggersAPIMatcher, triggersAPIMatcher
+   * @param method http method of the request
+   * @param uri uri of the request
+   * @return Some(ApiMatcherResult) or None
+   */
+  def matchAPI(entityType: String, matcher: Regex, method: String, uri: String): Option[ApiMatcherResult] = {
+    // ignored: invoke action, list all actions
+    val entityTypePathSelector = entityType + "s" // plural of entityType
+    val targetType = thisService + "/" + entityType
+    val actionTypePrefix = thisService + "." + entityType
+    uri match {
+      case matcher() =>
+        val pos = uri.indexOf("/" + entityTypePathSelector + "/") + ("/" + entityTypePathSelector + "/").length
+        val targetName = uri.substring(pos)
+        method match {
+          case "GET" =>
+            Some(
+              ApiMatcherResult(
+                actionTypePrefix + ".read",
+                messagePrefix + "get " + entityType + " " + targetName,
+                targetName,
+                targetType))
+          case "PUT" =>
+            Some(
+              ApiMatcherResult(
+                actionTypePrefix + ".create",
+                messagePrefix + "create " + entityType + " " + targetName,
+                targetName,
+                targetType))
+          case "DELETE" =>
+            Some(
+              ApiMatcherResult(
+                actionTypePrefix + ".delete",
+                messagePrefix + "delete " + entityType + " " + targetName,
+                targetName,
+                targetType))
+          case _ => None
+        }
+      case _ =>
+        None
+    }
+  }
+
+  /**
+   * Matcher for the rules API. In contrast to other entities the POST method (enable/disable a rule) is logged
+   *
+   * @param method http method of the request
+   * @param uri uri of the request
+   * @return Some(ApiMatcherResult) or None
+   */
+  def matchRulesAPI(transid: TransactionId, method: String, uri: String, logger: Logging): Option[ApiMatcherResult] = {
+    // ignored: list all rules
+    val targetType = thisService + "/" + "rule"
+    uri match {
+      case rulesAPIMatcher() =>
+        val pos = uri.indexOf("/rules/") + "/rules/".length
+        val ruleName = uri.substring(pos)
+        method match {
+          case "GET" =>
+            Some(
+              ApiMatcherResult(
+                thisService + ".rule.read",
+                messagePrefix + "get rule " + ruleName,
+                ruleName,
+                targetType))
+          case "PUT" =>
+            Some(
+              ApiMatcherResult(
+                thisService + ".rule.create",
+                messagePrefix + "create rule " + ruleName,
+                ruleName,
+                targetType))
+          case "DELETE" =>
+            Some(
+              ApiMatcherResult(
+                thisService + ".rule.delete",
+                messagePrefix + "delete rule " + ruleName,
+                ruleName,
+                targetType))
+          case "POST" =>
+            val requestedStatus = transid.getTag(TransactionId.tagRequestedStatus)
+            requestedStatus match {
+              case "active" =>
+                Some(
+                  ApiMatcherResult(
+                    thisService + ".rule.enable",
+                    messagePrefix + "enable rule " + ruleName,
+                    ruleName,
+                    targetType))
+              case "inactive" =>
+                Some(
+                  ApiMatcherResult(
+                    thisService + ".rule.disable",
+                    messagePrefix + "disable rule " + ruleName,
+                    ruleName,
+                    targetType))
+              case _ =>
+                logger.error(this, "audit.log - rules API, POST: unexpected requested status: " + requestedStatus)(
+                  id = transid)
+                None
+            }
+          case _ => None
+        }
+      case _ =>
+        None
+    }
+  }
+
+  /**
+   * This matcher is finally called if there are no other matches in getServiceAction.
+   * In other words, no event should be generated for this request (e.g., for invoke action, list all namespaces, etc.).
+   *
+   * @param method http method of the request
+   * @param uri uri of the request
+   * @return None
+   */
+  def matchOther(transactionId: TransactionId,
+                 method: String,
+                 uri: String,
+                 logger: Logging): Option[ApiMatcherResult] = {
+    logger.debug(this, "audit log - no event created for method=" + method + ", uri=" + uri)(id = transactionId)
+    None
+  }
+
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
@@ -393,7 +393,7 @@ trait ActivityUtils {
           case "GET" =>
             Some(
               ApiMatcherResult(
-                actionTypePrefix + ".read",
+                actionTypePrefix + ".get",
                 messagePrefix + "get " + entityType + " " + targetName,
                 targetName,
                 targetType))
@@ -435,11 +435,7 @@ trait ActivityUtils {
         method match {
           case "GET" =>
             Some(
-              ApiMatcherResult(
-                thisService + ".rule.read",
-                messagePrefix + "get rule " + ruleName,
-                ruleName,
-                targetType))
+              ApiMatcherResult(thisService + ".rule.get", messagePrefix + "get rule " + ruleName, ruleName, targetType))
           case "PUT" =>
             Some(
               ApiMatcherResult(

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -47,7 +47,7 @@ import scala.concurrent.Future
 /**
  * Base class for activity trackers that are called in BasicHttpService on the request path (requestHandler),
  * and on the response path (responseHandler). The method isActive determines whether the activity tracker
- * should activated.
+ * should used. If isActive returns false then requestHandler and responseHandlerAsync are not called.
  *
  * The Activity Tracker is instantiated in the Controller class. The related instance is stored in the companion
  * object of BasicHttpService. The Activity Tracker is not (yet) loaded as a SPI.
@@ -63,9 +63,9 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem,
                                        logPath: String) {
 
   /** requestHandler is called before each request is processed. It collects data that is required for
-   * creating activity events. No further processing should be performed in requestHandler.
-   * requestHandler is assumed to be fast, i.e. incoming requests are not slowed down. Therefore no separate
-   * future needs to be created. Should requestHandler have to contain long running parts then these parts
+   * creating activity events. No further processing should be performed in requestHandler. requestHandler
+   * should be fast, incoming requests should not be slowed down. No separate future is created for the
+   * requestHandler. Should a requestHandler have to contain long running parts then these parts
    * should run asynchronously (which in turn might have to be synchronized with responseHandlerAsync).
    *
    * @param transid transaction id
@@ -74,9 +74,9 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem,
   def requestHandler(transid: TransactionId, req: HttpRequest): Unit
 
   /**
-   * responseHandlerAsync creates activity events based on the collected data and writes the events to the activity log.
-   * responseHandlerAsync is considered a to be little more time consuming is therefore defined as a future.
-   * in order to not slow down the response for the API caller.
+   * responseHandlerAsync creates activity events based on the collected data and writes the events to the
+   * activity log. responseHandlerAsync is considered a to be little more time consuming and is therefore
+   * defined as a future in order to not slow down the response for the API caller.
    *
    * @param transid transaction id
    * @param resp outgoing http response

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -93,7 +93,7 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem,
   def isActive: Boolean = false
 }
 
-// ActivityTracker Implementation.
+// ActivityTracker Implementation
 //
 // The following implementation creates activity events that are based on the CADF
 // standard https://www.dmtf.org/sites/default/files/standards/documents/DSP0262_1.0.0.pdf

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -49,7 +49,7 @@ import scala.concurrent.Future
  * and on the response path (responseHandler). The method isActive determines whether the activity tracker
  * should used. If isActive returns false then both requestHandler and responseHandlerAsync are not called.
  *
- * The Activity Tracker is instantiated in the Controller class. The related instance is stored in the companion
+ * The Activity Tracker is instantiated by the Controller class. The related instance is stored in the companion
  * object of BasicHttpService. The Activity Tracker is not (yet) loaded as a SPI.
  *
  * @param actorSystem actor system

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -275,7 +275,7 @@ class ActivityTracker(actorSystem: ActorSystem,
             message = logMessage,
             logSourceCRN = convertToLogSourceCRN(targetId),
             saveServiceCopy = true,
-            dataEvent = false,
+            dataEvent = serviceAction.isDataEvent,
             id = transid.toString,
             requestData)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.http
+
+import java.nio.file.Paths
+
+import scala.util.Try
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.ActorMaterializer
+import kamon.Kamon
+import org.apache.openwhisk.common.{Logging, TransactionId}
+import org.apache.openwhisk.core.database.FileStorage
+import org.apache.openwhisk.core.entity.{
+  ActivityEvent,
+  ActivityUtils,
+  ApiMatcherResult,
+  Initiator,
+  InitiatorCredential,
+  InitiatorHost,
+  Reason,
+  RequestData,
+  Target
+}
+
+import scala.concurrent.Future
+
+/**
+ * Base class for activity trackers that are called in BasicHttpService on the request path (requestHandler),
+ * and on the response path (responseHandler). The method isActive determines whether the activity tracker
+ * should activated.
+ *
+ * The Activity Tracker is instantiated in the Controller class. The related instance is stored in the companion
+ * object of BasicHttpService. The Activity Tracker is not (yet) loaded as a SPI.
+ *
+ * @param actorSystem actor system
+ * @param materializer materializer
+ * @param logging logging
+ * @param logPath path for the activity logs
+ */
+abstract class AbstractActivityTracker(actorSystem: ActorSystem,
+                                       materializer: ActorMaterializer,
+                                       logging: Logging,
+                                       logPath: String) {
+
+  /** requestHandler is called before each request is processed. It collects data that is required for
+   * creating activity events. No further processing should be performed in requestHandler.
+   * requestHandler is assumed to be fast, i.e. incoming requests are not slowed down. Therefore no separate
+   * future needs to be created. Should requestHandler have to contain long running parts then these parts
+   * should run asynchronously (which in turn might have to be synchronized with responseHandlerAsync).
+   *
+   * @param transid transaction id
+   * @param req incoming http request
+   */
+  def requestHandler(transid: TransactionId, req: HttpRequest): Unit
+
+  /**
+   * responseHandlerAsync creates activity events based on the collected data and writes the events to the activity log.
+   * responseHandlerAsync is considered a to be little more time consuming is therefore defined as a future.
+   * in order to not slow down the response for the API caller.
+   *
+   * @param transid transaction id
+   * @param resp outgoing http response
+   * @return
+   */
+  def responseHandlerAsync(transid: TransactionId, resp: HttpResponse): Future[Unit]
+
+  /**
+   * Check if requestHandler and responseHandler should be called (example: restrict activity logs
+   * to crudcontroller).
+   *
+   * @return true if requestHandler and responseHandler should be called. Returns false, otherwise,
+   */
+  def isActive: Boolean = false
+}
+
+// ActivityTracker Implementation.
+//
+// The following implementation creates activity events that are based on the CADF
+// standard https://www.dmtf.org/sites/default/files/standards/documents/DSP0262_1.0.0.pdf
+// The implementation adds some more information in addition to the CADF standard, see
+// https://test.cloud.ibm.com/docs/Activity-Tracker-with-LogDNA?topic=Activity-Tracker-with-LogDNA-ibm_event_fields#eventTime
+// The implementation works for both BasicAuthenticationDirective and IAMAuthenticationDirective.
+// IAMAuthenticationDirective is an external component from IBM. It it not required to bind this
+// component or other external components to openwhisk in order to run the activity tracker implementation
+// with BasicAuthenticationDirective.
+
+/**
+ * Configuration for the activity tracker implementation.
+ *
+ * @param runActivityTracker flag that decides whether the acitivity tracker is active or inactive.
+ */
+case class ActivityTrackerConfig(runActivityTracker: Boolean)
+
+/**
+ * The Activity Tracker collects information about user activities and stores the data in activity log files
+ * which in turn are sent to a region-specific Activity Tracker LogDNA instance. Users can also inspect
+ * their own activities if they instantiate a user Activity Tracker LogDNA instance in their account and in
+ * the same region as their cloud function namespace(s).
+ *
+ * The collected data comprises information about the initiator, the activity, the target service, and the outcome.
+ * The entries in the activity log files must follow a specific schema:
+ * https://github.ibm.com/activity-tracker/helloATv3/blob/master/eventLinter/events_schema_logdna.json
+ *
+ * Data collection details:
+ *
+ * - used tags and where these are set:
+ * tagGrantType: BasicAuthenticationDirective || IAMAuthenticationDirective(*)
+ * tagHttpMethod: ActivityTracker
+ * tagInitiatorId: BasicAuthenticationDirective || IAMAuthenticationDirective
+ * tagInitiatorIp: ActivityTracker
+ * tagInitiatorName: BasicAuthenticationDirective || IAMAuthenticationDirective
+ * tagNamespaceId: ActivityTracker || IAMAuthenticationDirective
+ * tagRequestedStatus: Rules (empty, otherwise)
+ * tagResourceGroupId: IAMAuthenticationDirective
+ * tagTargetId: ActivityTracker || IAMAuthenticationDirective
+ * tagTargetIdEncoded: BasicAuthenticationDirective
+ * tagUri: ActivityTracker
+ * tagUserAgent: ActivityTracker
+ *
+ * - other collected data:
+ * reasoncode: from response
+ * eventTime: ActivityEvent
+ * id (transid): responseHandler
+ *
+ * (*) IAMAuthenticationDirective is an external component from IBM. It is not required to bind this component
+ * or other external components to openwhisk for running ActivityTracker with BasicAuthenticationDirective.
+ *
+ * @param actorSystem actor system
+ * @param materializer materializer
+ * @param logging logging
+ * @param logPath path for the activity logs
+ */
+class ActivityTracker(actorSystem: ActorSystem,
+                      materializer: ActorMaterializer,
+                      logging: Logging,
+                      logPath: String = "/atlogs")
+    extends AbstractActivityTracker(actorSystem, materializer, logging, logPath)
+    with ActivityUtils {
+
+  private val fileStore = new FileStorage("activitylogs", Paths.get(logPath), materializer, logging)
+  private val isCrudController = Kamon.environment.host.toLowerCase.contains("crudcontroller")
+
+  def store(line: String): Unit = fileStore.store(line)
+
+  override def isActive: Boolean = isCrudController
+
+  logging.info(this, "Activity Tracker instantiated, isActive=" + isActive)
+
+  /**
+   * Collects data from the request for the activity tracker. Data are stored in transid meta tags
+   * with restricted length for later usage in responseHandler. Collected data:
+   * - http method
+   * - url
+   * - values of headers x-forwarded-for and user-agent
+   *
+   * @param transid transaction id
+   * @param req api request
+   */
+  def requestHandler(transid: TransactionId, req: HttpRequest): Unit = {
+    try {
+      transid.setTag(TransactionId.tagHttpMethod, getString(req.method.value, 7))
+      transid.setTag(TransactionId.tagUri, getString(req.uri.toString, 2048))
+
+      val it = req.headers.iterator
+      var found = 0
+
+      // copy headers x-forwarded-for and user-agent
+      while (it.hasNext && found < 2) {
+        val hdr = it.next
+        val hdrName = hdr.name.toLowerCase
+        if (hdrName == "x-forwarded-for") {
+          transid.setTag(TransactionId.tagInitiatorIp, getString(hdr.value, 64))
+          found += 1
+        } else if (hdrName == "user-agent") {
+          transid.setTag(TransactionId.tagUserAgent, getString(hdr.value, 350))
+          found += 1
+        }
+      }
+    } catch {
+      case ex: Exception =>
+        logging.error(this, "Unexpected exception caught in requestHandler: " + ex.getMessage)
+    }
+  }
+
+  def responseHandlerAsync(transid: TransactionId, resp: HttpResponse): Future[Unit] =
+    if (isActive) Future { responseHandler(transid, resp) }(actorSystem.dispatcher) else Future.successful((): Unit)
+
+  /**
+   * Combines data from the response with data from the request handler and other collected data
+   * to create an activity tracker event that is finally written to the activity tracker log file.
+   *
+   * @param transid transaction id
+   * @param resp api repsonse
+   */
+  private def responseHandler(transid: TransactionId, resp: HttpResponse): Unit = {
+    try {
+      val initiatorName = transid.getTag(TransactionId.tagInitiatorName)
+      val httpMethod = transid.getTag(TransactionId.tagHttpMethod)
+      val uri = transid.getTag(TransactionId.tagUri)
+
+      if (!isIgnoredUser(initiatorName)) {
+
+        val serviceAction: ApiMatcherResult = getServiceAction(transid, httpMethod, uri, logging)
+
+        if (serviceAction != null) {
+
+          val initiator =
+            Initiator(
+              transid.getTag(TransactionId.tagInitiatorId),
+              transid.getTag(TransactionId.tagInitiatorName),
+              "service/security/account/user",
+              InitiatorCredential(getGrantType(transid.getTag(TransactionId.tagGrantType))),
+              InitiatorHost(transid.getTag(TransactionId.tagInitiatorIp)))
+
+          val reasonCode = resp.status.value.split(" ")(0)
+          val reasonCodeInt = Try { reasonCode.toInt }.getOrElse(0)
+          val reasonType = getReasonType(reasonCode)
+          val success = reasonCodeInt >= 200 && reasonCodeInt < 300
+          val targetId = getTargetId(transid)
+          val resourceGroupId = transid.getTag(TransactionId.tagResourceGroupId)
+          val scope = extractScope(targetId)
+
+          val resourceGroupCrn =
+            if (resourceGroupId == null || resourceGroupId.isEmpty)
+              ""
+            else
+              "crn:v1:bluemix:public:resource-controller:global:" +
+                (if (scope.isEmpty) "unknown" else scope) + "::resource-group:" +
+                resourceGroupId
+
+          val requestData =
+            RequestData(
+              method = transid.getTag(TransactionId.tagHttpMethod),
+              url = uri,
+              userAgent = transid.getTag(TransactionId.tagUserAgent),
+              failure = if (success) "" else reasonType,
+              resourceGroupCrn = resourceGroupCrn)
+
+          var nameSpaceId = transid.getTag(TransactionId.tagNamespaceId)
+          if (nameSpaceId.isEmpty) nameSpaceId = extractInstance(targetId)
+
+          val logMessage = serviceAction.logMessage +
+            (if (nameSpaceId == "") "" else " for namespace " + nameSpaceId) +
+            (if (success) "" else " -failure")
+
+          val event = ActivityEvent(
+            initiator = initiator,
+            target = Target(targetId, serviceAction.targetName, serviceAction.targetType),
+            action = serviceAction.actionType,
+            outcome = if (success) "success" else "failure",
+            reason = Reason(reasonCode, reasonType),
+            severity = "warning",
+            message = logMessage,
+            logSourceCRN = convertToLogSourceCRN(targetId),
+            saveServiceCopy = true,
+            dataEvent = false,
+            id = transid.toString,
+            requestData)
+
+          val line = event.toJson.compactPrint
+          logging.info(this, "activity tracker event: " + line.replaceAll("\\{", "(").replaceAll("\\}", ")"))(
+            id = transid)
+
+          // write to activity log
+          store(line)
+        }
+      }
+
+    } catch {
+      case ex: Exception =>
+        logging.error(this, "Unexpected exception caught in responseHandler: " + ex.getMessage)
+    }
+
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -47,7 +47,7 @@ import scala.concurrent.Future
 /**
  * Base class for activity trackers that are called in BasicHttpService on the request path (requestHandler),
  * and on the response path (responseHandler). The method isActive determines whether the activity tracker
- * should used. If isActive returns false then requestHandler and responseHandlerAsync are not called.
+ * should used. If isActive returns false then both requestHandler and responseHandlerAsync are not called.
  *
  * The Activity Tracker is instantiated in the Controller class. The related instance is stored in the companion
  * object of BasicHttpService. The Activity Tracker is not (yet) loaded as a SPI.

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -86,7 +86,7 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem,
 
   /**
    * Check if requestHandler and responseHandler should be called (example: create activity logs
-   * for crudcontroller only).
+   * for the crudcontroller only).
    *
    * @return true if requestHandler and responseHandler should be called. Returns false, otherwise.
    */

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -85,10 +85,10 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem,
   def responseHandlerAsync(transid: TransactionId, resp: HttpResponse): Future[Unit]
 
   /**
-   * Check if requestHandler and responseHandler should be called (example: restrict activity logs
-   * to crudcontroller).
+   * Check if requestHandler and responseHandler should be called (example: create activity logs
+   * for crudcontroller only).
    *
-   * @return true if requestHandler and responseHandler should be called. Returns false, otherwise,
+   * @return true if requestHandler and responseHandler should be called. Returns false, otherwise.
    */
   def isActive: Boolean = false
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
@@ -180,7 +180,7 @@ object BasicHttpService {
 
   def attachActivityTracker(instance: AbstractActivityTracker): Unit = { activityTracker = instance }
   def getActivityTracker: AbstractActivityTracker = activityTracker
-  def isActivityTrackerActive: Boolean = if (activityTracker == null) false else getActivityTracker.isActive
+  def isActivityTrackerActive: Boolean = if (getActivityTracker == null) false else getActivityTracker.isActive
 
   /**
    * Starts an HTTP(S) route handler on given port and registers a shutdown hook.

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
@@ -79,11 +79,23 @@ trait BasicHttpService extends Directives {
       respondWithHeader(transid.toHeader) {
         DebuggingDirectives.logRequest(logRequestInfo _) {
           DebuggingDirectives.logRequestResult(logResponseInfo _) {
-            BasicDirectives.mapRequest(_.removeHeader(OW_EXTRA_LOGGING_HEADER)) {
-              handleRejections(BasicHttpService.customRejectionHandler) {
-                prioritizeRejections {
-                  toStrictEntity(30.seconds) {
-                    routes
+            BasicDirectives.mapRequest(req => {
+              if (BasicHttpService.activityTracker.isActive)
+                BasicHttpService.getActivityTracker.requestHandler(transid, req)
+              req
+            }) {
+              BasicDirectives.mapRequest(_.removeHeader(OW_EXTRA_LOGGING_HEADER)) {
+                BasicDirectives.mapResponse(resp => {
+                  if (BasicHttpService.activityTracker.isActive)
+                    BasicHttpService.getActivityTracker.responseHandlerAsync(transid, resp)
+                  resp
+                }) {
+                  handleRejections(BasicHttpService.customRejectionHandler) {
+                    prioritizeRejections {
+                      toStrictEntity(30.seconds) {
+                        routes
+                      }
+                    }
                   }
                 }
               }
@@ -164,6 +176,11 @@ trait BasicHttpService extends Directives {
 
 object BasicHttpService {
 
+  private var activityTracker: AbstractActivityTracker = _
+
+  def attachActivityTracker(instance: AbstractActivityTracker): Unit = { activityTracker = instance }
+  def getActivityTracker: AbstractActivityTracker = activityTracker
+
   /**
    * Starts an HTTP(S) route handler on given port and registers a shutdown hook.
    */
@@ -193,5 +210,4 @@ object BasicHttpService {
       case x => x
     }
   }
-
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
@@ -80,13 +80,13 @@ trait BasicHttpService extends Directives {
         DebuggingDirectives.logRequest(logRequestInfo _) {
           DebuggingDirectives.logRequestResult(logResponseInfo _) {
             BasicDirectives.mapRequest(req => {
-              if (BasicHttpService.activityTracker.isActive)
+              if (BasicHttpService.isActivityTrackerActive)
                 BasicHttpService.getActivityTracker.requestHandler(transid, req)
               req
             }) {
               BasicDirectives.mapRequest(_.removeHeader(OW_EXTRA_LOGGING_HEADER)) {
                 BasicDirectives.mapResponse(resp => {
-                  if (BasicHttpService.activityTracker.isActive)
+                  if (BasicHttpService.isActivityTrackerActive)
                     BasicHttpService.getActivityTracker.responseHandlerAsync(transid, resp)
                   resp
                 }) {
@@ -176,10 +176,11 @@ trait BasicHttpService extends Directives {
 
 object BasicHttpService {
 
-  private var activityTracker: AbstractActivityTracker = _
+  private var activityTracker: AbstractActivityTracker = null
 
   def attachActivityTracker(instance: AbstractActivityTracker): Unit = { activityTracker = instance }
   def getActivityTracker: AbstractActivityTracker = activityTracker
+  def isActivityTrackerActive: Boolean = if (activityTracker == null) false else getActivityTracker.isActive
 
   /**
    * Starts an HTTP(S) route handler on given port and registers a shutdown hook.

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -40,7 +40,7 @@ import org.apache.openwhisk.core.entity.ActivationId.ActivationIdGenerator
 import org.apache.openwhisk.core.entity.ExecManifest.Runtimes
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.loadBalancer.{InvokerState, LoadBalancerProvider}
-import org.apache.openwhisk.http.{BasicHttpService, BasicRasService}
+import org.apache.openwhisk.http.{AbstractActivityTracker, ActivityTracker, BasicHttpService, BasicRasService}
 import org.apache.openwhisk.spi.SpiLoader
 
 import scala.concurrent.ExecutionContext.Implicits
@@ -121,6 +121,11 @@ class Controller(val instance: ControllerInstanceId,
   private implicit val logStore = SpiLoader.get[LogStoreProvider].instance(actorSystem)
   private implicit val activationStore =
     SpiLoader.get[ActivationStoreProvider].instance(actorSystem, materializer, logging)
+  private implicit val activityTracker: AbstractActivityTracker =
+    new ActivityTracker(actorSystem, materializer, logging)
+
+  // Defines the activity tracker instance for BasicHttpService
+  BasicHttpService.attachActivityTracker(activityTracker)
 
   // register collections
   Collection.initialize(entityStore)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
@@ -134,6 +134,9 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
     extractStatusRequest { requestedState =>
       val docid = entityName.toDocId
 
+      // save requested state for activity tracker
+      transid.setTag(TransactionId.tagRequestedStatus, requestedState.toString)
+
       getEntity(WhiskRule.get(entityStore, docid), Some {
         rule: WhiskRule =>
           val ruleName = rule.fullyQualifiedName(false)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -190,7 +190,8 @@ class ActivityTrackerTests()
     targetId: String =
       "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::",
     logSourceCRN: String = "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
-    accountInResourceGroupId: String = "a/eb2e36585c91a27a709c44e2652a381a") =
+    accountInResourceGroupId: String = "a/eb2e36585c91a27a709c44e2652a381a",
+    dataEvent: Boolean = false) =
     s"""
 {"requestData":{
     "method":"GET",
@@ -222,7 +223,8 @@ class ActivityTrackerTests()
     "typeURI":"service/security/account/user",
     "credential":{"type":"$credType"}
  },
- "dataEvent":false,"responseData":{}
+ "dataEvent":$dataEvent,
+ "responseData":{}
 }
 """
 
@@ -525,6 +527,7 @@ class ActivityTrackerTests()
       // sequences indexed by methodIndex
       val method = Seq("PUT", "GET", "DELETE")
       val operation = Seq("create", "get", "delete")
+      val dataEvent = Seq(false, true, false)
       val actionType = operation
       val reasonCode = 200 // // always 200
       val reasonType = getReasonType(reasonCode.toString)
@@ -597,7 +600,7 @@ class ActivityTrackerTests()
          "type":"apikey"
      }
  },
- "dataEvent":false,
+ "dataEvent":${dataEvent(methodIndex)},
  "responseData":{}
 }
 """
@@ -782,7 +785,7 @@ class ActivityTrackerTests()
     eventString = null
     Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
 
-    val expectedString = getExpectedResultForInvalidValuesTests(credType = "unknown")
+    val expectedString = getExpectedResultForInvalidValuesTests(credType = "unknown", dataEvent = true)
     verifyEvent(eventString, expectedString)
   }
 
@@ -861,7 +864,8 @@ class ActivityTrackerTests()
       getExpectedResultForInvalidValuesTests(
         targetId = "INVALID",
         logSourceCRN = "INVALID",
-        accountInResourceGroupId = "unknown")
+        accountInResourceGroupId = "unknown",
+        dataEvent = true)
 
     verifyEvent(eventString, expectedString)
   }
@@ -901,7 +905,11 @@ class ActivityTrackerTests()
 
     // "NOTBASE64" cannot be decoded via base64 therefore both targetid and logSourceCRN are empty
     val expectedString =
-      getExpectedResultForInvalidValuesTests(targetId = "", logSourceCRN = "", accountInResourceGroupId = "unknown")
+      getExpectedResultForInvalidValuesTests(
+        targetId = "",
+        logSourceCRN = "",
+        accountInResourceGroupId = "unknown",
+        dataEvent = true)
 
     verifyEvent(eventString, expectedString)
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -1,0 +1,1049 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.controller.test
+
+import java.nio.file.Paths
+import java.io.{File, FilenameFilter}
+
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+import scala.util.Try
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfterEach, FlatSpecLike, Matchers}
+import org.scalatestplus.junit.JUnitRunner
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import spray.json._
+import DefaultJsonProtocol._
+import common.StreamLogging
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.database.FileStorage
+import org.apache.openwhisk.http.ActivityTracker
+import org.apache.openwhisk.core.entity.ActivityUtils
+
+import scala.concurrent.duration._
+import scala.io.Source
+
+// Tags have been added to TransactionId for storing key-value pairs along the path of a request. This is the
+// list of the currently used tags for creating activity-tracker log files, and where these tags are set:
+//
+//  tagGrantType: BasicAuthenticationDirective || IAMAuthenticationDirective
+//  tagHttpMethod: ActivityTracker
+//  tagInitiatorId: BasicAuthenticationDirective || IAMAuthenticationDirective
+//  tagInitiatorIp: ActivityTracker
+//  tagInitiatorName: BasicAuthenticationDirective || IAMAuthenticationDirective
+//  tagNamespaceId: ActivityTracker || IAMAuthenticationDirective
+//  tagRequestedStatus: Rules (empty, otherwise)
+//  tagResourceGroupId: IAMAuthenticationDirective
+//  tagTargetId: ActivityTracker || IAMAuthenticationDirective
+//  tagTargetIdEncoded: BasicAuthenticationDirective
+//  tagUri: ActivityTracker
+//  tagUserAgent: ActivityTracker
+//
+// This test includes a simulation of IAMAuthenticationDirective, an external component from IBM.
+// It is not required to bind this component to openwhisk.
+// The code for activity logs works for BasicAuthenticationDirective and IAMAuthenticationDirective.
+
+@RunWith(classOf[JUnitRunner])
+class ActivityTrackerTests()
+    extends FlatSpecLike
+    with Matchers
+    with StreamLogging
+    with BeforeAndAfterEach
+    with ActivityUtils {
+
+  implicit val actorSystem: ActorSystem = ActorSystem("ActivityTrackerTests")
+  implicit val ec: ExecutionContextExecutor = actorSystem.dispatcher
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  val waitTime = 30.seconds
+
+  private val r = scala.util.Random
+
+  override def beforeEach = stream.reset()
+
+  it should "handle TransactionId tags correctly when using multiple threads" in {
+
+    val transid = TransactionId("testTags")
+    val n = 20
+    val waitMillis = 6
+    val ra = new Array[Int](n)
+
+    for (i <- 0 until n) ra(i) = r.nextInt(waitMillis)
+
+    val set_fs = (0 until n).map(i => {
+      Future {
+        Thread.sleep(ra(i))
+        transid.setTag("name" + i, i.toString)
+      }
+    })
+
+    Await.result(Future.sequence(set_fs), 60.seconds)
+
+    for (i <- 0 until n) ra(i) = r.nextInt(waitMillis)
+
+    val get_fs = (0 until n).map(i => {
+      Future {
+        Thread.sleep(ra(i))
+        (i, transid.getTag("name" + i))
+      }
+    })
+
+    Await.result(Future.sequence(get_fs), 60.seconds).map(pair => pair._1.toString shouldBe pair._2)
+  }
+
+  it should "verify that FileStorage creates file content correctly when using multiple threads" in {
+
+    // use /tmp instead of default path to ensure sufficient access rights for the file
+    val logPath = "/tmp"
+    val logFilePrefix = "testFileStorage"
+    val fileStore = new FileStorage(logFilePrefix, Paths.get(logPath), materializer, logging)
+    val line = "The quick brown fox jumps over the lazy dog. The five boxing wizards jump quickly."
+    val lineLength = line.length
+    val dir = new File(logPath)
+    val fileFilter = new FilenameFilter {
+      override def accept(dir: File, name: String): Boolean = name.startsWith(logFilePrefix)
+    }
+
+    var foundFiles = dir.listFiles(fileFilter)
+    for (f <- foundFiles) f.delete() // not embedded in try/catch - test should fail if there is a problem here
+
+    val n = 20
+    val ra = new Array[Int](n)
+    val waitMillis = 6
+
+    for (i <- 0 until n) ra(i) = r.nextInt(waitMillis)
+
+    val write_fs = (0 until n).map(i => {
+      Future {
+        Thread.sleep(ra(i))
+        fileStore.store(line)
+      }
+    })
+
+    Await.result(Future.sequence(write_fs), 60.seconds)
+
+    var remainingAttempts = 3
+    var found = false
+    while (remainingAttempts > 0 && !found) {
+      Thread.sleep(5000)
+      foundFiles = dir.listFiles(fileFilter)
+      found = foundFiles.length > 0 && foundFiles(0).length > 0
+      remainingAttempts -= 1
+    }
+
+    foundFiles.length shouldBe 1
+
+    val filePath = foundFiles(0).getAbsolutePath
+    val source = Source.fromFile(filePath)
+    val content = source.mkString
+    source.close
+
+    content shouldBe (line + "\n") * n
+
+  }
+
+  // Some of the following cases are not routed to the crudcontroller during normal operation
+  // but this test simulates and checks all api calls anyway.
+
+  def verifyEvent(resultString: String, expectedString: String): Unit = {
+    if (resultString != null || expectedString != null) {
+      if (resultString == null) "ok" shouldBe "resultString is null but expectedString is " + expectedString
+      if (expectedString == null) "ok" shouldBe "expectedString is null but resultString is " + resultString
+
+      val result = Try { resultString.parseJson }.getOrElse(null)
+      if (result == null) "ok" shouldBe "resultString is no valid json: " + resultString
+
+      val resultFields = result.asJsObject.fields
+      val expectedFields = expectedString.parseJson.asJsObject.fields
+      val expectedFieldsKeys = expectedFields.keySet
+
+      resultFields.keySet shouldBe expectedFieldsKeys
+
+      for (field <- expectedFieldsKeys)
+        if (field != "eventTime") resultFields.get(field) shouldBe expectedFields.get(field)
+
+      // expected format: YYY-MM-DDTHH:mm:ss.SS+0000, e.g. "2019-11-03T21:40:53.94+0000" (at least 2 digits for millis)
+      val timestamp = resultFields("eventTime").convertTo[String]
+      val ok = timestamp.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{2,}+\\+0{4}")
+      "ok" shouldBe (if (ok) "ok" else "timestamp " + timestamp + " does not match YYYY-MM-DDTHH:mm:ss.SS+0000")
+    }
+  }
+
+  def getExpectedResultForInvalidValuesTests(
+    credType: String = "apikey",
+    targetId: String =
+      "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::",
+    logSourceCRN: String = "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
+    accountInResourceGroupId: String = "a/eb2e36585c91a27a709c44e2652a381a") =
+    s"""
+{"requestData":{
+    "method":"GET",
+    "url":"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/testrule",
+    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64",
+    "resourceGroupId":"crn:v1:bluemix:public:resource-controller:global:$accountInResourceGroupId::resource-group:ca23a1a3f0a84e2ab6b70c22ec6b1324"
+ },
+ "observer":{"name":"ActivityTracker"},
+ "outcome":"success",
+ "saveServiceCopy":true,
+ "reason":{
+     "reasonCode":200,
+     "reasonType":"OK"
+ },
+ "id":"#tid_test_get_activation",
+ "eventTime":"2020-06-04T15:02:20.663+0000",
+ "message":"IBM Cloud Functions: get rule testrule for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
+ "target":{
+     "id":"$targetId",
+     "name":"testrule","typeURI":"functions/rule"
+ },
+ "severity":"warning",
+ "logSourceCRN":"$logSourceCRN",
+ "action":"functions.rule.read",
+ "initiator":{
+    "name":"john.doe@acme.com",
+    "host":{"address":"192.168.0.1"},
+    "id":"IBMid-310000GN7M",
+    "typeURI":"service/security/account/user",
+    "credential":{"type":"$credType"}
+ },
+ "dataEvent":false,"responseData":{}
+}
+"""
+
+  it should "handle unsuccessful create action correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    val settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "PUT"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/hello123?overwrite=false"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    val transid = TransactionId("test_create_action_err")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.Conflict)), waitTime)
+
+    // in case of errors following additional settings hold:
+    // - requestData.reasonForFailure must be filled
+    // - message must contain "-failure"
+    // - outcome is "failure"
+    val expectedString =
+      """
+{"requestData":{
+    "url":"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/hello123?overwrite=false",
+    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64",
+    "reasonForFailure":"Conflict",
+    "resourceGroupId":"crn:v1:bluemix:public:resource-controller:global:a/eb2e36585c91a27a709c44e2652a381a::resource-group:ca23a1a3f0a84e2ab6b70c22ec6b1324",
+    "method":"PUT"
+ },
+ "observer":{"name":"ActivityTracker"},
+ "outcome":"failure",
+ "saveServiceCopy":true,
+ "reason":{
+     "reasonCode":409,
+     "reasonType":"Conflict"
+ },
+ "id":"#tid_test_create_action_err",
+ "eventTime":"2020-06-02T18:42:55.149+0000",
+ "message":"IBM Cloud Functions: create action hello123 for namespace a88c0a24-853b-4477-82f8-6876e72bebf2 -failure",
+ "target":{
+     "id":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::",
+     "name":"hello123",
+     "typeURI":"functions/action"
+ },
+ "severity":"warning",
+ "logSourceCRN":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
+ "action":"functions.action.create",
+ "initiator":{
+     "name":"john.doe@acme.com",
+     "host":{
+         "address":"192.168.0.1"
+      },
+      "id":"IBMid-310000GN7M",
+      "typeURI":"service/security/account/user",
+      "credential":{
+          "type":"apikey"
+      }
+ },
+ "dataEvent":false,
+ "responseData":{}
+}
+"""
+    verifyEvent(eventString, expectedString)
+  }
+
+  it should "handle successful create action in classic namespace correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    // BasicAuth is used
+    val settings = Seq(
+      (TransactionId.tagGrantType, "password"),
+      (TransactionId.tagHttpMethod, "PUT"),
+      (TransactionId.tagInitiatorId, "john.doe@acme.com"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, ""), // not set for BasicAuth
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, ""), // not filles for classic namespaces
+      (TransactionId.tagTargetId, ""), // only filled for IAM Auth (in this case tagTargetIdEncoded is empty)
+      (
+        TransactionId.tagTargetIdEncoded,
+        "Y3JuOnYxOmJsdWVtaXg6cHVibGljOmZ1bmN0aW9uczp1cy1zb3V0aDphL2ViMmUzNjU4NWM5MWEyN2E3MDljNDRlMjY1MmEzODFhOnMtM2M5ZjJlZDgtNjQzNi00Mjg4LTkzYWQtMTgxNWI3ZWExMGE2Ojo="),
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/helloClassic1?overwrite=false"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    val transid = TransactionId("test_create_action_classic")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    val expectedString =
+      """
+{"requestData":{
+    "method":"PUT",
+    "url":"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/helloClassic1?overwrite=false",
+    "resourceGroupId":"",
+    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"
+ },
+ "observer":{
+     "name":"ActivityTracker"
+ },
+ "outcome":"success",
+ "saveServiceCopy":true,
+ "reason":{
+     "reasonCode":200,
+     "reasonType":"OK"
+ },
+ "id":"#tid_test_create_action_classic",
+ "eventTime":"2020-06-03T00:47:51.818+0000",
+ "message":"IBM Cloud Functions: create action helloClassic1 for namespace s-3c9f2ed8-6436-4288-93ad-1815b7ea10a6",
+ "target":{
+     "id":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:s-3c9f2ed8-6436-4288-93ad-1815b7ea10a6::",
+     "name":"helloClassic1",
+     "typeURI":"functions/action"
+ },
+ "severity":"warning",
+ "logSourceCRN":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
+ "action":"functions.action.create",
+ "initiator":{
+     "name":"john.doe@acme.com",
+     "host":{
+         "address":"192.168.0.1"
+     },
+     "id":"john.doe@acme.com",
+     "typeURI":"service/security/account/user",
+     "credential":{
+         "type":"user"
+     }
+ },
+ "dataEvent":false,
+ "responseData":{}
+}
+"""
+    verifyEvent(eventString, expectedString)
+  }
+
+  it should "create no activity event for get all (actions, packages, rules, triggers)" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    for (entityType <- Seq("action", "package", "rule", "trigger")) {
+
+      val settings = Seq(
+        (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+        (TransactionId.tagHttpMethod, "GET"),
+        (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+        (TransactionId.tagInitiatorIp, "192.168.0.1"),
+        (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+        (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+        (TransactionId.tagRequestedStatus, ""), // only filled for rules
+        (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+        (
+          TransactionId.tagTargetId,
+          "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+        (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+        (
+          TransactionId.tagUri,
+          s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/${entityType}s?limit=30&skip=0"),
+        (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+      val transid = TransactionId("test_get_all_action")
+      for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+      eventString = null
+      Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+      eventString shouldBe null
+    }
+  }
+
+  it should "create no activity event for get activation" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    val settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "GET"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/activations/2755eba166ba4f4095eba166babf4096"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    val transid = TransactionId("test_get_activation")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    eventString shouldBe null
+  }
+
+  it should "create no activity event for get all namespaces" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    val settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "GET"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces?limit=30&skip=0"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    val transid = TransactionId("test_get_all_namespaces")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    eventString shouldBe null
+  }
+
+  it should "handle successful (create, get, delete) (action, package, rule, trigger) correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    for (methodIndex <- 0 to 2) {
+
+      // sequences indexed by methodIndex
+      val method = Seq("PUT", "GET", "DELETE")
+      val operation = Seq("create", "get", "delete")
+      val actionType = Seq("create", "read", "delete")
+      val reasonCode = 200 // // always 200
+      val reasonType = getReasonType(reasonCode.toString)
+
+      for (entityType <- Seq("action", "package", "rule", "trigger")) {
+
+        val entityName = "hello123"
+
+        val url =
+          s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/${entityType}s/$entityName?key=value"
+
+        val settings = Seq(
+          (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+          (TransactionId.tagHttpMethod, method(methodIndex)),
+          (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+          (TransactionId.tagInitiatorIp, "192.168.0.1"),
+          (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+          (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+          (TransactionId.tagRequestedStatus, ""), // only filled for rules
+          (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+          (
+            TransactionId.tagTargetId,
+            "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+          (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+          (TransactionId.tagUri, url),
+          (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+        val transid = TransactionId("test_api")
+        for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+        eventString = null
+        Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+        val expectedString =
+          s"""
+{"requestData":{
+    "method":"${method(methodIndex)}",
+    "url":"$url",
+    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64",
+    "resourceGroupId":"crn:v1:bluemix:public:resource-controller:global:a/eb2e36585c91a27a709c44e2652a381a::resource-group:ca23a1a3f0a84e2ab6b70c22ec6b1324"
+ },
+ "observer":{
+    "name":"ActivityTracker"
+ },
+ "outcome":"success",
+ "saveServiceCopy":true,
+ "reason":{
+     "reasonCode":$reasonCode,
+     "reasonType":"$reasonType"
+ },
+ "id":"#tid_test_api",
+ "eventTime":"2020-06-03T14:38:10.258+0000",
+ "message":"IBM Cloud Functions: ${operation(methodIndex)} $entityType $entityName for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
+ "target":{
+     "id":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::",
+     "name":"$entityName",
+     "typeURI":"functions/$entityType"
+ },
+ "severity":"warning",
+ "logSourceCRN":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
+ "action":"functions.$entityType.${actionType(methodIndex)}",
+ "initiator":{
+     "name":"john.doe@acme.com",
+     "host":{
+         "address":"192.168.0.1"
+     },
+     "id":"IBMid-310000GN7M",
+     "typeURI":"service/security/account/user",
+     "credential":{
+         "type":"apikey"
+     }
+ },
+ "dataEvent":false,
+ "responseData":{}
+}
+"""
+        verifyEvent(eventString, expectedString)
+      }
+    }
+  }
+
+  it should "handle successful (enable, disable) rule correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    for (operationIndex <- 0 to 1) {
+
+      // sequences indexed by operationIndex
+      val requestedStatus = Seq("active", "inactive")
+      val actionType = Seq("enable", "disable")
+
+      val reasonCode = 200 // // always 200
+      val reasonType = getReasonType(reasonCode.toString)
+      val entityName = "hello123"
+      val method = "POST"
+
+      for (entityType <- 0 to 1) {
+
+        val url =
+          s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/$entityName"
+
+        val settings = Seq(
+          (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+          (TransactionId.tagHttpMethod, method),
+          (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+          (TransactionId.tagInitiatorIp, "192.168.0.1"),
+          (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+          (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+          (TransactionId.tagRequestedStatus, requestedStatus(operationIndex)), // only filled for rules
+          (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+          (
+            TransactionId.tagTargetId,
+            "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+          (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+          (TransactionId.tagUri, url),
+          (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+        val transid = TransactionId("test_api")
+        for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+        eventString = null
+        Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+        val expectedString =
+          s"""
+{"requestData":{
+    "method":"$method",
+    "url":"$url",
+    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64",
+    "resourceGroupId":"crn:v1:bluemix:public:resource-controller:global:a/eb2e36585c91a27a709c44e2652a381a::resource-group:ca23a1a3f0a84e2ab6b70c22ec6b1324"
+ },
+ "observer":{
+    "name":"ActivityTracker"
+ },
+ "outcome":"success",
+ "saveServiceCopy":true,
+ "reason":{
+     "reasonCode":$reasonCode,
+     "reasonType":"$reasonType"
+ },
+ "id":"#tid_test_api",
+ "eventTime":"2020-06-03T14:38:10.258+0000",
+ "message":"IBM Cloud Functions: ${actionType(operationIndex)} rule $entityName for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
+ "target":{
+     "id":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::",
+     "name":"$entityName",
+     "typeURI":"functions/rule"
+ },
+ "severity":"warning",
+ "logSourceCRN":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
+ "action":"functions.rule.${actionType(operationIndex)}",
+ "initiator":{
+     "name":"john.doe@acme.com",
+     "host":{
+         "address":"192.168.0.1"
+     },
+     "id":"IBMid-310000GN7M",
+     "typeURI":"service/security/account/user",
+     "credential":{
+         "type":"apikey"
+     }
+ },
+ "dataEvent":false,
+ "responseData":{}
+}
+"""
+        verifyEvent(eventString, expectedString)
+      }
+    }
+  }
+
+  it should "create no activity event for post method on (action, trigger)" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    for (entityType <- Seq("action", "trigger")) {
+
+      val entityName = "hello123"
+
+      val url =
+        s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/${entityType}s/$entityName?key=value"
+
+      val settings = Seq(
+        (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+        (TransactionId.tagHttpMethod, "POST"),
+        (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+        (TransactionId.tagInitiatorIp, "192.168.0.1"),
+        (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+        (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+        (TransactionId.tagRequestedStatus, ""), // only filled for rules
+        (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+        (
+          TransactionId.tagTargetId,
+          "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+        (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+        (TransactionId.tagUri, url),
+        (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+      val transid = TransactionId("test_api")
+      for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+      eventString = null
+      Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+      eventString shouldBe null
+    }
+  }
+
+  it should "handle invalid grantType correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    var settings = Seq(
+      (TransactionId.tagGrantType, "INVALID"),
+      (TransactionId.tagHttpMethod, "GET"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/testrule"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    var transid = TransactionId("test_get_activation")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    val expectedString = getExpectedResultForInvalidValuesTests(credType = "unknown")
+    verifyEvent(eventString, expectedString)
+  }
+
+  it should "handle invalid httpMethod correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    var settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "INVALID"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/testrule"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    var transid = TransactionId("test_get_activation")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    eventString shouldBe null
+  }
+
+  it should "handle invalid targetId correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    var settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "GET"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (TransactionId.tagTargetId, "INVALID"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/testrule"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    var transid = TransactionId("test_get_activation")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    val expectedString =
+      getExpectedResultForInvalidValuesTests(
+        targetId = "INVALID",
+        logSourceCRN = "INVALID",
+        accountInResourceGroupId = "unknown")
+
+    verifyEvent(eventString, expectedString)
+  }
+
+  it should "handle invalid targetIdEncoded correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    var settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "GET"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (TransactionId.tagTargetId, ""),
+      (TransactionId.tagTargetIdEncoded, "NOTBASE64"), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (
+        TransactionId.tagUri,
+        "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/testrule"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    var transid = TransactionId("test_get_activation")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    // "NOTBASE64" cannot be decoded via base64 therefore both targetid and logSourceCRN are empty
+    val expectedString =
+      getExpectedResultForInvalidValuesTests(targetId = "", logSourceCRN = "", accountInResourceGroupId = "unknown")
+
+    verifyEvent(eventString, expectedString)
+  }
+
+  it should "handle invalid urls correctly" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    var settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "GET"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (TransactionId.tagUri, "THIS_IS_NO_URL!"),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    var transid = TransactionId("test_get_activation")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    eventString = null
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    eventString shouldBe null
+  }
+
+  it should "handle the isActive flag correctly" in {
+
+    // This is the create action test case with isActive = false and true.
+    // The result should be empty if isActive = false. Otherwise, the expected event should
+    // be the related event for creating an action.
+
+    var eventString: String = null
+
+    for (activeFlag <- Seq(false, true)) {
+
+      val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+        override def isActive = activeFlag
+
+        override def store(line: String): Unit = {
+          eventString = line
+        }
+      }
+
+      for (methodIndex <- 0 to 0) {
+
+        // sequences indexed by methodIndex
+        val method = Seq("PUT")
+        val operation = Seq("create")
+        val actionType = Seq("create")
+        val reasonCode = 200 // // always 200
+        val reasonType = getReasonType(reasonCode.toString)
+
+        for (entityType <- Seq("action")) {
+
+          val entityName = "hello123"
+
+          val url =
+            s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/${entityType}s/$entityName?key=value"
+
+          val settings = Seq(
+            (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+            (TransactionId.tagHttpMethod, method(methodIndex)),
+            (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+            (TransactionId.tagInitiatorIp, "192.168.0.1"),
+            (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+            (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+            (TransactionId.tagRequestedStatus, ""), // only filled for rules
+            (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+            (
+              TransactionId.tagTargetId,
+              "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+            (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+            (TransactionId.tagUri, url),
+            (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+          val transid = TransactionId("test_api")
+          for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+          val expectedString =
+            s"""
+{"requestData":{
+    "method":"${method(methodIndex)}",
+    "url":"$url",
+    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64",
+    "resourceGroupId":"crn:v1:bluemix:public:resource-controller:global:a/eb2e36585c91a27a709c44e2652a381a::resource-group:ca23a1a3f0a84e2ab6b70c22ec6b1324"
+ },
+ "observer":{
+    "name":"ActivityTracker"
+ },
+ "outcome":"success",
+ "saveServiceCopy":true,
+ "reason":{
+     "reasonCode":$reasonCode,
+     "reasonType":"$reasonType"
+ },
+ "id":"#tid_test_api",
+ "eventTime":"2020-06-03T14:38:10.258+0000",
+ "message":"IBM Cloud Functions: ${operation(methodIndex)} $entityType $entityName for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
+ "target":{
+     "id":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::",
+     "name":"$entityName",
+     "typeURI":"functions/$entityType"
+ },
+ "severity":"warning",
+ "logSourceCRN":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
+ "action":"functions.$entityType.${actionType(methodIndex)}",
+ "initiator":{
+     "name":"john.doe@acme.com",
+     "host":{
+         "address":"192.168.0.1"
+     },
+     "id":"IBMid-310000GN7M",
+     "typeURI":"service/security/account/user",
+     "credential":{
+         "type":"apikey"
+     }
+ },
+ "dataEvent":false,
+ "responseData":{}
+}
+"""
+          eventString = null
+          Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+          if (activeFlag) verifyEvent(eventString, expectedString) else eventString shouldBe null
+        }
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -214,7 +214,7 @@ class ActivityTrackerTests()
  },
  "severity":"warning",
  "logSourceCRN":"$logSourceCRN",
- "action":"functions.rule.read",
+ "action":"functions.rule.get",
  "initiator":{
     "name":"john.doe@acme.com",
     "host":{"address":"192.168.0.1"},
@@ -525,7 +525,7 @@ class ActivityTrackerTests()
       // sequences indexed by methodIndex
       val method = Seq("PUT", "GET", "DELETE")
       val operation = Seq("create", "get", "delete")
-      val actionType = Seq("create", "read", "delete")
+      val actionType = operation
       val reasonCode = 200 // // always 200
       val reasonType = getReasonType(reasonCode.toString)
 


### PR DESCRIPTION
This PR adds audit logging to track activities on the Controller API based on the CADF (Cloud Auditing Data Federation) standard DSP0262, v1.0.0.

**Please note: an additional log rotation for the created activity tracker audit logs needs to be installed (basically the same as for user logs.) Otherwise, the file system runs full.**

## Description
The implementation plugs in the BasicHttpService. A request handler collects information from incoming http requests, the authenticaton components BasicAuthenticationDirective and IAMAuthenticationDirective collect some additional information dependent on the authentication type, and the response handler adds some more information and finally creates the related activity events and stores them as audit log in the file system.

The request handler and the authentication components store the collected data as tags in the transactionId which now provides this capability. Since there is no further processing on the collected data and since the size of collected information is small the API performance is not degraded by the collection. On the other hand, the response handler performs some more processing and is therefore called asynchronously in order to not slow down the reponse for the caller.

A base class for activity trackers (component that creates audit logs) and an implementation that bases on the CADF standard DSP0262, v1.0.0, is provided. The implementation adds some more information in addition to the CADF standard, see
https://test.cloud.ibm.com/docs/Activity-Tracker-with-LogDNA?topic=Activity-Tracker-with-LogDNA-ibm_event_fields#eventTime

The implementation works for both BasicAuthenticationDirective and IAMAuthenticationDirective. IAMAuthenticationDirective is an external component from IBM. It it not required to bind this component or other external components to openwhisk in order to run the activity tracker implementation with BasicAuthenticationDirective. The implementation is activated by setting the flag runActivityTracker to true in the pureconfig namespace whisk.controller.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

