### PR TITLE
Make package deletion success required, check if package was deleted afterwards

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/ApiGwRestBasicTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/ApiGwRestBasicTests.scala
@@ -29,8 +29,6 @@ import common.TestUtils
 
 import scala.util.matching.Regex
 import common.WskProps
-import common.rest.RestResult
-import common.rest.WskRestOperations
 
 import scala.concurrent.duration.DurationInt
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/ApiGwRestBasicTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/ApiGwRestBasicTests.scala
@@ -941,8 +941,8 @@ abstract class ApiGwRestBasicTests extends BaseApiGwTests {
             wsk.action.delete(name = actionName)
             apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
             org.apache.openwhisk.utils.retry({
-              wsk.pkg.list().stdout should not include (s"/${wsk.namespace}/$packageName/$actionName")
-            }, retriesOnTestFailures, Some(waitBeforeRetry), Some(s"${this.getClass.getName} package ${wsk.pkg} not empty, retrying.."))
+              wsk.action.get(name = actionName, expectedExitCode = 404)
+            }, retriesOnTestFailures, Some(waitBeforeRetry), Some(s"${this.getClass.getName} action ${actionName} not yet deleted, retrying.."))
             wsk.pkg.delete(packageName).stdout should include regex (s""""name":\\s*"$packageName"""")
           }
         },

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/ApiGwRestBasicTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/ApiGwRestBasicTests.scala
@@ -941,7 +941,7 @@ abstract class ApiGwRestBasicTests extends BaseApiGwTests {
             wsk.action.delete(name = actionName)
             apiDelete(basepathOrApiName = testbasepath, expectedExitCode = DONTCARE_EXIT)
             org.apache.openwhisk.utils.retry({
-              wsk.pkg.list().getBodyListString.length shouldBe (0)
+              wsk.pkg.list().stdout should not include (s"/${wsk.namespace}/$packageName/$actionName")
             }, retriesOnTestFailures, Some(waitBeforeRetry), Some(s"${this.getClass.getName} package ${wsk.pkg} not empty, retrying.."))
             wsk.pkg.delete(packageName).stdout should include regex (s""""name":\\s*"$packageName"""")
           }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
@@ -31,7 +31,6 @@ import common._
 import common.TestHelpers
 import common.TestUtils._
 import common.WhiskProperties
-import common.WskOperations
 import common.WskProps
 import common.WskTestHelpers
 import common.rest.WskRestOperations

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
@@ -23,31 +23,28 @@ import java.time.Instant
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.math.max
+
 import org.junit.runner.RunWith
+
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
-import common._
+
 import common.TestHelpers
 import common.TestUtils._
 import common.WhiskProperties
+import common.WskOperations
 import common.WskProps
 import common.WskTestHelpers
-import common.rest.WskRestOperations
 
 /**
  * Tests for testing the CLI "api" subcommand.  Most of these tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-abstract class BaseApiGwTests
-    extends TestHelpers
-    with WskTestHelpers
-    with WskActorSystem
-    with BeforeAndAfterEach
-    with BeforeAndAfterAll {
+abstract class BaseApiGwTests extends TestHelpers with WskTestHelpers with BeforeAndAfterEach with BeforeAndAfterAll {
 
   implicit val wskprops = WskProps()
-  val wsk = new WskRestOperations
+  val wsk: WskOperations
 
   // This test suite makes enough CLI invocations in 60 seconds to trigger the OpenWhisk
   // throttling restriction.  To avoid CLI failures due to being throttled, track the

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/BaseApiGwTests.scala
@@ -23,28 +23,32 @@ import java.time.Instant
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration._
 import scala.math.max
-
 import org.junit.runner.RunWith
-
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
-
+import common._
 import common.TestHelpers
 import common.TestUtils._
 import common.WhiskProperties
 import common.WskOperations
 import common.WskProps
 import common.WskTestHelpers
+import common.rest.WskRestOperations
 
 /**
  * Tests for testing the CLI "api" subcommand.  Most of these tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-abstract class BaseApiGwTests extends TestHelpers with WskTestHelpers with BeforeAndAfterEach with BeforeAndAfterAll {
+abstract class BaseApiGwTests
+    extends TestHelpers
+    with WskTestHelpers
+    with WskActorSystem
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll {
 
   implicit val wskprops = WskProps()
-  val wsk: WskOperations
+  val wsk = new WskRestOperations
 
   // This test suite makes enough CLI invocations in 60 seconds to trigger the OpenWhisk
   // throttling restriction.  To avoid CLI failures due to being throttled, track the


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from one of these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
21:09:20      Starting test Wsk api should verify get API name that uses custom package at 2020-07-03 15:09:17.702
21:09:20  
21:09:20  org.apache.openwhisk.core.cli.test.ApiGwRestTests > Wsk api should verify get API name that uses custom package STANDARD_OUT
21:09:20      Action invokes within last minute: 28
21:09:20      Action invokes within last minute: 28
21:09:20      Action invokes within last minute: 27
21:09:20  
21:09:20  org.apache.openwhisk.core.cli.test.ApiGwRestTests > Wsk api should verify get API name that uses custom package FAILED
21:09:20      org.scalatest.exceptions.TestFailedException: 409 was not equal to 200
21:09:20  
21:09:20  org.apache.openwhisk.core.cli.test.ApiGwRestTests STANDARD_OUT
21:09:20  
21:09:20      Finished test Wsk api should verify get API name that uses custom package at 2020-07-03 15:09:19.579

Jul 3 19:09:18 public-crbldqmkbd0vv6k9nb7100-alb1-5b59676d6d-j6fcd nginx-ingress {client: 129.41.87.5, host: fn-dev-build.us-south.containers.appdomain.cloud, scheme: https, request_method: PUT, request_uri: /api/v1/namespaces/_/packages/pkg-1593803357702, time_date: 03/Jul/2020:19:09:18 +0000, status: 200, http_user_agent: akka-http/10.1.11, request_id: fd2415acc71199f63aa26a8aea8b1a9b, content_type: application/json, upstream_addr: 172.30.165.76:8080, upstream_status: 200, request_time: 0.294, upstream_response_time: 0.292, upstream_connect_time: 0.024, upstream_header_time: 0.292}
Jul 3 19:09:19 public-crbldqmkbd0vv6k9nb7100-alb1-5b59676d6d-j6fcd nginx-ingress {client: 129.41.87.5, host: fn-dev-build.us-south.containers.appdomain.cloud, scheme: https, request_method: PUT, request_uri: /api/v1/namespaces/_/actions/pkg-1593803357702/CLI_APIGWTEST25_action, time_date: 03/Jul/2020:19:09:18 +0000, status: 200, http_user_agent: akka-http/10.1.11, request_id: d88b31dbeb6519e5559914829dca82cb, content_type: application/json, upstream_addr: 172.30.165.76:8080, upstream_status: 200, request_time: 0.259, upstream_response_time: 0.260, upstream_connect_time: 0.000, upstream_header_time: 0.260}
Jul 3 19:09:19 public-crbldqmkbd0vv6k9nb7100-alb1-5b59676d6d-j6fcd nginx-ingress {client: 129.41.87.5, host: fn-dev-build.us-south.containers.appdomain.cloud, scheme: https, request_method: DELETE, request_uri: /api/v1/namespaces/_/actions/pkg-1593803357702/CLI_APIGWTEST25_action, time_date: 03/Jul/2020:19:09:19 +0000, status: 200, http_user_agent: akka-http/10.1.11, request_id: 57186feb8c0cf413374cac08f4d90d4c, content_type: application/json, upstream_addr: 172.30.50.112:8080, upstream_status: 200, request_time: 0.385, upstream_response_time: 0.384, upstream_connect_time: 0.000, upstream_header_time: 0.384}
Jul 3 19:09:20 public-crbldqmkbd0vv6k9nb7100-alb1-5b59676d6d-j6fcd nginx-ingress {client: 129.41.87.5, host: fn-dev-build.us-south.containers.appdomain.cloud, scheme: https, request_method: DELETE, request_uri: /api/v1/namespaces/_/packages/pkg-1593803357702, time_date: 03/Jul/2020:19:09:19 +0000, status: 409, http_user_agent: akka-http/10.1.11, request_id: 9abe9e535eafb1533f584ad82c7526fe, content_type: application/json, upstream_addr: 172.30.50.112:8080, upstream_status: 409, request_time: 0.137, upstream_response_time: 0.136, upstream_connect_time: 0.000, upstream_header_time: 0.136}
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

