### PR TITLE
Support Functions appdomain.cloud for Web Actions - Reverse check for filtering domain

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
@@ -431,7 +431,7 @@ trait WhiskWebActionsApi
   private val webActionsFilterConfig = loadConfig[WebActionsFilterConfig](webActionsFilterConfigNamespace).toOption
   private val filterWebActionsEnabled = webActionsFilterConfig.map(_.enabled).getOrElse(false)
   private val filterWebActionsHeaderField = webActionsFilterConfig.map(_.headerField).getOrElse("host")
-  private val filterWebActionsHostDomainSuffix = webActionsFilterConfig.map(_.domainSuffix).getOrElse("cloud.ibm.com")
+  private val filterWebActionsHostDomainSuffix = webActionsFilterConfig.map(_.domainSuffix).getOrElse("appdomain.cloud")
   private val filterWebActionsFallbackMediaType = webActionsFilterConfig.map(_.fallbackMediaType).getOrElse(".text")
   private val filterWebActionsWhitelistedNamespacesFromEnvironment =
     webActionsFilterConfig.map(_.whitelistedNamespaces).getOrElse("None")
@@ -709,7 +709,8 @@ trait WhiskWebActionsApi
     val filterWebAction =
       filterWebActionsEnabled && (context.headers.find(_.lowercaseName == filterWebActionsHeaderField) match {
         case Some(header) =>
-          header.value.endsWith((filterWebActionsHostDomainSuffix))
+          // check if host domain suffix is not our whitelisted appdomain.cloud domain
+          !header.value.endsWith((filterWebActionsHostDomainSuffix))
         case None => false
       }) && filterWebActionsWhitelistedNamespaces
         .split(",")

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
@@ -710,7 +710,7 @@ trait WhiskWebActionsApi
       filterWebActionsEnabled && (context.headers.find(_.lowercaseName == filterWebActionsHeaderField) match {
         case Some(header) =>
           // check if host domain suffix is not our whitelisted appdomain.cloud domain
-          !header.value.endsWith((filterWebActionsHostDomainSuffix))
+          !header.value.toLowerCase.endsWith((filterWebActionsHostDomainSuffix))
         case None => false
       }) && filterWebActionsWhitelistedNamespaces
         .split(",")


### PR DESCRIPTION
Support Functions `appdomain.cloud` for Web Actions, reverse check for filtering domain, we now enable filtering if request is not initiated from our white-listed appdomain.cloud domain

## Description

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [X] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [X] Breaking change (a bug fix or enhancement which changes existing behavior).