### PR TITLE
Retry on failures for all ActivationsApiTests to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivationsApiTests.scala
@@ -32,6 +32,7 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.{ErrorResponse, Messages}
 import org.apache.openwhisk.core.database.UserContext
+import scala.concurrent.duration._
 
 /**
  * Tests Activations API.
@@ -55,6 +56,8 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   val context = UserContext(creds)
   val namespace = EntityPath(creds.subject.asString)
   val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  val retriesOnTestFailures = 5
+  val waitBeforeRetry = 1.second
 
   def aname() = MakeName.next("activations_tests")
 
@@ -72,73 +75,81 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
 
   //// GET /activations
   it should "get summary activation by namespace" in {
-    implicit val tid = transid()
-    // create two sets of activation records, and check that only one set is served back
-    val creds1 = WhiskAuthHelpers.newAuth()
-    val notExpectedActivations = (1 to 2).map { i =>
-      WhiskActivation(
-        EntityPath(creds1.subject.asString),
-        aname(),
-        creds1.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    }
-    val actionName = aname()
-    val activations = (1 to 2).map { i =>
-      WhiskActivation(
-        namespace,
-        actionName,
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    }.toList
-    try {
-      (notExpectedActivations ++ activations).foreach(storeActivation(_, context))
-      waitOnListActivationsInNamespace(namespace, 2, context)
-
-      org.apache.openwhisk.utils.retry {
-        Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-          status should be(OK)
-          val response = responseAs[List[JsObject]]
-          activations.length should be(response.length)
-          response should contain theSameElementsAs activations.map(_.summaryAsJson)
-          response forall { a =>
-            a.getFields("for") match {
-              case Seq(JsString(n)) => n == actionName.asString
-              case _                => false
-            }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          // create two sets of activation records, and check that only one set is served back
+          val creds1 = WhiskAuthHelpers.newAuth()
+          val notExpectedActivations = (1 to 2).map { i =>
+            WhiskActivation(
+              EntityPath(creds1.subject.asString),
+              aname(),
+              creds1.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
           }
-        }
-      }
+          val actionName = aname()
+          val activations = (1 to 2).map { i =>
+            WhiskActivation(
+              namespace,
+              actionName,
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          }.toList
+          try {
+            (notExpectedActivations ++ activations).foreach(storeActivation(_, context))
+            waitOnListActivationsInNamespace(namespace, 2, context)
 
-      // it should "list activations with explicit namespace owned by subject" in {
-      org.apache.openwhisk.utils.retry {
-        Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-          status should be(OK)
-          val response = responseAs[List[JsObject]]
-          activations.length should be(response.length)
-          response should contain theSameElementsAs activations.map(_.summaryAsJson)
-          response forall { a =>
-            a.getFields("for") match {
-              case Seq(JsString(n)) => n == actionName.asString
-              case _                => false
+            org.apache.openwhisk.utils.retry {
+              Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+                status should be(OK)
+                val response = responseAs[List[JsObject]]
+                activations.length should be(response.length)
+                response should contain theSameElementsAs activations.map(_.summaryAsJson)
+                response forall { a =>
+                  a.getFields("for") match {
+                    case Seq(JsString(n)) => n == actionName.asString
+                    case _                => false
+                  }
+                }
+              }
             }
+
+            // it should "list activations with explicit namespace owned by subject" in {
+            org.apache.openwhisk.utils.retry {
+              Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+                status should be(OK)
+                val response = responseAs[List[JsObject]]
+                activations.length should be(response.length)
+                response should contain theSameElementsAs activations.map(_.summaryAsJson)
+                response forall { a =>
+                  a.getFields("for") match {
+                    case Seq(JsString(n)) => n == actionName.asString
+                    case _                => false
+                  }
+                }
+              }
+            }
+
+            // it should "reject list activations with explicit namespace not owned by subject" in {
+            val auser = WhiskAuthHelpers.newIdentity()
+            Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+              status should be(Forbidden)
+            }
+
+          } finally {
+            (notExpectedActivations ++ activations).foreach(activation =>
+              deleteActivation(ActivationId(activation.docid.asString), context))
           }
-        }
-      }
-
-      // it should "reject list activations with explicit namespace not owned by subject" in {
-      val auser = WhiskAuthHelpers.newIdentity()
-      Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-        status should be(Forbidden)
-      }
-
-    } finally {
-      (notExpectedActivations ++ activations).foreach(activation =>
-        deleteActivation(ActivationId(activation.docid.asString), context))
-    }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should get summary activation by namespace not successful, retrying.."))
   }
 
   //// GET /activations?docs=true
@@ -154,248 +165,281 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   }
 
   it should "get full activation by namespace" in {
-    implicit val tid = transid()
-    // create two sets of activation records, and check that only one set is served back
-    val creds1 = WhiskAuthHelpers.newAuth()
-    val notExpectedActivations = (1 to 2).map { i =>
-      WhiskActivation(
-        EntityPath(creds1.subject.asString),
-        aname(),
-        creds1.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    }
-    val actionName = aname()
-    val activations = (1 to 2).map { i =>
-      WhiskActivation(
-        namespace,
-        actionName,
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now,
-        response = ActivationResponse.success(Some(JsNumber(5))))
-    }.toList
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          // create two sets of activation records, and check that only one set is served back
+          val creds1 = WhiskAuthHelpers.newAuth()
+          val notExpectedActivations = (1 to 2).map { i =>
+            WhiskActivation(
+              EntityPath(creds1.subject.asString),
+              aname(),
+              creds1.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          }
+          val actionName = aname()
+          val activations = (1 to 2).map { i =>
+            WhiskActivation(
+              namespace,
+              actionName,
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now,
+              response = ActivationResponse.success(Some(JsNumber(5))))
+          }.toList
 
-    try {
-      (notExpectedActivations ++ activations).foreach(storeActivation(_, context))
-      waitOnListActivationsInNamespace(namespace, 2, context)
-      checkCount("", 2)
+          try {
+            (notExpectedActivations ++ activations).foreach(storeActivation(_, context))
+            waitOnListActivationsInNamespace(namespace, 2, context)
+            checkCount("", 2)
 
-      org.apache.openwhisk.utils.retry {
-        Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
-          status should be(OK)
-          val response = responseAs[List[JsObject]]
-          activations.length should be(response.length)
-          response should contain theSameElementsAs activations.map(_.toExtendedJson())
-        }
-      }
-    } finally {
-      (notExpectedActivations ++ activations).foreach(activation =>
-        deleteActivation(ActivationId(activation.docid.asString), context))
-    }
+            org.apache.openwhisk.utils.retry {
+              Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
+                status should be(OK)
+                val response = responseAs[List[JsObject]]
+                activations.length should be(response.length)
+                response should contain theSameElementsAs activations.map(_.toExtendedJson())
+              }
+            }
+          } finally {
+            (notExpectedActivations ++ activations).foreach(activation =>
+              deleteActivation(ActivationId(activation.docid.asString), context))
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should get full activation by namespace not successful, retrying.."))
   }
 
   //// GET /activations?docs=true&since=xxx&upto=yyy
   it should "get full activation by namespace within a date range" in {
-    implicit val tid = transid()
-    // create two sets of activation records, and check that only one set is served back
-    val creds1 = WhiskAuthHelpers.newAuth()
-    val notExpectedActivations = (1 to 2).map { i =>
-      WhiskActivation(
-        EntityPath(creds1.subject.asString),
-        aname(),
-        creds1.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    }
-
-    val actionName = aname()
-    val now = Instant.now(Clock.systemUTC())
-    val since = now.plusSeconds(10)
-    val upto = now.plusSeconds(30)
-    val activations = Seq(
-      WhiskActivation(
-        namespace,
-        actionName,
-        creds.subject,
-        ActivationId.generate(),
-        start = now.plusSeconds(9),
-        end = now.plusSeconds(9)),
-      WhiskActivation(
-        namespace,
-        actionName,
-        creds.subject,
-        ActivationId.generate(),
-        start = now.plusSeconds(20),
-        end = now.plusSeconds(20)), // should match
-      WhiskActivation(
-        namespace,
-        actionName,
-        creds.subject,
-        ActivationId.generate(),
-        start = now.plusSeconds(10),
-        end = now.plusSeconds(20)), // should match
-      WhiskActivation(
-        namespace,
-        actionName,
-        creds.subject,
-        ActivationId.generate(),
-        start = now.plusSeconds(31),
-        end = now.plusSeconds(31)),
-      WhiskActivation(
-        namespace,
-        actionName,
-        creds.subject,
-        ActivationId.generate(),
-        start = now.plusSeconds(30),
-        end = now.plusSeconds(30))) // should match
-
-    try {
-      (notExpectedActivations ++ activations).foreach(storeActivation(_, context))
-      waitOnListActivationsInNamespace(namespace, activations.length, context)
-
-      { // get between two time stamps
-        val filter = s"since=${since.toEpochMilli}&upto=${upto.toEpochMilli}"
-        val expected = activations.filter { e =>
-          (e.start.equals(since) || e.start.equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
-        }
-
-        checkCount(filter, expected.length)
-
-        org.apache.openwhisk.utils.retry {
-          Get(s"$collectionPath?docs=true&$filter") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            expected.length should be(response.length)
-            response should contain theSameElementsAs expected.map(_.toExtendedJson())
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          // create two sets of activation records, and check that only one set is served back
+          val creds1 = WhiskAuthHelpers.newAuth()
+          val notExpectedActivations = (1 to 2).map { i =>
+            WhiskActivation(
+              EntityPath(creds1.subject.asString),
+              aname(),
+              creds1.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
           }
-        }
-      }
 
-      { // get 'upto' with no defined since value should return all activation 'upto'
-        val expected = activations.filter(e => e.start.equals(upto) || e.start.isBefore(upto))
-        val filter = s"upto=${upto.toEpochMilli}"
+          val actionName = aname()
+          val now = Instant.now(Clock.systemUTC())
+          val since = now.plusSeconds(10)
+          val upto = now.plusSeconds(30)
+          val activations = Seq(
+            WhiskActivation(
+              namespace,
+              actionName,
+              creds.subject,
+              ActivationId.generate(),
+              start = now.plusSeconds(9),
+              end = now.plusSeconds(9)),
+            WhiskActivation(
+              namespace,
+              actionName,
+              creds.subject,
+              ActivationId.generate(),
+              start = now.plusSeconds(20),
+              end = now.plusSeconds(20)), // should match
+            WhiskActivation(
+              namespace,
+              actionName,
+              creds.subject,
+              ActivationId.generate(),
+              start = now.plusSeconds(10),
+              end = now.plusSeconds(20)), // should match
+            WhiskActivation(
+              namespace,
+              actionName,
+              creds.subject,
+              ActivationId.generate(),
+              start = now.plusSeconds(31),
+              end = now.plusSeconds(31)),
+            WhiskActivation(
+              namespace,
+              actionName,
+              creds.subject,
+              ActivationId.generate(),
+              start = now.plusSeconds(30),
+              end = now.plusSeconds(30))) // should match
 
-        checkCount(filter, expected.length)
+          try {
+            (notExpectedActivations ++ activations).foreach(storeActivation(_, context))
+            waitOnListActivationsInNamespace(namespace, activations.length, context)
 
-        org.apache.openwhisk.utils.retry {
-          Get(s"$collectionPath?docs=true&$filter") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            expected.length should be(response.length)
-            response should contain theSameElementsAs expected.map(_.toExtendedJson())
+            { // get between two time stamps
+              val filter = s"since=${since.toEpochMilli}&upto=${upto.toEpochMilli}"
+              val expected = activations.filter { e =>
+                (e.start.equals(since) || e.start.equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
+              }
+
+              checkCount(filter, expected.length)
+
+              org.apache.openwhisk.utils.retry {
+                Get(s"$collectionPath?docs=true&$filter") ~> Route.seal(routes(creds)) ~> check {
+                  status should be(OK)
+                  val response = responseAs[List[JsObject]]
+                  expected.length should be(response.length)
+                  response should contain theSameElementsAs expected.map(_.toExtendedJson())
+                }
+              }
+            }
+
+            { // get 'upto' with no defined since value should return all activation 'upto'
+              val expected = activations.filter(e => e.start.equals(upto) || e.start.isBefore(upto))
+              val filter = s"upto=${upto.toEpochMilli}"
+
+              checkCount(filter, expected.length)
+
+              org.apache.openwhisk.utils.retry {
+                Get(s"$collectionPath?docs=true&$filter") ~> Route.seal(routes(creds)) ~> check {
+                  status should be(OK)
+                  val response = responseAs[List[JsObject]]
+                  expected.length should be(response.length)
+                  response should contain theSameElementsAs expected.map(_.toExtendedJson())
+                }
+              }
+            }
+
+            { // get 'since' with no defined upto value should return all activation 'since'
+              org.apache.openwhisk.utils.retry {
+                val expected = activations.filter(e => e.start.equals(since) || e.start.isAfter(since))
+                val filter = s"since=${since.toEpochMilli}"
+
+                checkCount(filter, expected.length)
+
+                Get(s"$collectionPath?docs=true&$filter") ~> Route.seal(routes(creds)) ~> check {
+                  status should be(OK)
+                  val response = responseAs[List[JsObject]]
+                  expected.length should be(response.length)
+                  response should contain theSameElementsAs expected.map(_.toExtendedJson())
+                }
+              }
+            }
+
+          } finally {
+            (notExpectedActivations ++ activations).foreach(activation =>
+              deleteActivation(ActivationId(activation.docid.asString), context))
           }
-        }
-      }
-
-      { // get 'since' with no defined upto value should return all activation 'since'
-        org.apache.openwhisk.utils.retry {
-          val expected = activations.filter(e => e.start.equals(since) || e.start.isAfter(since))
-          val filter = s"since=${since.toEpochMilli}"
-
-          checkCount(filter, expected.length)
-
-          Get(s"$collectionPath?docs=true&$filter") ~> Route.seal(routes(creds)) ~> check {
-            status should be(OK)
-            val response = responseAs[List[JsObject]]
-            expected.length should be(response.length)
-            response should contain theSameElementsAs expected.map(_.toExtendedJson())
-          }
-        }
-      }
-
-    } finally {
-      (notExpectedActivations ++ activations).foreach(activation =>
-        deleteActivation(ActivationId(activation.docid.asString), context))
-    }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should get full activation by namespace within a date range not successful, retrying.."))
   }
 
   //// GET /activations?name=xyz
   it should "accept valid name parameters and reject invalid ones" in {
-    implicit val tid = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
 
-    Seq(("", OK), ("name=", OK), ("name=abc", OK), ("name=abc/xyz", OK), ("name=abc/xyz/123", BadRequest)).foreach {
-      case (p, s) =>
-        Get(s"$collectionPath?$p") ~> Route.seal(routes(creds)) ~> check {
-          status should be(s)
-          if (s == BadRequest) {
-            responseAs[String] should include(Messages.badNameFilter(p.drop(5)))
-          }
-        }
-    }
+          Seq(("", OK), ("name=", OK), ("name=abc", OK), ("name=abc/xyz", OK), ("name=abc/xyz/123", BadRequest))
+            .foreach {
+              case (p, s) =>
+                Get(s"$collectionPath?$p") ~> Route.seal(routes(creds)) ~> check {
+                  status should be(s)
+                  if (s == BadRequest) {
+                    responseAs[String] should include(Messages.badNameFilter(p.drop(5)))
+                  }
+                }
+            }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should accept valid name parameters and reject invalid ones not successful, retrying.."))
   }
 
   it should "get summary activation by namespace and action name" in {
-    implicit val tid = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
 
-    // create two sets of activation records, and check that only one set is served back
-    val creds1 = WhiskAuthHelpers.newAuth()
-    val notExpectedActivations = (1 to 2).map { i =>
-      WhiskActivation(
-        EntityPath(creds1.subject.asString),
-        aname(),
-        creds1.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    }
-    val activations = (1 to 2).map { i =>
-      WhiskActivation(
-        namespace,
-        EntityName(s"xyz"),
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    }.toList
+          // create two sets of activation records, and check that only one set is served back
+          val creds1 = WhiskAuthHelpers.newAuth()
+          val notExpectedActivations = (1 to 2).map { i =>
+            WhiskActivation(
+              EntityPath(creds1.subject.asString),
+              aname(),
+              creds1.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          }
+          val activations = (1 to 2).map { i =>
+            WhiskActivation(
+              namespace,
+              EntityName(s"xyz"),
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          }.toList
 
-    val activationsInPackage = (1 to 2).map { i =>
-      WhiskActivation(
-        namespace,
-        EntityName(s"xyz"),
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now,
-        annotations = Parameters("path", s"${namespace.asString}/pkg/xyz"))
-    }.toList
-    try {
-      (notExpectedActivations ++ activations ++ activationsInPackage).foreach(storeActivation(_, context))
-      waitOnListActivationsMatchingName(namespace, EntityPath("xyz"), activations.length, context)
-      waitOnListActivationsMatchingName(
-        namespace,
-        EntityName("pkg").addPath(EntityName("xyz")),
-        activations.length,
-        context)
-      checkCount("name=xyz", activations.length)
+          val activationsInPackage = (1 to 2).map { i =>
+            WhiskActivation(
+              namespace,
+              EntityName(s"xyz"),
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now,
+              annotations = Parameters("path", s"${namespace.asString}/pkg/xyz"))
+          }.toList
+          try {
+            (notExpectedActivations ++ activations ++ activationsInPackage).foreach(storeActivation(_, context))
+            waitOnListActivationsMatchingName(namespace, EntityPath("xyz"), activations.length, context)
+            waitOnListActivationsMatchingName(
+              namespace,
+              EntityName("pkg").addPath(EntityName("xyz")),
+              activations.length,
+              context)
+            checkCount("name=xyz", activations.length)
 
-      org.apache.openwhisk.utils.retry {
-        Get(s"$collectionPath?name=xyz") ~> Route.seal(routes(creds)) ~> check {
-          status should be(OK)
-          val response = responseAs[List[JsObject]]
-          activations.length should be(response.length)
-          response should contain theSameElementsAs activations.map(_.summaryAsJson)
-        }
-      }
+            org.apache.openwhisk.utils.retry {
+              Get(s"$collectionPath?name=xyz") ~> Route.seal(routes(creds)) ~> check {
+                status should be(OK)
+                val response = responseAs[List[JsObject]]
+                activations.length should be(response.length)
+                response should contain theSameElementsAs activations.map(_.summaryAsJson)
+              }
+            }
 
-      checkCount("name=pkg/xyz", activations.length)
+            checkCount("name=pkg/xyz", activations.length)
 
-      org.apache.openwhisk.utils.retry {
-        Get(s"$collectionPath?name=pkg/xyz") ~> Route.seal(routes(creds)) ~> check {
-          status should be(OK)
-          val response = responseAs[List[JsObject]]
-          activationsInPackage.length should be(response.length)
-          response should contain theSameElementsAs activationsInPackage.map(_.summaryAsJson)
-        }
-      }
-    } finally {
-      (notExpectedActivations ++ activations ++ activationsInPackage).foreach(activation =>
-        deleteActivation(ActivationId(activation.docid.asString), context))
-    }
+            org.apache.openwhisk.utils.retry {
+              Get(s"$collectionPath?name=pkg/xyz") ~> Route.seal(routes(creds)) ~> check {
+                status should be(OK)
+                val response = responseAs[List[JsObject]]
+                activationsInPackage.length should be(response.length)
+                response should contain theSameElementsAs activationsInPackage.map(_.summaryAsJson)
+              }
+            }
+          } finally {
+            (notExpectedActivations ++ activations ++ activationsInPackage).foreach(activation =>
+              deleteActivation(ActivationId(activation.docid.asString), context))
+          }
 
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should get summary activation by namespace and action name not successful, retrying.."))
   }
 
   it should "reject invalid query parameter combinations" in {
@@ -410,291 +454,426 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   }
 
   it should "reject list when limit is greater than maximum allowed value" in {
-    implicit val tid = transid()
-    val exceededMaxLimit = Collection.MAX_LIST_LIMIT + 1
-    val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.listLimitOutOfRange(Collection.ACTIVATIONS, exceededMaxLimit, Collection.MAX_LIST_LIMIT)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val exceededMaxLimit = Collection.MAX_LIST_LIMIT + 1
+          val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.listLimitOutOfRange(Collection.ACTIVATIONS, exceededMaxLimit, Collection.MAX_LIST_LIMIT)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject list when limit is greater than maximum allowed value not successful, retrying.."))
   }
 
   it should "reject list when limit is not an integer" in {
-    implicit val tid = transid()
-    val notAnInteger = "string"
-    val response = Get(s"$collectionPath?limit=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.argumentNotInteger(Collection.ACTIVATIONS, notAnInteger)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val notAnInteger = "string"
+          val response = Get(s"$collectionPath?limit=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.argumentNotInteger(Collection.ACTIVATIONS, notAnInteger)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject list when limit is not an integer not successful, retrying.."))
   }
 
   it should "reject list when skip is negative" in {
-    implicit val tid = transid()
-    val negativeSkip = -1
-    val response = Get(s"$collectionPath?skip=$negativeSkip") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.listSkipOutOfRange(Collection.ACTIVATIONS, negativeSkip)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val negativeSkip = -1
+          val response = Get(s"$collectionPath?skip=$negativeSkip") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.listSkipOutOfRange(Collection.ACTIVATIONS, negativeSkip)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject list when skip is negative not successful, retrying.."))
   }
 
   it should "reject list when skip is not an integer" in {
-    implicit val tid = transid()
-    val notAnInteger = "string"
-    val response = Get(s"$collectionPath?skip=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.argumentNotInteger(Collection.ACTIVATIONS, notAnInteger)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val notAnInteger = "string"
+          val response = Get(s"$collectionPath?skip=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.argumentNotInteger(Collection.ACTIVATIONS, notAnInteger)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject list when skip is not an integer not successful, retrying.."))
   }
 
   it should "reject get activation by namespace and action name when action name is not a valid name" in {
-    implicit val tid = transid()
-    Get(s"$collectionPath?name=0%20") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          Get(s"$collectionPath?name=0%20") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject get activation by namespace and action name when action name is not a valid name not successful, retrying.."))
   }
 
   it should "reject get activation with invalid since/upto value" in {
-    implicit val tid = transid()
-    Get(s"$collectionPath?since=xxx") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-    }
-    Get(s"$collectionPath?upto=yyy") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          Get(s"$collectionPath?since=xxx") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+          }
+          Get(s"$collectionPath?upto=yyy") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject get activation with invalid since/upto value not successful, retrying.."))
   }
 
   it should "skip activations and return correct ones" in {
-    implicit val tid = transid()
-    val activations: Seq[WhiskActivation] = (1 to 3).map { i =>
-      //make sure the time is different for each activation
-      val time = Instant.now.plusMillis(i)
-      WhiskActivation(namespace, aname(), creds.subject, ActivationId.generate(), start = time, end = time)
-    }.toList
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val activations: Seq[WhiskActivation] = (1 to 3).map { i =>
+            //make sure the time is different for each activation
+            val time = Instant.now.plusMillis(i)
+            WhiskActivation(namespace, aname(), creds.subject, ActivationId.generate(), start = time, end = time)
+          }.toList
 
-    try {
-      activations.foreach(storeActivation(_, context))
-      waitOnListActivationsInNamespace(namespace, activations.size, context)
+          try {
+            activations.foreach(storeActivation(_, context))
+            waitOnListActivationsInNamespace(namespace, activations.size, context)
 
-      Get(s"$collectionPath?skip=1") ~> Route.seal(routes(creds)) ~> check {
-        status should be(OK)
-        val resultActivationIds = responseAs[List[JsObject]].map(_.fields("name"))
-        val expectedActivationIds = activations.map(_.toJson.fields("name")).reverse.drop(1)
-        resultActivationIds should be(expectedActivationIds)
-      }
-    } finally {
-      activations.foreach(a => deleteActivation(ActivationId(a.docid.asString), context))
-      waitOnListActivationsInNamespace(namespace, 0, context)
-    }
+            Get(s"$collectionPath?skip=1") ~> Route.seal(routes(creds)) ~> check {
+              status should be(OK)
+              val resultActivationIds = responseAs[List[JsObject]].map(_.fields("name"))
+              val expectedActivationIds = activations.map(_.toJson.fields("name")).reverse.drop(1)
+              resultActivationIds should be(expectedActivationIds)
+            }
+          } finally {
+            activations.foreach(a => deleteActivation(ActivationId(a.docid.asString), context))
+            waitOnListActivationsInNamespace(namespace, 0, context)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should skip activations and return correct ones not successful, retrying.."))
   }
 
   it should "return last activation" in {
-    implicit val tid = transid()
-    val activations = (1 to 3).map { i =>
-      //make sure the time is different for each activation
-      val time = Instant.now.plusMillis(i)
-      WhiskActivation(namespace, aname(), creds.subject, ActivationId.generate(), start = time, end = time)
-    }.toList
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val activations = (1 to 3).map { i =>
+            //make sure the time is different for each activation
+            val time = Instant.now.plusMillis(i)
+            WhiskActivation(namespace, aname(), creds.subject, ActivationId.generate(), start = time, end = time)
+          }.toList
 
-    try {
-      activations.foreach(storeActivation(_, context))
-      waitOnListActivationsInNamespace(namespace, activations.size, context)
+          try {
+            activations.foreach(storeActivation(_, context))
+            waitOnListActivationsInNamespace(namespace, activations.size, context)
 
-      Get(s"$collectionPath?limit=1") ~> Route.seal(routes(creds)) ~> check {
-        status should be(OK)
-        val activationsJson = activations.map(_.toJson)
-        withClue(s"Original activations: ${activationsJson}") {
-          val respNames = responseAs[List[JsObject]].map(_.fields("name"))
-          val expectNames = activationsJson.map(_.fields("name")).drop(2)
-          respNames should be(expectNames)
-        }
-      }
-    } finally {
-      activations.foreach(a => deleteActivation(ActivationId(a.docid.asString), context))
-      waitOnListActivationsInNamespace(namespace, 0, context)
-    }
+            Get(s"$collectionPath?limit=1") ~> Route.seal(routes(creds)) ~> check {
+              status should be(OK)
+              val activationsJson = activations.map(_.toJson)
+              withClue(s"Original activations: ${activationsJson}") {
+                val respNames = responseAs[List[JsObject]].map(_.fields("name"))
+                val expectNames = activationsJson.map(_.fields("name")).drop(2)
+                respNames should be(expectNames)
+              }
+            }
+          } finally {
+            activations.foreach(a => deleteActivation(ActivationId(a.docid.asString), context))
+            waitOnListActivationsInNamespace(namespace, 0, context)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Activations API should return last activation not successful, retrying.."))
   }
 
   //// GET /activations/id
   it should "get activation by id" in {
-    implicit val tid = transid()
-    val activation =
-      WhiskActivation(
-        namespace,
-        aname(),
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    try {
-      storeActivation(activation, context)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val activation =
+            WhiskActivation(
+              namespace,
+              aname(),
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          try {
+            storeActivation(activation, context)
 
-      Get(s"$collectionPath/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
-        status should be(OK)
-        val response = responseAs[JsObject]
-        response should be(activation.toExtendedJson())
-      }
+            Get(s"$collectionPath/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
+              status should be(OK)
+              val response = responseAs[JsObject]
+              response should be(activation.toExtendedJson())
+            }
 
-      // it should "get activation by name in explicit namespace owned by subject" in
-      Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route.seal(routes(creds)) ~> check {
-        status should be(OK)
-        val response = responseAs[JsObject]
-        response should be(activation.toExtendedJson())
-      }
+            // it should "get activation by name in explicit namespace owned by subject" in
+            Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route
+              .seal(routes(creds)) ~> check {
+              status should be(OK)
+              val response = responseAs[JsObject]
+              response should be(activation.toExtendedJson())
+            }
 
-      // it should "reject get activation by name in explicit namespace not owned by subject" in
-      val auser = WhiskAuthHelpers.newIdentity()
-      Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route.seal(routes(auser)) ~> check {
-        status should be(Forbidden)
-      }
-    } finally {
-      deleteActivation(ActivationId(activation.docid.asString), context)
-    }
+            // it should "reject get activation by name in explicit namespace not owned by subject" in
+            val auser = WhiskAuthHelpers.newIdentity()
+            Get(s"/$namespace/${collection.path}/${activation.activationId.asString}") ~> Route
+              .seal(routes(auser)) ~> check {
+              status should be(Forbidden)
+            }
+          } finally {
+            deleteActivation(ActivationId(activation.docid.asString), context)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Activations API should get activation by id not successful, retrying.."))
   }
 
   //// GET /activations/id/result
   it should "get activation result by id" in {
-    implicit val tid = transid()
-    val activation =
-      WhiskActivation(
-        namespace,
-        aname(),
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    try {
-      storeActivation(activation, context)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val activation =
+            WhiskActivation(
+              namespace,
+              aname(),
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          try {
+            storeActivation(activation, context)
 
-      Get(s"$collectionPath/${activation.activationId.asString}/result") ~> Route.seal(routes(creds)) ~> check {
-        status should be(OK)
-        val response = responseAs[JsObject]
-        response should be(activation.response.toExtendedJson)
-      }
-    } finally {
-      deleteActivation(ActivationId(activation.docid.asString), context)
-    }
+            Get(s"$collectionPath/${activation.activationId.asString}/result") ~> Route.seal(routes(creds)) ~> check {
+              status should be(OK)
+              val response = responseAs[JsObject]
+              response should be(activation.response.toExtendedJson)
+            }
+          } finally {
+            deleteActivation(ActivationId(activation.docid.asString), context)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should get activation result by id not successful, retrying.."))
   }
 
   //// GET /activations/id/logs
   it should "get activation logs by id" in {
-    implicit val tid = transid()
-    val activation =
-      WhiskActivation(
-        namespace,
-        aname(),
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    try {
-      storeActivation(activation, context)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val activation =
+            WhiskActivation(
+              namespace,
+              aname(),
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          try {
+            storeActivation(activation, context)
 
-      Get(s"$collectionPath/${activation.activationId.asString}/logs") ~> Route.seal(routes(creds)) ~> check {
-        status should be(OK)
-        val response = responseAs[JsObject]
-        response should be(activation.logs.toJsonObject)
-      }
-    } finally {
-      deleteActivation(ActivationId(activation.docid.asString), context)
-    }
+            Get(s"$collectionPath/${activation.activationId.asString}/logs") ~> Route.seal(routes(creds)) ~> check {
+              status should be(OK)
+              val response = responseAs[JsObject]
+              response should be(activation.logs.toJsonObject)
+            }
+          } finally {
+            deleteActivation(ActivationId(activation.docid.asString), context)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Activations API should get activation logs by id not successful, retrying.."))
   }
 
   //// GET /activations/id/bogus
   it should "reject request to get invalid activation resource" in {
-    implicit val tid = transid()
-    val activation =
-      WhiskActivation(
-        namespace,
-        aname(),
-        creds.subject,
-        ActivationId.generate(),
-        start = Instant.now,
-        end = Instant.now)
-    storeActivation(activation, context)
-    try {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val activation =
+            WhiskActivation(
+              namespace,
+              aname(),
+              creds.subject,
+              ActivationId.generate(),
+              start = Instant.now,
+              end = Instant.now)
+          storeActivation(activation, context)
+          try {
 
-      Get(s"$collectionPath/${activation.activationId.asString}/bogus") ~> Route.seal(routes(creds)) ~> check {
-        status should be(NotFound)
-      }
-    } finally {
-      deleteActivation(ActivationId(activation.docid.asString), context)
-    }
+            Get(s"$collectionPath/${activation.activationId.asString}/bogus") ~> Route.seal(routes(creds)) ~> check {
+              status should be(NotFound)
+            }
+          } finally {
+            deleteActivation(ActivationId(activation.docid.asString), context)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject request to get invalid activation resource not successful, retrying.."))
   }
 
   it should "reject get requests with invalid activation ids" in {
-    implicit val tid = transid()
-    val activationId = ActivationId.generate().toString
-    val tooshort = activationId.substring(0, 31)
-    val toolong = activationId + "xxx"
-    val malformed = tooshort + "z"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val activationId = ActivationId.generate().toString
+          val tooshort = activationId.substring(0, 31)
+          val toolong = activationId + "xxx"
+          val malformed = tooshort + "z"
 
-    Get(s"$collectionPath/$tooshort") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", tooshort.length.B, 32.B))
-    }
+          Get(s"$collectionPath/$tooshort") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] shouldBe Messages.activationIdLengthError(
+              SizeError("Activation id", tooshort.length.B, 32.B))
+          }
 
-    Get(s"$collectionPath/$toolong") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] shouldBe Messages.activationIdLengthError(SizeError("Activation id", toolong.length.B, 32.B))
-    }
+          Get(s"$collectionPath/$toolong") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] shouldBe Messages.activationIdLengthError(
+              SizeError("Activation id", toolong.length.B, 32.B))
+          }
 
-    Get(s"$collectionPath/$malformed") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-    }
+          Get(s"$collectionPath/$malformed") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject get requests with invalid activation ids not successful, retrying.."))
   }
 
   it should "reject request with put" in {
-    implicit val tid = transid()
-    Put(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(MethodNotAllowed)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          Put(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(MethodNotAllowed)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Activations API should reject request with put not successful, retrying.."))
   }
 
   it should "reject request with post" in {
-    implicit val tid = transid()
-    Post(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(MethodNotAllowed)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          Post(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(MethodNotAllowed)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Activations API should reject request with pos not successful, retrying.."))
   }
 
   it should "reject request with delete" in {
-    implicit val tid = transid()
-    Delete(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(MethodNotAllowed)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          Delete(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(MethodNotAllowed)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject request with delete not successful, retrying.."))
   }
 
   it should "report proper error when record is corrupted on get" in {
-    implicit val tid = transid()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
 
-    //A bad activation type which breaks the deserialization by removing the subject entry
-    class BadActivation(override val namespace: EntityPath,
-                        override val name: EntityName,
-                        override val subject: Subject,
-                        override val activationId: ActivationId,
-                        override val start: Instant,
-                        override val end: Instant)
-        extends WhiskActivation(namespace, name, subject, activationId, start, end) {
-      override def toJson = {
-        val json = super.toJson
-        JsObject(json.fields - "subject")
-      }
-    }
+          //A bad activation type which breaks the deserialization by removing the subject entry
+          class BadActivation(override val namespace: EntityPath,
+                              override val name: EntityName,
+                              override val subject: Subject,
+                              override val activationId: ActivationId,
+                              override val start: Instant,
+                              override val end: Instant)
+              extends WhiskActivation(namespace, name, subject, activationId, start, end) {
+            override def toJson = {
+              val json = super.toJson
+              JsObject(json.fields - "subject")
+            }
+          }
 
-    val activation =
-      new BadActivation(namespace, aname(), creds.subject, ActivationId.generate(), Instant.now, Instant.now)
-    storeActivation(activation, context)
+          val activation =
+            new BadActivation(namespace, aname(), creds.subject, ActivationId.generate(), Instant.now, Instant.now)
+          storeActivation(activation, context)
 
-    Get(s"$collectionPath/${activation.activationId}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(InternalServerError)
-      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-    }
+          Get(s"$collectionPath/${activation.activationId}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(InternalServerError)
+            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should report proper error when record is corrupted on get not successful, retrying.."))
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
01:00:13  org.apache.openwhisk.core.controller.test.ActivationsApiTests > Activations API should skip activations and return correct ones STANDARD_OUT
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:13      condition not met, retrying
01:00:14      condition not met, retrying
01:00:14      condition not met, retrying
01:00:14      condition not met, retrying
01:00:14      condition not met, retrying
01:00:15  
01:00:15  org.apache.openwhisk.core.controller.test.ActivationsApiTests > Activations API should skip activations and return correct ones FAILED
01:00:15      org.scalatest.exceptions.TestFailedException: List("xyz", "xyz") was not equal to List("activations_tests_name14", "activations_tests_name13")
01:00:15          at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
01:00:15          at org.scalatest.Matchers$ShouldMethodHelper$.shouldMatcher(Matchers.scala:6723)
01:00:15          at org.scalatest.Matchers$AnyShouldWrapper.should(Matchers.scala:6759)
01:00:15          at org.apache.openwhisk.core.controller.test.ActivationsApiTests.$anonfun$new$76(ActivationsApiTests.scala:489)
01:00:15          at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
01:00:15          at akka.http.scaladsl.testkit.RouteTest.$anonfun$check$1(RouteTest.scala:56)
01:00:15          at akka.http.scaladsl.testkit.RouteTestResultComponent$RouteTestResult.$tilde$greater(RouteTestResultComponent.scala:50)
01:00:15          at org.apache.openwhisk.core.controller.test.ActivationsApiTests.$anonfun$new$73(ActivationsApiTests.scala:485)
01:00:15          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
01:00:15          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
01:00:15          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
01:00:15          at org.scalatest.Transformer.apply(Transformer.scala:22)
01:00:15          at org.scalatest.Transformer.apply(Transformer.scala:20)
01:00:15          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
01:00:15          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
01:00:15          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
01:00:15          at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1685)
01:00:15          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
01:00:15          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
01:00:15          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
01:00:15          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
01:00:15          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
01:00:15          at org.apache.openwhisk.core.controller.test.ActivationsApiTests.org$scalatest$BeforeAndAfterEach$$super$runTest(ActivationsApiTests.scala:49)
01:00:15          at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:221)
01:00:15          at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:214)
01:00:15          at org.apache.openwhisk.core.controller.test.ActivationsApiTests.runTest(ActivationsApiTests.scala:49)
01:00:15          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
01:00:15          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
01:00:15          at scala.collection.immutable.List.foreach(List.scala:392)
01:00:15          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
01:00:15          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
01:00:15          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
01:00:15          at scala.collection.immutable.List.foreach(List.scala:392)
01:00:15          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
01:00:15          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
01:00:15          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
01:00:15          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
01:00:15          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
01:00:15          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
01:00:15          at org.scalatest.Suite.run(Suite.scala:1124)
01:00:15          at org.scalatest.Suite.run$(Suite.scala:1106)
01:00:15          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
01:00:15          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
01:00:15          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
01:00:15          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
01:00:15          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
01:00:15          at org.apache.openwhisk.core.controller.test.ActivationsApiTests.org$scalatest$BeforeAndAfterAll$$super$run(ActivationsApiTests.scala:49)
01:00:15          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
01:00:15          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
01:00:15          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
01:00:15          at org.apache.openwhisk.core.controller.test.ActivationsApiTests.run(ActivationsApiTests.scala:49)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

