### PR TITLE
Retry for all UserCommandTests to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/UserCommandTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/UserCommandTests.scala
@@ -35,200 +35,322 @@ class UserCommandTests extends FlatSpec with WhiskAdminCliTestBase {
 
   behavior of "create user"
 
-  org.apache.openwhisk.utils.retry(
-    {
-      it should "fail for subject less than length 5" in {
+  it should "fail for subject less than length 5" in {
+    org.apache.openwhisk.utils.retry(
+      {
+        cleanup()
         the[Exception] thrownBy {
           new Conf(Seq("user", "create", "foo"))
         } should have message CommandMessages.shortName
-      }
-    },
-    10,
-    Some(1.second),
-    Some(
-      s"${this.getClass.getName} > create user should fail for subject less than length 5 not successful, retrying.."))
+      },
+      10,
+      Some(1.second),
+      Some(
+        s"${this.getClass.getName} > create user should fail for subject less than length 5 not successful, retrying.."))
+  }
 
   it should "fail for short key" in {
-    the[Exception] thrownBy {
-      new Conf(Seq("user", "create", "--auth", "uid:shortKey", "foobar"))
-    } should have message CommandMessages.shortKey
+    org.apache.openwhisk.utils.retry(
+      {
+        cleanup()
+        the[Exception] thrownBy {
+          new Conf(Seq("user", "create", "--auth", "uid:shortKey", "foobar"))
+        } should have message CommandMessages.shortKey
+      },
+      10,
+      Some(1.second),
+      Some(s"${this.getClass.getName} > create user should fail for short key not successful, retrying.."))
   }
 
   it should "fail for invalid uuid" in {
-    val key = "x" * 64
-    the[Exception] thrownBy {
-      new Conf(Seq("user", "create", "--auth", s"uid:$key", "foobar"))
-    } should have message CommandMessages.invalidUUID
+    org.apache.openwhisk.utils.retry(
+      {
+        cleanup()
+        val key = "x" * 64
+        the[Exception] thrownBy {
+          new Conf(Seq("user", "create", "--auth", s"uid:$key", "foobar"))
+        } should have message CommandMessages.invalidUUID
+      },
+      10,
+      Some(1.second),
+      Some(s"${this.getClass.getName} > create user should fail for invalid uuid not successful, retrying.."))
   }
 
   it should "create a user" in {
-    val subject = newSubject()
-    val key = BasicAuthenticationAuthKey()
-    val conf = new Conf(Seq("user", "create", "--auth", key.compact, subject))
-    val admin = WhiskAdmin(conf)
-    admin.executeCommand().futureValue.right.get shouldBe key.compact
+    org.apache.openwhisk.utils.retry(
+      {
+        cleanup()
+        val subject = newSubject()
+        val key = BasicAuthenticationAuthKey()
+        val conf = new Conf(Seq("user", "create", "--auth", key.compact, subject))
+        val admin = WhiskAdmin(conf)
+        admin.executeCommand().futureValue.right.get shouldBe key.compact
+      },
+      10,
+      Some(1.second),
+      Some(s"${this.getClass.getName} > create user should create a user not successful, retrying.."))
   }
 
   it should "create a user with default key" in {
-    val subject = newSubject()
-    val generatedKey = resultOk("user", "create", subject)
-    resultOk("user", "get", subject) shouldBe generatedKey
+    org.apache.openwhisk.utils.retry(
+      {
+        cleanup()
+        val subject = newSubject()
+        val generatedKey = resultOk("user", "create", subject)
+        resultOk("user", "get", subject) shouldBe generatedKey
+      },
+      10,
+      Some(1.second),
+      Some(s"${this.getClass.getName} > create user should create a user with default key not successful, retrying.."))
   }
 
   it should "force update an existing user" in {
-    val subject = newSubject()
-    val oldKey = resultOk("user", "create", "--force", subject)
-    resultOk("user", "get", subject) shouldBe oldKey
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          val subject = newSubject()
+          val oldKey = resultOk("user", "create", "--force", subject)
+          resultOk("user", "get", subject) shouldBe oldKey
 
-    // Force update with provided auth uuid:key
-    val key = BasicAuthenticationAuthKey()
-    val newKey = resultOk("user", "create", "--auth", key.compact, "--force", subject)
-    resultOk("user", "get", subject) shouldBe newKey
-    newKey shouldBe key.compact
+          // Force update with provided auth uuid:key
+          val key = BasicAuthenticationAuthKey()
+          val newKey = resultOk("user", "create", "--auth", key.compact, "--force", subject)
+          resultOk("user", "get", subject) shouldBe newKey
+          newKey shouldBe key.compact
 
-    // Force update without auth, uuid:key is randomly generated
-    val generatedKey = resultOk("user", "create", "--force", subject)
-    generatedKey should not be newKey
-    generatedKey should not be oldKey
+          // Force update without auth, uuid:key is randomly generated
+          val generatedKey = resultOk("user", "create", "--force", subject)
+          generatedKey should not be newKey
+          generatedKey should not be oldKey
+        },
+        10,
+        Some(1.second),
+        Some(s"${this.getClass.getName} > create user should force update an existing user not successful, retrying.."))
   }
 
   it should "create a user or update an existing user with revoke flag" in {
-    val subject = newSubject()
-    val oldKey = resultOk("user", "create", "--revoke", subject)
-    resultOk("user", "get", subject) shouldBe oldKey
-    val newKey = resultOk("user", "create", "--revoke", subject)
-    resultOk("user", "get", subject) shouldBe newKey
-    val oldAuthKey = BasicAuthenticationAuthKey(oldKey)
-    val newAuthKey = BasicAuthenticationAuthKey(newKey)
-    newAuthKey.uuid shouldBe oldAuthKey.uuid
-    newAuthKey.key should not be oldAuthKey.key
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          val subject = newSubject()
+          val oldKey = resultOk("user", "create", "--revoke", subject)
+          resultOk("user", "get", subject) shouldBe oldKey
+          val newKey = resultOk("user", "create", "--revoke", subject)
+          resultOk("user", "get", subject) shouldBe newKey
+          val oldAuthKey = BasicAuthenticationAuthKey(oldKey)
+          val newAuthKey = BasicAuthenticationAuthKey(newKey)
+          newAuthKey.uuid shouldBe oldAuthKey.uuid
+          newAuthKey.key should not be oldAuthKey.key
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > create user should create a user or update an existing user with revoke flag not successful, retrying.."))
   }
 
   it should "add namespace to existing user" in {
-    val subject = newSubject()
-    val key = BasicAuthenticationAuthKey()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          val subject = newSubject()
+          val key = BasicAuthenticationAuthKey()
 
-    //Create user
-    WhiskAdmin(new Conf(Seq("user", "create", "--auth", key.compact, subject))).executeCommand().futureValue
+          //Create user
+          WhiskAdmin(new Conf(Seq("user", "create", "--auth", key.compact, subject))).executeCommand().futureValue
 
-    //Add new namespace
-    val key2 = BasicAuthenticationAuthKey()
-    resultOk("user", "create", "--auth", key2.compact, "--namespace", "foo", subject) shouldBe key2.compact
+          //Add new namespace
+          val key2 = BasicAuthenticationAuthKey()
+          resultOk("user", "create", "--auth", key2.compact, "--namespace", "foo", subject) shouldBe key2.compact
 
-    //Adding same namespace should fail
-    resultNotOk("user", "create", "--auth", key2.compact, "--namespace", "foo", subject) shouldBe CommandMessages.namespaceExists
+          //Adding same namespace should fail
+          resultNotOk("user", "create", "--auth", key2.compact, "--namespace", "foo", subject) shouldBe CommandMessages.namespaceExists
 
-    //Adding same namespace with force flag should update the namespace with specified uuid:key
-    val newKey = resultOk("user", "create", "--force", "--auth", key2.compact, "--namespace", "foo", subject)
-    newKey shouldBe key2.compact
+          //Adding same namespace with force flag should update the namespace with specified uuid:key
+          val newKey = resultOk("user", "create", "--force", "--auth", key2.compact, "--namespace", "foo", subject)
+          newKey shouldBe key2.compact
 
-    //Adding same namespace with force flag without auth should regenerate random uuid:key
-    val generatedKey = resultOk("user", "create", "--force", "--namespace", "foo", subject)
-    generatedKey should not be key2.compact
-    generatedKey should not be key.compact
+          //Adding same namespace with force flag without auth should regenerate random uuid:key
+          val generatedKey = resultOk("user", "create", "--force", "--namespace", "foo", subject)
+          generatedKey should not be key2.compact
+          generatedKey should not be key.compact
 
-    //It should be possible to lookup by new namespace
-    implicit val tid = transid()
-    val i = Identity.get(authStore, EntityName("foo")).futureValue
-    i.subject.asString shouldBe subject
-    resultOk("user", "get", "--namespace", "foo", subject) shouldBe generatedKey
+          //It should be possible to lookup by new namespace
+          implicit val tid = transid()
+          val i = Identity.get(authStore, EntityName("foo")).futureValue
+          i.subject.asString shouldBe subject
+          resultOk("user", "get", "--namespace", "foo", subject) shouldBe generatedKey
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > create user should add namespace to existing user not successful, retrying.."))
   }
 
   it should "not add namespace to a blocked user" in {
-    val subject = newSubject()
-    val ns = randomString()
-    val blockedAuth =
-      new ExtendedAuth(Subject(subject), Set(newNS(EntityName(ns), BasicAuthenticationAuthKey())), Some(true))
-    val authStore2 = UserCommand.createDataStore()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          val subject = newSubject()
+          val ns = randomString()
+          val blockedAuth =
+            new ExtendedAuth(Subject(subject), Set(newNS(EntityName(ns), BasicAuthenticationAuthKey())), Some(true))
+          val authStore2 = UserCommand.createDataStore()
 
-    implicit val tid = transid()
-    authStore2.put(blockedAuth).futureValue
+          implicit val tid = transid()
+          authStore2.put(blockedAuth).futureValue
 
-    resultNotOk("user", "create", "--namespace", "foo", subject) shouldBe CommandMessages.subjectBlocked
+          resultNotOk("user", "create", "--namespace", "foo", subject) shouldBe CommandMessages.subjectBlocked
 
-    authStore2.shutdown()
+          authStore2.shutdown()
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > create user should not add namespace to a blocked user not successful, retrying.."))
   }
 
   behavior of "delete user"
 
   it should "fail deleting non existing user" in {
-    resultNotOk("user", "delete", "non-existing-user") shouldBe CommandMessages.subjectMissing
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          resultNotOk("user", "delete", "non-existing-user") shouldBe CommandMessages.subjectMissing
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > delete user should fail deleting non existing user not successful, retrying.."))
   }
 
   it should "delete existing user" in {
-    val subject = newSubject()
-    val key = BasicAuthenticationAuthKey()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          val subject = newSubject()
+          val key = BasicAuthenticationAuthKey()
 
-    //Create user
-    WhiskAdmin(new Conf(Seq("user", "create", "--auth", key.compact, subject))).executeCommand().futureValue
+          //Create user
+          WhiskAdmin(new Conf(Seq("user", "create", "--auth", key.compact, subject))).executeCommand().futureValue
 
-    resultOk("user", "delete", subject) shouldBe CommandMessages.subjectDeleted
+          resultOk("user", "delete", subject) shouldBe CommandMessages.subjectDeleted
+        },
+        10,
+        Some(1.second),
+        Some(s"${this.getClass.getName} > delete user should fail delete existing user not successful, retrying.."))
   }
 
   it should "remove namespace from existing user" in {
-    implicit val tid = transid()
-    val subject = newSubject()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          implicit val tid = transid()
+          val subject = newSubject()
 
-    val ns1 = newNS()
-    val ns2 = newNS()
+          val ns1 = newNS()
+          val ns2 = newNS()
 
-    val auth = WhiskAuth(Subject(subject), Set(ns1, ns2))
+          val auth = WhiskAuth(Subject(subject), Set(ns1, ns2))
 
-    put(authStore, auth)
+          put(authStore, auth)
 
-    resultOk("user", "delete", "--namespace", ns1.namespace.name.asString, subject) shouldBe CommandMessages.namespaceDeleted
+          resultOk("user", "delete", "--namespace", ns1.namespace.name.asString, subject) shouldBe CommandMessages.namespaceDeleted
 
-    val authFromDB = authStore.get[WhiskAuth](DocInfo(DocId(subject))).futureValue
-    authFromDB.namespaces shouldBe Set(ns2)
+          val authFromDB = authStore.get[WhiskAuth](DocInfo(DocId(subject))).futureValue
+          authFromDB.namespaces shouldBe Set(ns2)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > delete user should remove namespace from existing user not successful, retrying.."))
   }
 
   it should "not remove missing namespace" in {
-    implicit val tid = transid()
-    val subject = newSubject()
-    val auth = WhiskAuth(Subject(subject), Set(newNS(), newNS()))
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          implicit val tid = transid()
+          val subject = newSubject()
+          val auth = WhiskAuth(Subject(subject), Set(newNS(), newNS()))
 
-    put(authStore, auth)
-    resultNotOk("user", "delete", "--namespace", "non-existing-ns", subject) shouldBe
-      CommandMessages.namespaceMissing("non-existing-ns", subject)
+          put(authStore, auth)
+          resultNotOk("user", "delete", "--namespace", "non-existing-ns", subject) shouldBe
+            CommandMessages.namespaceMissing("non-existing-ns", subject)
+        },
+        10,
+        Some(1.second),
+        Some(s"${this.getClass.getName} > delete user should not remove missing namespace not successful, retrying.."))
   }
 
   behavior of "get key"
 
   it should "not get key for missing subject" in {
-    resultNotOk("user", "get", "non-existing-user") shouldBe CommandMessages.subjectMissing
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          resultNotOk("user", "get", "non-existing-user") shouldBe CommandMessages.subjectMissing
+        },
+        10,
+        Some(1.second),
+        Some(s"${this.getClass.getName} > get key should not get key for missing subject not successful, retrying.."))
   }
 
   it should "get key for existing user" in {
-    implicit val tid = transid()
-    val subject = newSubject()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          implicit val tid = transid()
+          val subject = newSubject()
 
-    val ns1 = newNS()
-    val ns2 = newNS()
-    val ns3 = newNS(EntityName(subject), BasicAuthenticationAuthKey())
+          val ns1 = newNS()
+          val ns2 = newNS()
+          val ns3 = newNS(EntityName(subject), BasicAuthenticationAuthKey())
 
-    val auth = WhiskAuth(Subject(subject), Set(ns1, ns2, ns3))
-    put(authStore, auth)
+          val auth = WhiskAuth(Subject(subject), Set(ns1, ns2, ns3))
+          put(authStore, auth)
 
-    resultOk("user", "get", "--namespace", ns1.namespace.name.asString, subject) shouldBe ns1.authkey.compact
+          resultOk("user", "get", "--namespace", ns1.namespace.name.asString, subject) shouldBe ns1.authkey.compact
 
-    val all = resultOk("user", "get", "--all", subject)
+          val all = resultOk("user", "get", "--all", subject)
 
-    all should include(ns1.authkey.compact)
-    all should include(ns2.authkey.compact)
-    all should include(ns3.authkey.compact)
+          all should include(ns1.authkey.compact)
+          all should include(ns2.authkey.compact)
+          all should include(ns3.authkey.compact)
 
-    //Is --namespace is not there look by subject
-    resultOk("user", "get", subject) shouldBe ns3.authkey.compact
+          //Is --namespace is not there look by subject
+          resultOk("user", "get", subject) shouldBe ns3.authkey.compact
 
-    //Look for namespace which does not exist
-    resultNotOk("user", "get", "--namespace", "non-existing-ns", subject) shouldBe
-      CommandMessages.namespaceMissing("non-existing-ns", subject)
+          //Look for namespace which does not exist
+          resultNotOk("user", "get", "--namespace", "non-existing-ns", subject) shouldBe
+            CommandMessages.namespaceMissing("non-existing-ns", subject)
+        },
+        10,
+        Some(1.second),
+        Some(s"${this.getClass.getName} > get key should get key for existing user not successful, retrying.."))
   }
 
   behavior of "whois"
 
   it should "not get subject for missing subject" in {
-    resultNotOk("user", "whois", BasicAuthenticationAuthKey().compact) shouldBe CommandMessages.subjectMissing
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          resultNotOk("user", "whois", BasicAuthenticationAuthKey().compact) shouldBe CommandMessages.subjectMissing
+        },
+        10,
+        Some(1.second),
+        Some(s"${this.getClass.getName} > whois should not get subject for missing subject not successful, retrying.."))
   }
 
   it should "get key for existing user" in {
@@ -257,68 +379,85 @@ class UserCommandTests extends FlatSpec with WhiskAdminCliTestBase {
   behavior of "list"
 
   it should "list keys associated with given namespace" in {
-    implicit val tid = transid()
-    def newWhiskAuth(ns: String*) =
-      WhiskAuth(Subject(newSubject()), ns.map(n => newNS(EntityName(n), BasicAuthenticationAuthKey())).toSet)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          implicit val tid = transid()
+          def newWhiskAuth(ns: String*) =
+            WhiskAuth(Subject(newSubject()), ns.map(n => newNS(EntityName(n), BasicAuthenticationAuthKey())).toSet)
 
-    def key(a: WhiskAuth, ns: String) = a.namespaces.find(_.namespace.name.asString == ns).map(_.authkey).get
+          def key(a: WhiskAuth, ns: String) = a.namespaces.find(_.namespace.name.asString == ns).map(_.authkey).get
 
-    val ns1 = randomString()
-    val ns2 = randomString()
-    val ns3 = randomString()
+          val ns1 = randomString()
+          val ns2 = randomString()
+          val ns3 = randomString()
 
-    val a1 = newWhiskAuth(ns1)
-    val a2 = newWhiskAuth(ns1, ns2)
-    val a3 = newWhiskAuth(ns1, ns2, ns3)
+          val a1 = newWhiskAuth(ns1)
+          val a2 = newWhiskAuth(ns1, ns2)
+          val a3 = newWhiskAuth(ns1, ns2, ns3)
 
-    Seq(a1, a2, a3).foreach(put(authStore, _))
+          Seq(a1, a2, a3).foreach(put(authStore, _))
 
-    Seq(a1, a2, a3).foreach(a => waitOnView(authStore, key(a, ns1), 1))
+          Seq(a1, a2, a3).foreach(a => waitOnView(authStore, key(a, ns1), 1))
 
-    //Check negative case
-    resultNotOk("user", "list", "non-existing-ns") shouldBe CommandMessages.namespaceMissing("non-existing-ns")
+          //Check negative case
+          resultNotOk("user", "list", "non-existing-ns") shouldBe CommandMessages.namespaceMissing("non-existing-ns")
 
-    //Check all results
-    val r1 = resultOk("user", "list", ns1)
-    r1.split("\n").length shouldBe 3
-    r1 should include(a1.subject.asString)
-    r1 should include(key(a2, ns1).compact)
+          //Check all results
+          val r1 = resultOk("user", "list", ns1)
+          r1.split("\n").length shouldBe 3
+          r1 should include(a1.subject.asString)
+          r1 should include(key(a2, ns1).compact)
 
-    //Check limit
-    val r2 = resultOk("user", "list", "-p", "2", ns1)
-    r2.split("\n").length shouldBe 2
+          //Check limit
+          val r2 = resultOk("user", "list", "-p", "2", ns1)
+          r2.split("\n").length shouldBe 2
 
-    //Check key only
-    val r3 = resultOk("user", "list", "-k", ns1)
-    r3 should include(key(a2, ns1).compact)
-    r3 should not include a2.subject.asString
+          //Check key only
+          val r3 = resultOk("user", "list", "-k", ns1)
+          r3 should include(key(a2, ns1).compact)
+          r3 should not include a2.subject.asString
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > list should list keys associated with given namespace not successful, retrying.."))
   }
 
   behavior of "block"
 
   it should "block subjects" in {
-    implicit val tid = transid()
-    val a1 = WhiskAuth(Subject(newSubject()), Set(newNS()))
-    val a2 = WhiskAuth(Subject(newSubject()), Set(newNS()))
-    val a3 = WhiskAuth(Subject(newSubject()), Set(newNS()))
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          cleanup()
+          implicit val tid = transid()
+          val a1 = WhiskAuth(Subject(newSubject()), Set(newNS()))
+          val a2 = WhiskAuth(Subject(newSubject()), Set(newNS()))
+          val a3 = WhiskAuth(Subject(newSubject()), Set(newNS()))
 
-    Seq(a1, a2, a3).foreach(put(authStore, _))
+          Seq(a1, a2, a3).foreach(put(authStore, _))
 
-    val r1 = resultOk("user", "block", a1.subject.asString, a2.subject.asString)
+          val r1 = resultOk("user", "block", a1.subject.asString, a2.subject.asString)
 
-    val authStore2 = UserCommand.createDataStore()
+          val authStore2 = UserCommand.createDataStore()
 
-    authStore2.get[ExtendedAuth](a1.docinfo).futureValue.isBlocked shouldBe true
-    authStore2.get[ExtendedAuth](a2.docinfo).futureValue.isBlocked shouldBe true
-    authStore2.get[ExtendedAuth](a3.docinfo).futureValue.isBlocked shouldBe false
+          authStore2.get[ExtendedAuth](a1.docinfo).futureValue.isBlocked shouldBe true
+          authStore2.get[ExtendedAuth](a2.docinfo).futureValue.isBlocked shouldBe true
+          authStore2.get[ExtendedAuth](a3.docinfo).futureValue.isBlocked shouldBe false
 
-    val r2 = resultOk("user", "unblock", a2.subject.asString, a3.subject.asString)
+          val r2 = resultOk("user", "unblock", a2.subject.asString, a3.subject.asString)
 
-    authStore2.get[ExtendedAuth](a1.docinfo).futureValue.isBlocked shouldBe true
-    authStore2.get[ExtendedAuth](a2.docinfo).futureValue.isBlocked shouldBe false
-    authStore2.get[ExtendedAuth](a3.docinfo).futureValue.isBlocked shouldBe false
+          authStore2.get[ExtendedAuth](a1.docinfo).futureValue.isBlocked shouldBe true
+          authStore2.get[ExtendedAuth](a2.docinfo).futureValue.isBlocked shouldBe false
+          authStore2.get[ExtendedAuth](a3.docinfo).futureValue.isBlocked shouldBe false
 
-    authStore2.shutdown()
+          authStore2.shutdown()
+        },
+        10,
+        Some(1.second),
+        Some(s"${this.getClass.getName} > blockk should block subjects not successful, retrying.."))
   }
 
   override def cleanup()(implicit timeout: Duration): Unit = {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

