### PR TITLE
Activate activity tracker events for enable/diable rule and add update events

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
@@ -268,6 +268,7 @@ object TransactionId {
   val tagTargetId = "targetId"
   val tagTargetIdEncoded = "targetIdEncoded"
   val tagUri = "uri"
+  val tagUpdateInfo = "tagUpdateInfo"
   val tagUserAgent = "userAgent"
 
   def apply(tid: String, extraLogging: Boolean = false): TransactionId = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/FileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/FileStorage.scala
@@ -31,7 +31,7 @@ import org.apache.openwhisk.common.Logging
 import scala.concurrent.duration._
 
 class FileStorage(logFilePrefix: String,
-                  logFileMaxLen: Long,
+                  logFileMaxSize: Long,
                   logPath: Path,
                   actorMaterializer: ActorMaterializer,
                   logging: Logging) {
@@ -39,7 +39,7 @@ class FileStorage(logFilePrefix: String,
   implicit val materializer = actorMaterializer
 
   private var logFile = logPath
-  private val bufferSize = logFileMaxLen
+  private val bufferSize = logFileMaxSize
   private val perms = EnumSet.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE, OTHERS_READ, OTHERS_WRITE)
   private val writeToFile: Sink[ByteString, _] = MergeHub
     .source[ByteString]

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/FileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/FileStorage.scala
@@ -27,23 +27,26 @@ import akka.stream.alpakka.file.scaladsl.LogRotatorSink
 import akka.stream.scaladsl.{MergeHub, RestartSink, Sink, Source}
 import akka.util.ByteString
 import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.core.entity.size._
 
 import scala.concurrent.duration._
 
-class FileStorage(logFilePrefix: String, logPath: Path, actorMaterializer: ActorMaterializer, logging: Logging) {
+class FileStorage(logFilePrefix: String,
+                  logFileMaxLen: Long,
+                  logPath: Path,
+                  actorMaterializer: ActorMaterializer,
+                  logging: Logging) {
 
   implicit val materializer = actorMaterializer
 
   private var logFile = logPath
-  private val bufferSize = 25.MB
+  private val bufferSize = logFileMaxLen
   private val perms = EnumSet.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE, OTHERS_READ, OTHERS_WRITE)
   private val writeToFile: Sink[ByteString, _] = MergeHub
     .source[ByteString]
-    .batchWeighted(bufferSize.toBytes, _.length, identity)(_ ++ _)
+    .batchWeighted(bufferSize, _.length, identity)(_ ++ _)
     .to(RestartSink.withBackoff(minBackoff = 1.seconds, maxBackoff = 60.seconds, randomFactor = 0.2) { () =>
       LogRotatorSink(() => {
-        val maxSize = bufferSize.toBytes
+        val maxSize = bufferSize
         var bytesRead = maxSize
         element =>
           {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
@@ -407,8 +407,8 @@ trait ActivityUtils {
           case "GET" =>
             Some(
               ApiMatcherResult(
-                actionTypePrefix + ".get",
-                messagePrefix + "get " + entityType + " " + targetName,
+                actionTypePrefix + ".read",
+                messagePrefix + "read " + entityType + " " + targetName,
                 targetName,
                 targetType,
                 isDataEvent = true))
@@ -455,8 +455,8 @@ trait ActivityUtils {
           case "GET" =>
             Some(
               ApiMatcherResult(
-                thisService + ".rule.get",
-                messagePrefix + "get rule " + ruleName,
+                thisService + ".rule.read",
+                messagePrefix + "read rule " + ruleName,
                 ruleName,
                 targetType,
                 isDataEvent = true))

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -25,7 +25,6 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.ActorMaterializer
 import kamon.Kamon
 import pureconfig._
-import pureconfig.generic.auto._
 
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.database.FileStorage

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -161,10 +161,10 @@ class ActivityTracker(actorSystem: ActorSystem, materializer: ActorMaterializer,
   // config
   private val configNamespace = ConfigKeys.controller
   private val config = loadConfig[ActivityTrackerConfig](configNamespace).toOption
-  private val auditLogFilePath = config.map(_.auditLogFilePath).getOrElse("/tmp")
-  private val auditLogFileNamePrefix = config.map(_.auditLogFileNamePrefix).getOrElse(componentName)
+  private val auditLogFilePath: String = config.map(_.auditLogFilePath).getOrElse("/tmp")
+  private val auditLogFileNamePrefix: String = config.map(_.auditLogFileNamePrefix).getOrElse(componentName)
   // if auditLogMaxFileSize == 0 then ActivityTracker stays inactive
-  private val auditLogMaxFileSize = config.map(_.auditLogMaxFileSize).getOrElse(0)
+  private val auditLogMaxFileSize: Long = config.map(_.auditLogMaxFileSize).getOrElse(0)
 
   private val fileStore =
     if (isController && auditLogMaxFileSize > 0)

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -25,6 +25,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.ActorMaterializer
 import kamon.Kamon
 import pureconfig._
+import pureconfig.generic.auto._
 
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.database.FileStorage

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -196,7 +196,8 @@ class ActivityTracker(actorSystem: ActorSystem, materializer: ActorMaterializer,
 
   logging.info(
     this,
-    "Activity Tracker instantiated, isActive=" + isActive +
+    "Activity Tracker instantiated for component=" + componentName +
+      ", isActive=" + isActive +
       ", auditLogFilePath=" + auditLogFilePath +
       ", auditLogFileNamePrefix=" + auditLogFileNamePrefix +
       ", auditLogMaxFileSize=" + auditLogMaxFileSize)

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -194,6 +194,13 @@ class ActivityTracker(actorSystem: ActorSystem, materializer: ActorMaterializer,
    */
   def store(line: String): Unit = fileStore.store(line)
 
+  /**
+   * Function for isCrudController (defined for supporting the unit test).
+   *
+   * @return isCrudController
+   */
+  def getIsCrudController: Boolean = isCrudController
+
   logging.info(
     this,
     "Activity Tracker instantiated for component=" + componentName +
@@ -257,7 +264,7 @@ class ActivityTracker(actorSystem: ActorSystem, materializer: ActorMaterializer,
       if (!isIgnoredUser(initiatorName)) {
 
         val serviceAction: ApiMatcherResult =
-          getServiceAction(transid, isCrudController, httpMethod, uri, logging)
+          getServiceAction(transid, getIsCrudController, httpMethod, uri, logging)
 
         if (serviceAction != null) {
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -60,8 +60,8 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem, materializer: A
   /** requestHandler is called before each request is processed. It collects data that is required for
    * creating activity events. No further processing should be performed in requestHandler. requestHandler
    * should be fast, incoming requests should not be slowed down. No separate future is created for the
-   * requestHandler. Should a requestHandler have to contain long running parts then these parts
-   * should run asynchronously (which in turn might have to be synchronized with responseHandlerAsync).
+   * requestHandler. When a requestHandler needs long running parts then these parts should run
+   * asynchronously (which in turn might have to be synchronized with responseHandlerAsync).
    *
    * @param transid transaction id
    * @param req incoming http request
@@ -80,8 +80,7 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem, materializer: A
   def responseHandlerAsync(transid: TransactionId, resp: HttpResponse): Future[Unit]
 
   /**
-   * Check if requestHandler and responseHandler should be called (example: create activity logs
-   * for the crudcontroller only).
+   * Check if requestHandler and responseHandler should be called
    *
    * @return true if requestHandler and responseHandler should be called. Returns false, otherwise.
    */
@@ -95,13 +94,13 @@ abstract class AbstractActivityTracker(actorSystem: ActorSystem, materializer: A
 // The implementation adds some more information in addition to the CADF standard, see
 // https://test.cloud.ibm.com/docs/Activity-Tracker-with-LogDNA?topic=Activity-Tracker-with-LogDNA-ibm_event_fields#eventTime
 // The implementation works for both BasicAuthenticationDirective and IAMAuthenticationDirective.
-// IAMAuthenticationDirective is an external component from IBM. It it not required to bind this
+// IAMAuthenticationDirective is an external component from IBM. It is not required to bind this
 // component or other external components to openwhisk in order to run the activity tracker implementation
 // with BasicAuthenticationDirective.
 
 /**
- * Configuration for the activity tracker implementation. All three values should be defined as the
- * defaults are just suited for quick testing. If auditLogMaxFileSize is not defined then ActivityTracker
+ * Configuration for the activity tracker implementation. All three values should be defined since the
+ * defaults are just good for quick testing. If auditLogMaxFileSize is not defined then ActivityTracker
  * stays inactive.
  *
  * @param auditLogFilePath file path for audit logs (default: /tmp)
@@ -180,7 +179,7 @@ class ActivityTracker(actorSystem: ActorSystem, materializer: ActorMaterializer,
    * ActivityTracker is active for controller and crudcontroller but not for invoker.
    *
    * If auditLogMaxFileSize is not configured then ActivityTracker stays inactive.
-   * auditLogFilePath and auditLogFileNamePrefix should also be configured as the defaults
+   * auditLogFilePath and auditLogFileNamePrefix should also be configured since the defaults
    * are just good for quick testing.
    *
    * @return true if requestHandler and responseHandler should be called. Returns false, otherwise.

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ActivityTracker.scala
@@ -171,7 +171,7 @@ class ActivityTracker(actorSystem: ActorSystem, materializer: ActorMaterializer,
     if (isController && auditLogMaxFileSize > 0)
       new FileStorage(
         logFilePrefix = auditLogFileNamePrefix,
-        logFileMaxLen = auditLogMaxFileSize,
+        logFileMaxSize = auditLogMaxFileSize,
         logPath = Paths.get(auditLogFilePath),
         actorMaterializer = materializer,
         logging = logging)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
@@ -253,9 +253,11 @@ trait WriteOps extends Directives {
     onComplete(factory.get(datastore, docid) flatMap { doc =>
       if (overwrite) {
         logging.debug(this, s"[PUT] entity exists, will try to update '$doc'")
+        transid.setTag(TransactionId.tagUpdateInfo, "overwrite enabled")
         update(doc).map(updatedDoc => (Some(doc), updatedDoc))
       } else if (treatExistsAsConflict) {
         logging.debug(this, s"[PUT] entity exists, but overwrite is not enabled, aborting")
+        transid.setTag(TransactionId.tagUpdateInfo, "overwrite disabled")
         Future failed RejectRequest(Conflict, "resource already exists")
       } else {
         Future failed IdentityPut(doc)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -205,14 +205,14 @@ class ActivityTrackerTests()
  },
  "id":"#tid_test_get_activation",
  "eventTime":"2020-06-04T15:02:20.663+0000",
- "message":"IBM Cloud Functions: get rule testrule for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
+ "message":"IBM Cloud Functions: read rule testrule for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
  "target":{
      "id":"$targetId",
      "name":"testrule","typeURI":"functions/rule"
  },
  "severity":"warning",
  "logSourceCRN":"$logSourceCRN",
- "action":"functions.rule.get",
+ "action":"functions.rule.read",
  "initiator":{
     "name":"john.doe@acme.com",
     "host":{"address":"192.168.0.1"},
@@ -529,7 +529,7 @@ class ActivityTrackerTests()
 
     // sequences indexed by methodIndex
     val method = Seq("PUT", "GET", "DELETE", "PUT")
-    val operation = Seq("create", "get", "delete", "update")
+    val operation = Seq("create", "read", "delete", "update")
     val dataEvent = Seq(false, true, false, false)
     val actionType = operation
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -515,7 +515,7 @@ class ActivityTrackerTests()
     eventString shouldBe null
   }
 
-  it should "handle successful (create, get, delete) (action, package, rule, trigger) correctly (crudcontroller)" in {
+  it should "handle successful (create, get, delete, update) (action, package, rule, trigger) correctly (crudcontroller)" in {
 
     var eventString: String = null
 
@@ -527,15 +527,16 @@ class ActivityTrackerTests()
       }
     }
 
-    for (methodIndex <- 0 to 2) {
+    // sequences indexed by methodIndex
+    val method = Seq("PUT", "GET", "DELETE", "PUT")
+    val operation = Seq("create", "get", "delete", "update")
+    val dataEvent = Seq(false, true, false, false)
+    val actionType = operation
 
-      // sequences indexed by methodIndex
-      val method = Seq("PUT", "GET", "DELETE")
-      val operation = Seq("create", "get", "delete")
-      val dataEvent = Seq(false, true, false)
-      val actionType = operation
-      val reasonCode = 200 // // always 200
-      val reasonType = getReasonType(reasonCode.toString)
+    val reasonCode = 200 // // always 200
+    val reasonType = getReasonType(reasonCode.toString)
+
+    for (methodIndex <- 0 to 3) {
 
       for (entityType <- Seq("action", "package", "rule", "trigger")) {
 
@@ -557,6 +558,7 @@ class ActivityTrackerTests()
             TransactionId.tagTargetId,
             "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
           (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+          (TransactionId.tagUpdateInfo, if (operation(methodIndex) == "update") "true" else ""),
           (TransactionId.tagUri, url),
           (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
 
@@ -609,6 +611,7 @@ class ActivityTrackerTests()
  "responseData":{}
 }
 """
+        println(eventString)
         verifyEvent(eventString, expectedString)
       }
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -112,9 +112,9 @@ class ActivityTrackerTests()
     // use /tmp instead of default path to ensure sufficient access rights for the file
     val logPath = "/tmp"
     val logFilePrefix = "testFileStorage"
-    val fileStore = new FileStorage(logFilePrefix, Paths.get(logPath), materializer, logging)
+    val logFileMaxSize = 1000000
+    val fileStore = new FileStorage(logFilePrefix, logFileMaxSize, Paths.get(logPath), materializer, logging)
     val line = "The quick brown fox jumps over the lazy dog. The five boxing wizards jump quickly."
-    val lineLength = line.length
     val dir = new File(logPath)
     val fileFilter = new FilenameFilter {
       override def accept(dir: File, name: String): Boolean = name.startsWith(logFilePrefix)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -158,9 +158,6 @@ class ActivityTrackerTests()
 
   }
 
-  // Some of the following cases are not routed to the crudcontroller during normal operation
-  // but this test simulates and checks all api calls anyway.
-
   def verifyEvent(resultString: String, expectedString: String): Unit = {
     if (resultString != null || expectedString != null) {
       if (resultString == null) "ok" shouldBe "resultString is null but expectedString is " + expectedString
@@ -228,12 +225,15 @@ class ActivityTrackerTests()
 }
 """
 
-  it should "handle unsuccessful create action correctly" in {
+  // crudcontroller tests (getIsCrudController = true)
+
+  it should "handle unsuccessful create action correctly (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -312,12 +312,13 @@ class ActivityTrackerTests()
     verifyEvent(eventString, expectedString)
   }
 
-  it should "handle successful create action in classic namespace correctly" in {
+  it should "handle successful create action in classic namespace correctly (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -394,12 +395,13 @@ class ActivityTrackerTests()
     verifyEvent(eventString, expectedString)
   }
 
-  it should "create no activity event for get all (actions, packages, rules, triggers)" in {
+  it should "create no activity event for get all (actions, packages, rules, triggers) (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -435,12 +437,13 @@ class ActivityTrackerTests()
     }
   }
 
-  it should "create no activity event for get activation" in {
+  it should "create no activity event for get activation (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -473,12 +476,13 @@ class ActivityTrackerTests()
     eventString shouldBe null
   }
 
-  it should "create no activity event for get all namespaces" in {
+  it should "create no activity event for get all namespaces (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -511,12 +515,13 @@ class ActivityTrackerTests()
     eventString shouldBe null
   }
 
-  it should "handle successful (create, get, delete) (action, package, rule, trigger) correctly" in {
+  it should "handle successful (create, get, delete) (action, package, rule, trigger) correctly (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -609,109 +614,13 @@ class ActivityTrackerTests()
     }
   }
 
-  it should "handle successful (enable, disable) rule correctly" in {
+  it should "create no activity event for post method on (action, trigger) (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
-      override def store(line: String): Unit = {
-        eventString = line
-      }
-    }
-
-    for (operationIndex <- 0 to 1) {
-
-      // sequences indexed by operationIndex
-      val requestedStatus = Seq("active", "inactive")
-      val actionType = Seq("enable", "disable")
-
-      val reasonCode = 200 // // always 200
-      val reasonType = getReasonType(reasonCode.toString)
-      val entityName = "hello123"
-      val method = "POST"
-
-      for (entityType <- 0 to 1) {
-
-        val url =
-          s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/$entityName"
-
-        val settings = Seq(
-          (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
-          (TransactionId.tagHttpMethod, method),
-          (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
-          (TransactionId.tagInitiatorIp, "192.168.0.1"),
-          (TransactionId.tagInitiatorName, "john.doe@acme.com"),
-          (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
-          (TransactionId.tagRequestedStatus, requestedStatus(operationIndex)), // only filled for rules
-          (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
-          (
-            TransactionId.tagTargetId,
-            "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
-          (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
-          (TransactionId.tagUri, url),
-          (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
-
-        val transid = TransactionId("test_api")
-        for (setting <- settings) transid.setTag(setting._1, setting._2)
-
-        eventString = null
-        Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
-
-        val expectedString =
-          s"""
-{"requestData":{
-    "method":"$method",
-    "url":"$url",
-    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64",
-    "resourceGroupId":"crn:v1:bluemix:public:resource-controller:global:a/eb2e36585c91a27a709c44e2652a381a::resource-group:ca23a1a3f0a84e2ab6b70c22ec6b1324"
- },
- "observer":{
-    "name":"ActivityTracker"
- },
- "outcome":"success",
- "saveServiceCopy":true,
- "reason":{
-     "reasonCode":$reasonCode,
-     "reasonType":"$reasonType"
- },
- "id":"#tid_test_api",
- "eventTime":"2020-06-03T14:38:10.258+0000",
- "message":"IBM Cloud Functions: ${actionType(operationIndex)} rule $entityName for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
- "target":{
-     "id":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::",
-     "name":"$entityName",
-     "typeURI":"functions/rule"
- },
- "severity":"warning",
- "logSourceCRN":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
- "action":"functions.rule.${actionType(operationIndex)}",
- "initiator":{
-     "name":"john.doe@acme.com",
-     "host":{
-         "address":"192.168.0.1"
-     },
-     "id":"IBMid-310000GN7M",
-     "typeURI":"service/security/account/user",
-     "credential":{
-         "type":"apikey"
-     }
- },
- "dataEvent":false,
- "responseData":{}
-}
-"""
-        verifyEvent(eventString, expectedString)
-      }
-    }
-  }
-
-  it should "create no activity event for post method on (action, trigger)" in {
-
-    var eventString: String = null
-
-    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
-      override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -750,12 +659,13 @@ class ActivityTrackerTests()
     }
   }
 
-  it should "handle invalid grantType correctly" in {
+  it should "handle invalid grantType correctly (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -789,7 +699,7 @@ class ActivityTrackerTests()
     verifyEvent(eventString, expectedString)
   }
 
-  it should "handle invalid httpMethod correctly" in {
+  it should "handle invalid httpMethod correctly (crudcontroller)" in {
 
     var eventString: String = null
 
@@ -827,12 +737,13 @@ class ActivityTrackerTests()
     eventString shouldBe null
   }
 
-  it should "handle invalid targetId correctly" in {
+  it should "handle invalid targetId correctly (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -870,12 +781,13 @@ class ActivityTrackerTests()
     verifyEvent(eventString, expectedString)
   }
 
-  it should "handle invalid targetIdEncoded correctly" in {
+  it should "handle invalid targetIdEncoded correctly (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -914,12 +826,13 @@ class ActivityTrackerTests()
     verifyEvent(eventString, expectedString)
   }
 
-  it should "handle invalid urls correctly" in {
+  it should "handle invalid urls correctly (crudcontroller)" in {
 
     var eventString: String = null
 
     val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
       override def isActive = true
+      override def getIsCrudController: Boolean = true
       override def store(line: String): Unit = {
         eventString = line
       }
@@ -950,7 +863,7 @@ class ActivityTrackerTests()
     eventString shouldBe null
   }
 
-  it should "handle the isActive flag correctly" in {
+  it should "handle the isActive flag correctly (crudcontroller)" in {
 
     // This is the create action test case with isActive = false and true.
     // The result should be empty if isActive = false. Otherwise, the expected event should
@@ -962,7 +875,7 @@ class ActivityTrackerTests()
 
       val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
         override def isActive = activeFlag
-
+        override def getIsCrudController: Boolean = true
         override def store(line: String): Unit = {
           eventString = line
         }
@@ -1054,4 +967,184 @@ class ActivityTrackerTests()
       }
     }
   }
+
+  // controller tests (getIsCrudController = false)
+  // only http POST is tested since all requests with PUT, GET, DELETE are directed to crudcontroller
+
+  it should "handle successful (enable, disable) rule correctly (controller)" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def getIsCrudController: Boolean = false
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    for (operationIndex <- 0 to 1) {
+
+      // sequences indexed by operationIndex
+      val requestedStatus = Seq("active", "inactive")
+      val actionType = Seq("enable", "disable")
+
+      val reasonCode = 200 // // always 200
+      val reasonType = getReasonType(reasonCode.toString)
+      val entityName = "hello123"
+      val method = "POST"
+
+      for (entityType <- 0 to 1) {
+
+        val url =
+          s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/$entityName"
+
+        val settings = Seq(
+          (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+          (TransactionId.tagHttpMethod, method),
+          (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+          (TransactionId.tagInitiatorIp, "192.168.0.1"),
+          (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+          (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+          (TransactionId.tagRequestedStatus, requestedStatus(operationIndex)), // only filled for rules
+          (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+          (
+            TransactionId.tagTargetId,
+            "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+          (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+          (TransactionId.tagUri, url),
+          (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+        val transid = TransactionId("test_api")
+        for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+        eventString = null
+        Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+        val expectedString =
+          s"""
+{"requestData":{
+    "method":"$method",
+    "url":"$url",
+    "userAgent":"CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64",
+    "resourceGroupId":"crn:v1:bluemix:public:resource-controller:global:a/eb2e36585c91a27a709c44e2652a381a::resource-group:ca23a1a3f0a84e2ab6b70c22ec6b1324"
+ },
+ "observer":{
+    "name":"ActivityTracker"
+ },
+ "outcome":"success",
+ "saveServiceCopy":true,
+ "reason":{
+     "reasonCode":$reasonCode,
+     "reasonType":"$reasonType"
+ },
+ "id":"#tid_test_api",
+ "eventTime":"2020-06-03T14:38:10.258+0000",
+ "message":"IBM Cloud Functions: ${actionType(operationIndex)} rule $entityName for namespace a88c0a24-853b-4477-82f8-6876e72bebf2",
+ "target":{
+     "id":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::",
+     "name":"$entityName",
+     "typeURI":"functions/rule"
+ },
+ "severity":"warning",
+ "logSourceCRN":"crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a:::",
+ "action":"functions.rule.${actionType(operationIndex)}",
+ "initiator":{
+     "name":"john.doe@acme.com",
+     "host":{
+         "address":"192.168.0.1"
+     },
+     "id":"IBMid-310000GN7M",
+     "typeURI":"service/security/account/user",
+     "credential":{
+         "type":"apikey"
+     }
+ },
+ "dataEvent":false,
+ "responseData":{}
+}
+"""
+        verifyEvent(eventString, expectedString)
+      }
+    }
+  }
+
+  it should "create no event for an action invocation (controller)" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def getIsCrudController: Boolean = false
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    val url =
+      s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/hello123"
+
+    val settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "POST"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (TransactionId.tagUri, url),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    val transid = TransactionId("test_api")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    eventString shouldBe null
+  }
+
+  it should "create no event for firing a trigger (controller)" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def getIsCrudController: Boolean = false
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    val url =
+      s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/triggers/hello123"
+
+    val settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, "POST"),
+      (TransactionId.tagInitiatorId, "IBMid-310000GN7M"),
+      (TransactionId.tagInitiatorIp, "192.168.0.1"),
+      (TransactionId.tagInitiatorName, "john.doe@acme.com"),
+      (TransactionId.tagNamespaceId, "a88c0a24-853b-4477-82f8-6876e72bebf2"),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, "ca23a1a3f0a84e2ab6b70c22ec6b1324"),
+      (
+        TransactionId.tagTargetId,
+        "crn:v1:bluemix:public:functions:us-south:a/eb2e36585c91a27a709c44e2652a381a::a88c0a24-853b-4477-82f8-6876e72bebf2::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (TransactionId.tagUri, url),
+      (TransactionId.tagUserAgent, "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"))
+
+    val transid = TransactionId("test_api")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
+
+    eventString shouldBe null
+  }
+
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -611,7 +611,6 @@ class ActivityTrackerTests()
  "responseData":{}
 }
 """
-        println(eventString)
         verifyEvent(eventString, expectedString)
       }
     }


### PR DESCRIPTION
This PR adds code to activate activity tracker events for enable/diable rule api calls. A previous PR https://github.com/ibm-functions/openwhisk/pull/18 already added code to handle these calls. But that PR did not activate the controller to also handle activity events. As a consequence, no events were created for enable/diable rule api calls since POST calls are not handled by the crudcontroller.

Furthermore, this PR adds update events. Code is added that determines whether a PUT operation is a create or an update operation. Accordingly, create or update events are created.

## Description
The activity tracker is now enabled for the controller, too. This is required to handle the http POST calls to the rules API for enabling or disabling rules. Summary of changes by file:
- `TransactionId`: a new tag constant has been added `tagUpdateInfo`. It is left empty if PUT is a create operation. Otherwise, this tag is a non-empty string.
- `ApiUtils`:  function `putEntity` now sets the tag `tagUpdateInfo` if PUT is an update operation.
- `FileStorage`: parameter `logFileMaxSize` has been added to make the log file size configurable
- `ActivityEvent`:
   - function `getServiceAction` has an additional parameter `isCrudController` that indicates if the code is running in a crudcontroller or in a controller. The parameter has been added to reduce the amount of checks for the controller that only has to deal with the rules API.
    - the functions `matchAPI` and `matchRulesAPI` now distinguish between create and update operations for http PUT requests by inspecting the transactionId tag `tagUpdateInfo`.
- `ActivityTracker`: 
   - the parameter `logPath` in class `AbstractActivityTracker` has been removed. The log path is now configured via pureconfig. 
   - The configuration`ActivityTrackerConfig` has been changed: it now has the confiruration parameters `auditLogFilePath`, `auditLogFileNamePrefix`, and `auditLogMaxFileSize`. The parameter `runActivityTracker` is not required anymore.
   - The class `ActivityTracker` reads the new pureconfig parameters and activates the controller for activity events. In particular, the `isActive`method is now true if the component is a controller or a crudcontroller, and if `auditLogMaxFileSize` is greather than zero. This means, in the default case where `auditLogMaxFileSize` is not configured the ActivityTracker stays inactive.
- `ActivityTrackerTests`: added tests for controller/crudcontroller roles and for create/update events

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] Existing tests cover the changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

