### PR TITLE
Increase timeout for awaiting DB results in DbUtils from 15 to 30 seconds

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/DbUtils.scala
@@ -47,7 +47,7 @@ import scala.util.{Failure, Random, Success, Try}
  * names in tests, and defer all cleanup to the end of a test suite.
  */
 trait DbUtils extends Assertions {
-  implicit val dbOpTimeout = 15 seconds
+  implicit val dbOpTimeout = 30 seconds
   val instance = ControllerInstanceId("0")
   val docsToDelete = ListBuffer[(ArtifactStore[_], DocInfo)]()
   case class RetryOp() extends Throwable


### PR DESCRIPTION
In our tests we encounter every now and then failing tests that fail because of `java.util.concurrent.TimeoutException: Futures timed out after [15 seconds]`

## Description
This code change increases the timeout (dbOpTimeout) value from 15 to 30 seconds. Intention is to avoid the following error for awaiting results in eg `org.apache.openwhisk.core.controller.test.ActionsApiWithDbPollingTests` class: `java.util.concurrent.TimeoutException: Futures timed out after [15 seconds]`

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.