### PR TITLE
Retry for all CouchDBArtifactStore to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreQueryBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreQueryBehaviors.scala
@@ -17,6 +17,7 @@
 
 package org.apache.openwhisk.core.database.test.behavior
 
+import scala.concurrent.duration._
 import spray.json.{JsArray, JsNumber, JsObject, JsString}
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.entity.WhiskQueries.TOP
@@ -27,253 +28,350 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
   behavior of s"${storeType}ArtifactStore query"
 
   it should "find single entity" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val action = newAction(ns)
-    val docInfo = put(entityStore, action)
+          val ns = newNS()
+          val action = newAction(ns)
+          val docInfo = put(entityStore, action)
 
-    waitOnView(entityStore, ns.root, 1, WhiskAction.view)
-    val result = query[WhiskEntity](
-      entityStore,
-      WhiskAction.view.name,
-      List(ns.asString, 0),
-      List(ns.asString, TOP, TOP),
-      includeDocs = true)
+          waitOnView(entityStore, ns.root, 1, WhiskAction.view)
+          val result = query[WhiskEntity](
+            entityStore,
+            WhiskAction.view.name,
+            List(ns.asString, 0),
+            List(ns.asString, TOP, TOP),
+            includeDocs = true)
 
-    result should have length 1
+          result should have length 1
 
-    def js = result.head
-    js.fields("id") shouldBe JsString(docInfo.id.id)
-    js.fields("key") shouldBe JsArray(JsString(ns.asString), JsNumber(action.updated.toEpochMilli))
-    js.fields.get("value") shouldBe defined
-    js.fields.get("doc") shouldBe defined
-    js.fields("value") shouldBe action.summaryAsJson
-    dropRev(js.fields("doc").asJsObject) shouldBe action.toDocumentRecord
+          def js = result.head
+          js.fields("id") shouldBe JsString(docInfo.id.id)
+          js.fields("key") shouldBe JsArray(JsString(ns.asString), JsNumber(action.updated.toEpochMilli))
+          js.fields.get("value") shouldBe defined
+          js.fields.get("doc") shouldBe defined
+          js.fields("value") shouldBe action.summaryAsJson
+          dropRev(js.fields("doc").asJsObject) shouldBe action.toDocumentRecord
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should find single entity not successful, retrying.."))
   }
 
   it should "not have doc with includeDocs = false" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val action = newAction(ns)
-    val docInfo = put(entityStore, action)
+          val ns = newNS()
+          val action = newAction(ns)
+          val docInfo = put(entityStore, action)
 
-    waitOnView(entityStore, ns.root, 1, WhiskAction.view)
-    val result =
-      query[WhiskEntity](entityStore, WhiskAction.view.name, List(ns.asString, 0), List(ns.asString, TOP, TOP))
+          waitOnView(entityStore, ns.root, 1, WhiskAction.view)
+          val result =
+            query[WhiskEntity](entityStore, WhiskAction.view.name, List(ns.asString, 0), List(ns.asString, TOP, TOP))
 
-    result should have length 1
+          result should have length 1
 
-    def js = result.head
-    js.fields("id") shouldBe JsString(docInfo.id.id)
-    js.fields("key") shouldBe JsArray(JsString(ns.asString), JsNumber(action.updated.toEpochMilli))
-    js.fields.get("value") shouldBe defined
-    js.fields.get("doc") shouldBe None
-    js.fields("value") shouldBe action.summaryAsJson
+          def js = result.head
+          js.fields("id") shouldBe JsString(docInfo.id.id)
+          js.fields("key") shouldBe JsArray(JsString(ns.asString), JsNumber(action.updated.toEpochMilli))
+          js.fields.get("value") shouldBe defined
+          js.fields.get("doc") shouldBe None
+          js.fields("value") shouldBe action.summaryAsJson
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should not have doc with includeDocs = false not successful, retrying.."))
   }
 
   it should "find all entities" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val entities = Seq(newAction(ns), newAction(ns))
+          val ns = newNS()
+          val entities = Seq(newAction(ns), newAction(ns))
 
-    entities foreach {
-      put(entityStore, _)
-    }
+          entities foreach {
+            put(entityStore, _)
+          }
 
-    waitOnView(entityStore, ns.root, 2, WhiskAction.view)
-    val result =
-      query[WhiskEntity](entityStore, WhiskAction.view.name, List(ns.asString, 0), List(ns.asString, TOP, TOP))
+          waitOnView(entityStore, ns.root, 2, WhiskAction.view)
+          val result =
+            query[WhiskEntity](entityStore, WhiskAction.view.name, List(ns.asString, 0), List(ns.asString, TOP, TOP))
 
-    result should have length entities.length
-    result.map(_.fields("value")) should contain theSameElementsAs entities.map(_.summaryAsJson)
+          result should have length entities.length
+          result.map(_.fields("value")) should contain theSameElementsAs entities.map(_.summaryAsJson)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should find all entities not successful, retrying.."))
   }
 
   it should "exclude deleted entities" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val entities = Seq(newAction(ns), newAction(ns), newAction(ns))
-    val validEntities = entities.tail
-    val infos = entities.map(put(entityStore, _))
+          val ns = newNS()
+          val entities = Seq(newAction(ns), newAction(ns), newAction(ns))
+          val validEntities = entities.tail
+          val infos = entities.map(put(entityStore, _))
 
-    delete(entityStore, infos.head)
+          delete(entityStore, infos.head)
 
-    waitOnView(entityStore, ns.root, 2, WhiskAction.view)
-    val result =
-      query[WhiskEntity](entityStore, WhiskAction.view.name, List(ns.asString, 0), List(ns.asString, TOP, TOP))
+          waitOnView(entityStore, ns.root, 2, WhiskAction.view)
+          val result =
+            query[WhiskEntity](entityStore, WhiskAction.view.name, List(ns.asString, 0), List(ns.asString, TOP, TOP))
 
-    result should have length validEntities.length
-    result.map(_.fields("value")) should contain theSameElementsAs validEntities.map(_.summaryAsJson)
+          result should have length validEntities.length
+          result.map(_.fields("value")) should contain theSameElementsAs validEntities.map(_.summaryAsJson)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should exclude deleted entities not successful, retrying.."))
   }
 
   it should "return result in sorted order" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
-    activations foreach (put(activationStore, _))
+          val ns = newNS()
+          val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
+          activations foreach (put(activationStore, _))
 
-    val entityPath = s"${ns.asString}/testact"
-    waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
+          val entityPath = s"${ns.asString}/testact"
+          waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
 
-    val resultDescending = query[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP))
+          val resultDescending = query[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP))
 
-    resultDescending should have length activations.length
-    resultDescending.map(getJsField(_, "value", "start")) shouldBe activations
-      .map(_.summaryAsJson.fields("start"))
-      .reverse
+          resultDescending should have length activations.length
+          resultDescending.map(getJsField(_, "value", "start")) shouldBe activations
+            .map(_.summaryAsJson.fields("start"))
+            .reverse
 
-    val resultAscending = query[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP),
-      descending = false)
+          val resultAscending = query[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP),
+            descending = false)
 
-    resultAscending.map(getJsField(_, "value", "start")) shouldBe activations.map(_.summaryAsJson.fields("start"))
+          resultAscending.map(getJsField(_, "value", "start")) shouldBe activations.map(_.summaryAsJson.fields("start"))
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should return result in sorted order not successful, retrying.."))
   }
 
   it should "support skipping results" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
-    activations foreach (put(activationStore, _))
+          val ns = newNS()
+          val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
+          activations foreach (put(activationStore, _))
 
-    val entityPath = s"${ns.asString}/testact"
-    waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
-    val result = query[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP),
-      skip = 5,
-      descending = false)
+          val entityPath = s"${ns.asString}/testact"
+          waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
+          val result = query[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP),
+            skip = 5,
+            descending = false)
 
-    result.map(getJsField(_, "value", "start")) shouldBe activations.map(_.summaryAsJson.fields("start")).drop(5)
+          result.map(getJsField(_, "value", "start")) shouldBe activations.map(_.summaryAsJson.fields("start")).drop(5)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should support skipping results not successful, retrying.."))
   }
 
   it should "support limiting results" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
-    activations foreach (put(activationStore, _))
+          val ns = newNS()
+          val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
+          activations foreach (put(activationStore, _))
 
-    val entityPath = s"${ns.asString}/testact"
-    waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
-    val result = query[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP),
-      limit = 5,
-      descending = false)
+          val entityPath = s"${ns.asString}/testact"
+          waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
+          val result = query[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP),
+            limit = 5,
+            descending = false)
 
-    result.map(getJsField(_, "value", "start")) shouldBe activations.map(_.summaryAsJson.fields("start")).take(5)
+          result.map(getJsField(_, "value", "start")) shouldBe activations.map(_.summaryAsJson.fields("start")).take(5)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should support limiting results not successful, retrying.."))
   }
 
   it should "support including complete docs" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
-    activations foreach (put(activationStore, _))
+          val ns = newNS()
+          val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
+          activations foreach (put(activationStore, _))
 
-    val entityPath = s"${ns.asString}/testact"
-    waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
-    val result = query[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP),
-      includeDocs = true,
-      descending = false)
+          val entityPath = s"${ns.asString}/testact"
+          waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
+          val result = query[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP),
+            includeDocs = true,
+            descending = false)
 
-    //Drop the _rev field as activations do not have that field
-    result.map(js => JsObject(getJsObject(js, "doc").fields - "_rev")) shouldBe activations.map(_.toDocumentRecord)
+          //Drop the _rev field as activations do not have that field
+          result.map(js => JsObject(getJsObject(js, "doc").fields - "_rev")) shouldBe activations.map(
+            _.toDocumentRecord)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should support including complete docs not successful, retrying.."))
   }
 
   it should "throw exception for negative limits and skip" in {
-    implicit val tid: TransactionId = transid()
-    a[IllegalArgumentException] should be thrownBy query[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List("foo", 0),
-      List("foo", TOP, TOP),
-      limit = -1)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
+          a[IllegalArgumentException] should be thrownBy query[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List("foo", 0),
+            List("foo", TOP, TOP),
+            limit = -1)
 
-    a[IllegalArgumentException] should be thrownBy query[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List("foo", 0),
-      List("foo", TOP, TOP),
-      skip = -1)
+          a[IllegalArgumentException] should be thrownBy query[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List("foo", 0),
+            List("foo", TOP, TOP),
+            skip = -1)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore query should throw exception for negative limits and skip not successful, retrying.."))
   }
 
   behavior of s"${storeType}ArtifactStore count"
 
   it should "should match all created activations" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
-    activations foreach (put(activationStore, _))
+          val ns = newNS()
+          val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
+          activations foreach (put(activationStore, _))
 
-    val entityPath = s"${ns.asString}/testact"
-    waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
-    val result = count[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP))
+          val entityPath = s"${ns.asString}/testact"
+          waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
+          val result = count[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP))
 
-    result shouldBe 10
+          result shouldBe 10
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore count should should match all created activations not successful, retrying.."))
   }
 
   it should "count with skip" in {
-    implicit val tid: TransactionId = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
 
-    val ns = newNS()
-    val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
-    activations foreach (put(activationStore, _))
+          val ns = newNS()
+          val activations = (1000 until 1100 by 10).map(newActivation(ns.asString, "testact", _))
+          activations foreach (put(activationStore, _))
 
-    val entityPath = s"${ns.asString}/testact"
-    waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
-    val result = count[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP),
-      skip = 4)
+          val entityPath = s"${ns.asString}/testact"
+          waitOnView(activationStore, EntityPath(entityPath), activations.size, WhiskActivation.filtersView)
+          val result = count[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP),
+            skip = 4)
 
-    result shouldBe 10 - 4
+          result shouldBe 10 - 4
 
-    val result2 = count[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List(entityPath, 0),
-      List(entityPath, TOP, TOP),
-      skip = 1000)
+          val result2 = count[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List(entityPath, 0),
+            List(entityPath, TOP, TOP),
+            skip = 1000)
 
-    result2 shouldBe 0
+          result2 shouldBe 0
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore count should count with skip not successful, retrying.."))
   }
 
   it should "throw exception for negative skip" in {
-    implicit val tid: TransactionId = transid()
-    a[IllegalArgumentException] should be thrownBy count[WhiskActivation](
-      activationStore,
-      WhiskActivation.filtersView.name,
-      List("foo", 0),
-      List("foo", TOP, TOP),
-      skip = -1)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
+          a[IllegalArgumentException] should be thrownBy count[WhiskActivation](
+            activationStore,
+            WhiskActivation.filtersView.name,
+            List("foo", 0),
+            List("foo", TOP, TOP),
+            skip = -1)
+        },
+        10,
+        Some(1.second),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore count should throw exception for negative skip not successful, retrying.."))
   }
 
   private def dropRev(js: JsObject): JsObject = {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
16:00:20  org.apache.openwhisk.core.database.CouchDBArtifactStoreTests > CouchDBArtifactStore query should find single entity STANDARD_OUT
16:00:20      [2020-06-30T10:00:20.206Z] [INFO] SessionTrackerImpl exited loop!
16:00:21      [2020-06-30T14:00:19.859Z] [INFO] [#tid_sid_unknown] [WhiskConfig] reading properties from file /home/cusina/workspace/mainWhisk/blue/whisk.properties
16:00:21      [2020-06-30T14:00:19.860Z] [DEBUG] [#tid_sid_unknown] [WhiskConfig] properties file set value for runtimes.manifest
16:00:21      [2020-06-30T14:00:19.892Z] [INFO] [#tid_1] [CouchDbRestStore] [PUT] 'fn-dev-build_whisks' saving document: 'id: artifactTCK_VIb3_ns_HdqzA/artifactTCK_VIb3_name_jqTXl, rev: null' [marker:database_saveDocument_start:0]
16:00:21      [2020-06-30T14:00:20.308Z] [INFO] [#tid_1] [CouchDbRestStore] [marker:database_saveDocument_finish:416:416]
16:00:21      [2020-06-30T14:00:20.310Z] [INFO] [#tid_1] [CouchDbRestStore] [QUERY] 'fn-dev-build_whisks' searching 'whisks.v2.1.0/actions [marker:database_queryView_start:418]
16:00:21      [2020-06-30T14:00:20.416Z] [INFO] [#tid_1] [CouchDbRestStore] [marker:database_queryView_finish:524:106]
16:00:21      [2020-06-30T14:00:20.416Z] [INFO] [#tid_1] [CouchDbRestStore] [QUERY] 'fn-dev-build_whisks' searching 'whisks.v2.1.0/actions [marker:database_queryView_start:524]
16:00:21      [2020-06-30T14:00:20.520Z] [INFO] [#tid_1] [CouchDbRestStore] [marker:database_queryView_finish:628:104]
16:00:21      [2020-06-30T14:00:20.521Z] [INFO] [#tid_1] [CouchDbRestStore] [QUERY] 'fn-dev-build_whisks' searching 'whisks.v2.1.0/actions [marker:database_queryView_start:629]
16:00:21      [2020-06-30T14:00:20.623Z] [INFO] [#tid_1] [CouchDbRestStore] [marker:database_queryView_finish:731:102]
16:00:21      [2020-06-30T14:00:20.623Z] [INFO] [#tid_1] [CouchDbRestStore] [QUERY] 'fn-dev-build_whisks' searching 'whisks.v2.1.0/actions [marker:database_queryView_start:731]
16:00:21      [2020-06-30T14:00:20.725Z] [INFO] [#tid_1] [CouchDbRestStore] [marker:database_queryView_finish:833:101]
16:00:21      [2020-06-30T14:00:20.725Z] [INFO] [#tid_1] [CouchDbRestStore] [QUERY] 'fn-dev-build_whisks' searching 'whisks.v2.1.0/actions [marker:database_queryView_start:833]
16:00:21      [2020-06-30T14:00:20.827Z] [INFO] [#tid_1] [CouchDbRestStore] [marker:database_queryView_finish:935:102]
16:00:21      [2020-06-30T14:00:20.827Z] [INFO] [#tid_1] [CouchDbRestStore] [QUERY] 'fn-dev-build_whisks' searching 'whisks.v2.1.0/actions [marker:database_queryView_start:935]
16:00:21      [2020-06-30T14:00:20.929Z] [INFO] [#tid_1] [CouchDbRestStore] [marker:database_queryView_finish:1037:102]
16:00:21  
16:00:21  org.apache.openwhisk.core.database.CouchDBArtifactStoreTests > CouchDBArtifactStore query should find single entity FAILED
16:00:21      org.scalatest.exceptions.TestFailedException: List() had length 0 instead of expected length 1
16:00:21          at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
16:00:21          at org.scalatest.Matchers$ResultOfHaveWordForExtent.length(Matchers.scala:2685)
16:00:21          at org.apache.openwhisk.core.database.test.behavior.ArtifactStoreQueryBehaviors.$anonfun$$init$$1(ArtifactStoreQueryBehaviors.scala:44)
16:00:21          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
16:00:21          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
16:00:21          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
16:00:21          at org.scalatest.Transformer.apply(Transformer.scala:22)
16:00:21          at org.scalatest.Transformer.apply(Transformer.scala:20)
16:00:21          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
16:00:21          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
16:00:21          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
16:00:21          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.org$apache$openwhisk$core$database$test$behavior$ArtifactStoreBehaviorBase$$super$withFixture(CouchDBArtifactStoreTests.scala:26)
16:00:21          at org.apache.openwhisk.core.database.test.behavior.ArtifactStoreBehaviorBase.withFixture(ArtifactStoreBehaviorBase.scala:80)
16:00:21          at org.apache.openwhisk.core.database.test.behavior.ArtifactStoreBehaviorBase.withFixture$(ArtifactStoreBehaviorBase.scala:78)
16:00:21          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.withFixture(CouchDBArtifactStoreTests.scala:26)
16:00:21          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
16:00:21          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
16:00:21          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
16:00:21          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
16:00:21          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
16:00:21          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.org$scalatest$BeforeAndAfterEach$$super$runTest(CouchDBArtifactStoreTests.scala:26)
16:00:21          at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:221)
16:00:21          at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:214)
16:00:21          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.runTest(CouchDBArtifactStoreTests.scala:26)
16:00:21          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
16:00:21          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
16:00:21          at scala.collection.immutable.List.foreach(List.scala:392)
16:00:21          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
16:00:21          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
16:00:21          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
16:00:21          at scala.collection.immutable.List.foreach(List.scala:392)
16:00:21          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
16:00:21          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
16:00:21          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
16:00:21          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
16:00:21          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
16:00:21          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
16:00:21          at org.scalatest.Suite.run(Suite.scala:1124)
16:00:21          at org.scalatest.Suite.run$(Suite.scala:1106)
16:00:21          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
16:00:21          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
16:00:21          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
16:00:21          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
16:00:21          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
16:00:21          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.org$scalatest$BeforeAndAfterAll$$super$run(CouchDBArtifactStoreTests.scala:26)
16:00:21          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
16:00:21          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
16:00:21          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
16:00:21          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.run(CouchDBArtifactStoreTests.scala:26)```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

