### PR TITLE
Retry on failures for all ArtifactStoreAttachmentBehaviors to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -39,52 +39,71 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
   private val attachmentHandler = Some(WhiskAction.attachmentHandler _)
   private implicit val cacheUpdateNotifier: Option[CacheChangeNotification] = None
 
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
+
   it should "generate different attachment name on update" in {
-    implicit val tid: TransactionId = transid()
-    val exec = javaDefault(nonInlinedCode(entityStore), Some("hello"))
-    val javaAction =
-      WhiskAction(namespace, EntityName("attachment_unique"), exec)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
+          val exec = javaDefault(nonInlinedCode(entityStore), Some("hello"))
+          val javaAction =
+            WhiskAction(namespace, EntityName("attachment_unique-" + System.currentTimeMillis()), exec)
 
-    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
-    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+          val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+          val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
 
-    //Change attachment to inline one otherwise WhiskAction would not go for putAndAttach
-    val action2Updated = action2.copy(exec = exec).revision[WhiskAction](i1.rev)
-    val i2 = WhiskAction.put(entityStore, action2Updated, old = Some(action2)).futureValue
-    val action3 = entityStore.get[WhiskAction](i2, attachmentHandler).futureValue
+          //Change attachment to inline one otherwise WhiskAction would not go for putAndAttach
+          val action2Updated = action2.copy(exec = exec).revision[WhiskAction](i1.rev)
+          val i2 = WhiskAction.put(entityStore, action2Updated, old = Some(action2)).futureValue
+          val action3 = entityStore.get[WhiskAction](i2, attachmentHandler).futureValue
 
-    docsToDelete += ((entityStore, i2))
+          docsToDelete += ((entityStore, i2))
 
-    attached(action2).attachmentName should not be attached(action3).attachmentName
+          attached(action2).attachmentName should not be attached(action3).attachmentName
 
-    //Check that attachment name is actually a uri
-    val attachmentUri = Uri(attached(action2).attachmentName)
-    attachmentUri.isAbsolute shouldBe true
+          //Check that attachment name is actually a uri
+          val attachmentUri = Uri(attached(action2).attachmentName)
+          attachmentUri.isAbsolute shouldBe true
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should generate different attachment name on update not successful, retrying.."))
   }
 
   /**
    * This test asserts that old attachments are deleted and cannot be read again
    */
   it should "fail on reading with old non inlined attachment" in {
-    implicit val tid: TransactionId = transid()
-    val code1 = nonInlinedCode(entityStore)
-    val exec = javaDefault(code1, Some("hello"))
-    val javaAction =
-      WhiskAction(namespace, EntityName("attachment_update_2"), exec)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
+          val code1 = nonInlinedCode(entityStore)
+          val exec = javaDefault(code1, Some("hello"))
+          val javaAction =
+            WhiskAction(namespace, EntityName("attachment_update_2-" + System.currentTimeMillis()), exec)
 
-    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+          val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
 
-    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
-    val code2 = nonInlinedCode(entityStore)
-    val exec2 = javaDefault(code2, Some("hello"))
-    val action2Updated = action2.copy(exec = exec2).revision[WhiskAction](i1.rev)
+          val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+          val code2 = nonInlinedCode(entityStore)
+          val exec2 = javaDefault(code2, Some("hello"))
+          val action2Updated = action2.copy(exec = exec2).revision[WhiskAction](i1.rev)
 
-    val i2 = WhiskAction.put(entityStore, action2Updated, old = Some(action2)).futureValue
-    val action3 = entityStore.get[WhiskAction](i2, attachmentHandler).futureValue
+          val i2 = WhiskAction.put(entityStore, action2Updated, old = Some(action2)).futureValue
+          val action3 = entityStore.get[WhiskAction](i2, attachmentHandler).futureValue
 
-    docsToDelete += ((entityStore, i2))
-    getAttachmentBytes(i2, attached(action3)).futureValue.result() shouldBe decode(code2)
-    getAttachmentBytes(i1, attached(action2)).failed.futureValue shouldBe a[NoDocumentException]
+          docsToDelete += ((entityStore, i2))
+          getAttachmentBytes(i2, attached(action3)).futureValue.result() shouldBe decode(code2)
+          getAttachmentBytes(i1, attached(action2)).failed.futureValue shouldBe a[NoDocumentException]
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should fail on reading with old non inlined attachment not successful, retrying.."))
   }
 
   /**
@@ -92,120 +111,160 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
    * if attachment is inlined
    */
   it should "work on reading with old inlined attachment" in {
-    assumeAttachmentInliningEnabled(entityStore)
-    implicit val tid: TransactionId = transid()
-    val code1 = encodedRandomBytes(inlinedAttachmentSize(entityStore))
-    val exec = javaDefault(code1, Some("hello"))
-    val javaAction =
-      WhiskAction(namespace, EntityName("attachment_update_2"), exec)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assumeAttachmentInliningEnabled(entityStore)
+          implicit val tid: TransactionId = transid()
+          val code1 = encodedRandomBytes(inlinedAttachmentSize(entityStore))
+          val exec = javaDefault(code1, Some("hello"))
+          val javaAction =
+            WhiskAction(namespace, EntityName("attachment_update_2-" + System.currentTimeMillis()), exec)
 
-    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+          val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
 
-    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
-    val code2 = nonInlinedCode(entityStore)
-    val exec2 = javaDefault(code2, Some("hello"))
-    val action2Updated = action2.copy(exec = exec2).revision[WhiskAction](i1.rev)
+          val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+          val code2 = nonInlinedCode(entityStore)
+          val exec2 = javaDefault(code2, Some("hello"))
+          val action2Updated = action2.copy(exec = exec2).revision[WhiskAction](i1.rev)
 
-    val i2 = WhiskAction.put(entityStore, action2Updated, old = Some(action2)).futureValue
-    val action3 = entityStore.get[WhiskAction](i2, attachmentHandler).futureValue
+          val i2 = WhiskAction.put(entityStore, action2Updated, old = Some(action2)).futureValue
+          val action3 = entityStore.get[WhiskAction](i2, attachmentHandler).futureValue
 
-    docsToDelete += ((entityStore, i2))
-    getAttachmentBytes(i2, attached(action3)).futureValue.result() shouldBe decode(code2)
-    getAttachmentBytes(i2, attached(action2)).futureValue.result() shouldBe decode(code1)
+          docsToDelete += ((entityStore, i2))
+          getAttachmentBytes(i2, attached(action3)).futureValue.result() shouldBe decode(code2)
+          getAttachmentBytes(i2, attached(action2)).futureValue.result() shouldBe decode(code1)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should work on reading with old inlined attachment not successful, retrying.."))
   }
 
   it should "put and read large attachment" in {
-    implicit val tid: TransactionId = transid()
-    val size = Math.max(nonInlinedAttachmentSize(entityStore), getAttachmentSizeForTest(entityStore))
-    val base64 = encodedRandomBytes(size)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
+          val size = Math.max(nonInlinedAttachmentSize(entityStore), getAttachmentSizeForTest(entityStore))
+          val base64 = encodedRandomBytes(size)
 
-    val exec = javaDefault(base64, Some("hello"))
-    val javaAction =
-      WhiskAction(namespace, EntityName("attachment_large"), exec)
+          val exec = javaDefault(base64, Some("hello"))
+          val javaAction =
+            WhiskAction(namespace, EntityName("attachment_large-" + System.currentTimeMillis()), exec)
 
-    //Have more patience as reading large attachments take time specially for remote
-    //storage like Cosmos
-    implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.minute)
+          //Have more patience as reading large attachments take time specially for remote
+          //storage like Cosmos
+          implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.minute)
 
-    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
-    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+          val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+          val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
 
-    val action3 = WhiskAction.get(entityStore, i1.id, i1.rev).futureValue
+          val action3 = WhiskAction.get(entityStore, i1.id, i1.rev).futureValue
 
-    docsToDelete += ((entityStore, i1))
+          docsToDelete += ((entityStore, i1))
 
-    attached(action2).attachmentType shouldBe ContentTypes.`application/octet-stream`
-    attached(action2).length shouldBe Some(size)
-    attached(action2).digest should not be empty
+          attached(action2).attachmentType shouldBe ContentTypes.`application/octet-stream`
+          attached(action2).length shouldBe Some(size)
+          attached(action2).digest should not be empty
 
-    action3.exec shouldBe exec
-    inlined(action3).value shouldBe base64
+          action3.exec shouldBe exec
+          inlined(action3).value shouldBe base64
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should put and read large attachment not successful, retrying.."))
   }
 
   it should "inline small attachments" in {
-    assumeAttachmentInliningEnabled(entityStore)
-    implicit val tid: TransactionId = transid()
-    val attachmentSize = inlinedAttachmentSize(entityStore) - 1
-    val base64 = encodedRandomBytes(attachmentSize)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assumeAttachmentInliningEnabled(entityStore)
+          implicit val tid: TransactionId = transid()
+          val attachmentSize = inlinedAttachmentSize(entityStore) - 1
+          val base64 = encodedRandomBytes(attachmentSize)
 
-    val exec = javaDefault(base64, Some("hello"))
-    val javaAction = WhiskAction(namespace, EntityName("attachment_inline"), exec)
+          val exec = javaDefault(base64, Some("hello"))
+          val javaAction = WhiskAction(namespace, EntityName("attachment_inline" + System.currentTimeMillis()), exec)
 
-    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
-    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
-    val action3 = WhiskAction.get(entityStore, i1.id, i1.rev).futureValue
+          val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+          val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+          val action3 = WhiskAction.get(entityStore, i1.id, i1.rev).futureValue
 
-    docsToDelete += ((entityStore, i1))
+          docsToDelete += ((entityStore, i1))
 
-    action3.exec shouldBe exec
-    inlined(action3).value shouldBe base64
+          action3.exec shouldBe exec
+          inlined(action3).value shouldBe base64
 
-    val a = attached(action2)
+          val a = attached(action2)
 
-    val attachmentUri = Uri(a.attachmentName)
-    attachmentUri.scheme shouldBe AttachmentSupport.MemScheme
-    a.length shouldBe Some(attachmentSize)
-    a.digest should not be empty
+          val attachmentUri = Uri(a.attachmentName)
+          attachmentUri.scheme shouldBe AttachmentSupport.MemScheme
+          a.length shouldBe Some(attachmentSize)
+          a.digest should not be empty
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should inline small attachments not successful, retrying.."))
   }
 
   it should "throw NoDocumentException for non existing attachment" in {
-    implicit val tid: TransactionId = transid()
-    val attachmentName = "foo"
-    val attachmentId =
-      getAttachmentStore(entityStore).map(s => s"${s.scheme}:$attachmentName").getOrElse(attachmentName)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transid()
+          val attachmentName = "foo-" + System.currentTimeMillis()
+          val attachmentId =
+            getAttachmentStore(entityStore).map(s => s"${s.scheme}:$attachmentName").getOrElse(attachmentName)
 
-    val sink = StreamConverters.fromOutputStream(() => new ByteArrayOutputStream())
-    entityStore
-      .readAttachment[IOResult](
-        DocInfo ! ("non-existing-doc", "42"),
-        Attached(attachmentId, ContentTypes.`application/octet-stream`),
-        sink)
-      .failed
-      .futureValue shouldBe a[NoDocumentException]
+          val sink = StreamConverters.fromOutputStream(() => new ByteArrayOutputStream())
+          entityStore
+            .readAttachment[IOResult](
+              DocInfo ! ("non-existing-doc", "42"),
+              Attached(attachmentId, ContentTypes.`application/octet-stream`),
+              sink)
+            .failed
+            .futureValue shouldBe a[NoDocumentException]
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should throw NoDocumentException for non existing attachment not successful, retrying.."))
   }
 
   it should "delete attachment on document delete" in {
-    val attachmentStore = getAttachmentStore(entityStore)
-    assume(attachmentStore.isDefined, "ArtifactStore does not have attachmentStore configured")
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val attachmentStore = getAttachmentStore(entityStore)
+          assume(attachmentStore.isDefined, "ArtifactStore does not have attachmentStore configured")
 
-    implicit val tid: TransactionId = transid()
-    val size = nonInlinedAttachmentSize(entityStore)
-    val base64 = encodedRandomBytes(size)
+          implicit val tid: TransactionId = transid()
+          val size = nonInlinedAttachmentSize(entityStore)
+          val base64 = encodedRandomBytes(size)
 
-    val exec = javaDefault(base64, Some("hello"))
-    val javaAction =
-      WhiskAction(namespace, EntityName("attachment_unique"), exec)
+          val exec = javaDefault(base64, Some("hello"))
+          val javaAction =
+            WhiskAction(namespace, EntityName("attachment_unique-" + System.currentTimeMillis()), exec)
 
-    val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
-    val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
+          val i1 = WhiskAction.put(entityStore, javaAction, old = None).futureValue
+          val action2 = entityStore.get[WhiskAction](i1, attachmentHandler).futureValue
 
-    WhiskAction.del(entityStore, i1).futureValue shouldBe true
+          WhiskAction.del(entityStore, i1).futureValue shouldBe true
 
-    val attachmentName = Uri(attached(action2).attachmentName).path.toString
-    attachmentStore.get
-      .readAttachment(i1.id, attachmentName, byteStringSink())
-      .failed
-      .futureValue shouldBe a[NoDocumentException]
+          val attachmentName = Uri(attached(action2).attachmentName).path.toString
+          attachmentStore.get
+            .readAttachment(i1.id, attachmentName, byteStringSink())
+            .failed
+            .futureValue shouldBe a[NoDocumentException]
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should delete attachment on document delete not successful, retrying.."))
   }
 
   private def attached(a: WhiskAction): Attached =

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -261,7 +261,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
             .failed
             .futureValue shouldBe a[NoDocumentException]
         },
-        retriesOnTestFailures,
+        if (getAttachmentStore(entityStore).isDefined) retriesOnTestFailures else 1,
         Some(waitBeforeRetry),
         Some(
           s"${this.getClass.getName} > ${storeType}ArtifactStore attachments should delete attachment on document delete not successful, retrying.."))


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
17:11:37  org.apache.openwhisk.core.database.CouchDBArtifactStoreTests > CouchDBArtifactStore attachments should put and read large attachment STANDARD_OUT
17:11:37      [2020-07-02T15:11:31.753Z] [INFO] [#tid_47] [WhiskAction] write initiated on new cache entry
17:11:37      [2020-07-02T15:11:31.755Z] [INFO] [#tid_47] [CouchDbRestStore] [PUT] 'fn-dev-build_whisks' saving document: 'id: artifactTCK_Fft8_ns_CqjPQ/attachment_large, rev: null' [marker:database_saveDocument_start:540]
17:11:37      [2020-07-02T15:11:31.857Z] [INFO] [#tid_47] [CouchDbRestStore] [marker:database_saveDocument_finish:642:102]
17:11:37      [2020-07-02T15:11:31.857Z] [INFO] [#tid_47] [CouchDbRestStore] [ATT_PUT] 'fn-dev-build_whisks' uploading attachment '3af24794-bd82-447b-b247-94bd82e47bc7' of document 'id: artifactTCK_Fft8_ns_CqjPQ/attachment_large, rev: 1-cee6e1263ae7c0110e0be7db229f379f' [marker:database_saveDocumentAttachment_start:642]
17:11:37      [2020-07-02T15:11:37.309Z] [WARN] [#tid_47] [CouchDbRestStore] [ATT_PUT] 'fn-dev-build_whisks' failed to upload attachment '3af24794-bd82-447b-b247-94bd82e47bc7' of document 'id: artifactTCK_Fft8_ns_CqjPQ/attachment_large, rev: 1-cee6e1263ae7c0110e0be7db229f379f'; http status '500 Internal Server Error (details: {"error":"unknown_error","reason":"function_clause","ref":1941633815} )' [marker:database_saveDocumentAttachment_error:6094:5452]
17:11:37      [2020-07-02T15:11:37.310Z] [INFO] [#tid_47] [WhiskAction] invalidating CacheKey(artifactTCK_Fft8_ns_CqjPQ/attachment_large)
17:11:37  
17:11:37  org.apache.openwhisk.core.database.CouchDBArtifactStoreTests > CouchDBArtifactStore attachments should put and read large attachment FAILED
17:11:37      org.scalatest.exceptions.TestFailedException: The future returned an exception of type: org.apache.openwhisk.core.database.PutException, with message: Unexpected http response code: 500 Internal Server Error (details: {"error":"unknown_error","reason":"function_clause","ref":1941633815}
17:11:37      ).
17:11:37          at org.scalatest.concurrent.Futures$FutureConcept.tryTryAgain$1(Futures.scala:531)
17:11:37          at org.scalatest.concurrent.Futures$FutureConcept.futureValueImpl(Futures.scala:550)
17:11:37          at org.scalatest.concurrent.Futures$FutureConcept.futureValueImpl$(Futures.scala:479)
17:11:37          at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValueImpl(ScalaFutures.scala:275)
17:11:37          at org.scalatest.concurrent.Futures$FutureConcept.futureValue(Futures.scala:476)
17:11:37          at org.scalatest.concurrent.Futures$FutureConcept.futureValue$(Futures.scala:475)
17:11:37          at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValue(ScalaFutures.scala:275)
17:11:37          at org.apache.openwhisk.core.database.test.behavior.ArtifactStoreAttachmentBehaviors.$anonfun$$init$$4(ArtifactStoreAttachmentBehaviors.scala:130)
17:11:37          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
17:11:37          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
17:11:37          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
17:11:37          at org.scalatest.Transformer.apply(Transformer.scala:22)
17:11:37          at org.scalatest.Transformer.apply(Transformer.scala:20)
17:11:37          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
17:11:37          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
17:11:37          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
17:11:37          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.org$apache$openwhisk$core$database$test$behavior$ArtifactStoreBehaviorBase$$super$withFixture(CouchDBArtifactStoreTests.scala:26)
17:11:37          at org.apache.openwhisk.core.database.test.behavior.ArtifactStoreBehaviorBase.withFixture(ArtifactStoreBehaviorBase.scala:80)
17:11:37          at org.apache.openwhisk.core.database.test.behavior.ArtifactStoreBehaviorBase.withFixture$(ArtifactStoreBehaviorBase.scala:78)
17:11:37          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.withFixture(CouchDBArtifactStoreTests.scala:26)
17:11:37          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
17:11:37          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
17:11:37          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
17:11:37          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
17:11:37          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
17:11:37          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.org$scalatest$BeforeAndAfterEach$$super$runTest(CouchDBArtifactStoreTests.scala:26)
17:11:37          at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:221)
17:11:37          at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:214)
17:11:37          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.runTest(CouchDBArtifactStoreTests.scala:26)
17:11:37          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
17:11:37          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
17:11:37          at scala.collection.immutable.List.foreach(List.scala:392)
17:11:37          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
17:11:37          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
17:11:37          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
17:11:37          at scala.collection.immutable.List.foreach(List.scala:392)
17:11:37          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
17:11:37          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
17:11:37          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
17:11:37          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
17:11:37          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
17:11:37          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
17:11:37          at org.scalatest.Suite.run(Suite.scala:1124)
17:11:37          at org.scalatest.Suite.run$(Suite.scala:1106)
17:11:37          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
17:11:37          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
17:11:37          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
17:11:37          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
17:11:37          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
17:11:37          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.org$scalatest$BeforeAndAfterAll$$super$run(CouchDBArtifactStoreTests.scala:26)
17:11:37          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
17:11:37          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
17:11:37          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
17:11:37          at org.apache.openwhisk.core.database.CouchDBArtifactStoreTests.run(CouchDBArtifactStoreTests.scala:26)
17:11:37  
17:11:37          Caused by:
17:11:37          org.apache.openwhisk.core.database.PutException: Unexpected http response code: 500 Internal Server Error (details: {"error":"unknown_error","reason":"function_clause","ref":1941633815}
17:11:37          )
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

