### PR TITLE
Move helper method waitForIdentityToAppear to DbUtils

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/DbUtils.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/DbUtils.scala
@@ -91,6 +91,54 @@ trait DbUtils extends Assertions {
     } else Failure(new NoDocumentException("timed out"))
   }
 
+  def waitForIdentityToAppear(db: ExtendedCouchDbRestClient, authKey: String, expectedCount: Int): Unit = {
+    // query identities view by using authkey, if in view result will be as follows:
+    // {
+    //  "offset": 45,
+    //  "rows": [
+    //    {
+    //      "id": "anon-sdFOhq4kiknbYM33deFb7SSJ9vA",
+    //      "key": [
+    //        "58b9a982-e9ab-4010-8dc9-87650a123bc1",
+    //        "iX8***fb16"
+    //      ],
+    //      "value": {
+    //        "_id": "anon-sdFOhq4kiknbYM33deFb7SSJ9vA/limits",
+    //        "key": "iX8***b16",
+    //        "namespace": "anon-sdFOhq4kiknbYM33deFb7SSJ9vA",
+    //        "uuid": "58b9a982-e9ab-4010-8dc9-87650a123bc1"
+    //      }
+    //    }
+    //  ],
+    //  "total_rows": 296
+    //}
+    val key = List(authKey.split(":")(0), authKey.split(":")(1))
+
+    def checkForIdentityToAppearInView() =
+      db.executeView("subjects.v2.0.0", "identities")(key, key, reduce = false).map {
+        case Right(doc) =>
+          val rows = doc
+            .fields("rows")
+            .convertTo[List[JsObject]]
+          if (rows.length != expectedCount) {
+            println(s"view rows length: ${rows.length} (doc: $doc), expected: $expectedCount")
+            throw RetryOp()
+          }
+          true
+        case Left(statusCode) =>
+          println(s"unexpected left value: $statusCode")
+          throw RetryOp()
+      }
+
+    // query the view at least `successfulViewCalls` times successfully, to handle inconsistency between several CouchDB-nodes.
+    (0 until successfulViewCalls).map { _ =>
+      // try for 5 minutes
+      val success =
+        retry(() => checkForIdentityToAppearInView, timeout = 10.seconds, count = 90, graceBeforeRetry = 2.seconds)
+      assert(success.isSuccess, "wait for entries to appear in view not successful after 90 retries: " + success)
+    }
+  }
+
   /**
    * Wait on a view to update with documents added to namespace. This uses retry above,
    * where the step performs a direct db query to retrieve the view and check the count


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change moves the helper method `waitForIdentityToAppear` to `DbUtils`.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

