### PR TITLE
Retry on failures for all TriggersApiTests to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
@@ -69,423 +69,656 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   val parametersLimit = Parameters.sizeLimit
   val dummyInstant = Instant.now()
 
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
+
   //// GET /triggers
   it should "list triggers by default/explicit namespace" in {
-    implicit val tid = transid()
-    val triggers = (1 to 2).map { i =>
-      WhiskTrigger(namespace, aname(), Parameters("x", "b"))
-    }.toList
-    triggers foreach { put(entityStore, _) }
-    waitOnView(entityStore, WhiskTrigger, namespace, 2)
-    Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[List[JsObject]]
-      triggers.length should be(response.length)
-      response should contain theSameElementsAs triggers.map(_.summaryAsJson)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val triggers = (1 to 2).map { i =>
+            WhiskTrigger(namespace, aname(), Parameters("x", "b"))
+          }.toList
+          triggers foreach { put(entityStore, _) }
+          waitOnView(entityStore, WhiskTrigger, namespace, 2)
+          Get(s"$collectionPath") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[List[JsObject]]
+            triggers.length should be(response.length)
+            response should contain theSameElementsAs triggers.map(_.summaryAsJson)
+          }
 
-    // it should "list triggers with explicit namespace owned by subject" in {
-    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[List[JsObject]]
-      triggers.length should be(response.length)
-      response should contain theSameElementsAs triggers.map(_.summaryAsJson)
-    }
+          // it should "list triggers with explicit namespace owned by subject" in {
+          Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[List[JsObject]]
+            triggers.length should be(response.length)
+            response should contain theSameElementsAs triggers.map(_.summaryAsJson)
+          }
 
-    // it should "reject list triggers with explicit namespace not owned by subject" in {
-    val auser = WhiskAuthHelpers.newIdentity()
-    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
-      status should be(Forbidden)
-    }
+          // it should "reject list triggers with explicit namespace not owned by subject" in {
+          val auser = WhiskAuthHelpers.newIdentity()
+          Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(auser)) ~> check {
+            status should be(Forbidden)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should list triggers by default/explicit namespace not successful, retrying.."))
   }
 
   it should "reject list when limit is greater than maximum allowed value" in {
-    implicit val tid = transid()
-    val exceededMaxLimit = Collection.MAX_LIST_LIMIT + 1
-    val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.listLimitOutOfRange(Collection.TRIGGERS, exceededMaxLimit, Collection.MAX_LIST_LIMIT)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val exceededMaxLimit = Collection.MAX_LIST_LIMIT + 1
+          val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.listLimitOutOfRange(Collection.TRIGGERS, exceededMaxLimit, Collection.MAX_LIST_LIMIT)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject list when limit is greater than maximum allowed value not successful, retrying.."))
   }
 
   it should "reject list when limit is not an integer" in {
-    implicit val tid = transid()
-    val notAnInteger = "string"
-    val response = Get(s"$collectionPath?limit=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.argumentNotInteger(Collection.TRIGGERS, notAnInteger)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val notAnInteger = "string"
+          val response = Get(s"$collectionPath?limit=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.argumentNotInteger(Collection.TRIGGERS, notAnInteger)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject list when limit is not an integer not successful, retrying.."))
   }
 
   it should "reject list when skip is negative" in {
-    implicit val tid = transid()
-    val negativeSkip = -1
-    val response = Get(s"$collectionPath?skip=$negativeSkip") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.listSkipOutOfRange(Collection.TRIGGERS, negativeSkip)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val negativeSkip = -1
+          val response = Get(s"$collectionPath?skip=$negativeSkip") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.listSkipOutOfRange(Collection.TRIGGERS, negativeSkip)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject list when skip is negative not successful, retrying.."))
   }
 
   it should "reject list when skip is not an integer" in {
-    implicit val tid = transid()
-    val notAnInteger = "string"
-    val response = Get(s"$collectionPath?skip=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-      responseAs[String] should include {
-        Messages.argumentNotInteger(Collection.TRIGGERS, notAnInteger)
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val notAnInteger = "string"
+          val response = Get(s"$collectionPath?skip=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+            responseAs[String] should include {
+              Messages.argumentNotInteger(Collection.TRIGGERS, notAnInteger)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject list when skip is not an integer not successful, retrying.."))
   }
 
   // ?docs disabled
   ignore should "list triggers by default namespace with full docs" in {
-    implicit val tid = transid()
-    val triggers = (1 to 2).map { i =>
-      WhiskTrigger(namespace, aname(), Parameters("x", "b"))
-    }.toList
-    triggers foreach { put(entityStore, _) }
-    waitOnView(entityStore, WhiskTrigger, namespace, 2)
-    Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[List[WhiskTrigger]]
-      triggers.length should be(response.length)
-      response should contain theSameElementsAs triggers.map(_.summaryAsJson)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val triggers = (1 to 2).map { i =>
+            WhiskTrigger(namespace, aname(), Parameters("x", "b"))
+          }.toList
+          triggers foreach { put(entityStore, _) }
+          waitOnView(entityStore, WhiskTrigger, namespace, 2)
+          Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[List[WhiskTrigger]]
+            triggers.length should be(response.length)
+            response should contain theSameElementsAs triggers.map(_.summaryAsJson)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should list triggers by default namespace with full docs not successful, retrying.."))
   }
 
   //// GET /triggers/name
   it should "get trigger by name in default/explicit namespace" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
-    put(entityStore, trigger)
-    Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskTrigger]
-      response should be(trigger)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
+          put(entityStore, trigger)
+          Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            response should be(trigger)
+          }
 
-    // it should "get trigger by name in explicit namespace owned by subject" in
-    Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskTrigger]
-      response should be(trigger)
-    }
+          // it should "get trigger by name in explicit namespace owned by subject" in
+          Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            response should be(trigger)
+          }
 
-    // it should "reject get trigger by name in explicit namespace not owned by subject" in
-    val auser = WhiskAuthHelpers.newIdentity()
-    Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(auser)) ~> check {
-      status should be(Forbidden)
-    }
+          // it should "reject get trigger by name in explicit namespace not owned by subject" in
+          val auser = WhiskAuthHelpers.newIdentity()
+          Get(s"/$namespace/${collection.path}/${trigger.name}") ~> Route.seal(routes(auser)) ~> check {
+            status should be(Forbidden)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should get trigger by name in default/explicit namespace not successful, retrying.."))
   }
 
   it should "get trigger with updated field" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
-    put(entityStore, trigger)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
+          put(entityStore, trigger)
 
-    // `updated` field should be compared with a document in DB
-    val t = get(entityStore, trigger.docid, WhiskTrigger)
+          // `updated` field should be compared with a document in DB
+          val t = get(entityStore, trigger.docid, WhiskTrigger)
 
-    Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskTrigger]
-      response should be(trigger copy (updated = t.updated))
-    }
+          Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            response should be(trigger copy (updated = t.updated))
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should get trigger with updated field not successful, retrying.."))
   }
 
   it should "report Conflict if the name was of a different type" in {
-    implicit val tid = transid()
-    val rule = WhiskRule(
-      namespace,
-      aname(),
-      FullyQualifiedEntityName(namespace, aname()),
-      FullyQualifiedEntityName(namespace, aname()))
-    put(entityStore, rule)
-    Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(Conflict)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val rule = WhiskRule(
+            namespace,
+            aname(),
+            FullyQualifiedEntityName(namespace, aname()),
+            FullyQualifiedEntityName(namespace, aname()))
+          put(entityStore, rule)
+          Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(Conflict)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should report Conflict if the name was of a different type not successful, retrying.."))
   }
 
   //// DEL /triggers/name
   it should "delete trigger by name" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
-    put(entityStore, trigger)
-    Delete(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskTrigger]
-      response should be(trigger)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
+          put(entityStore, trigger)
+          Delete(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            response should be(trigger)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Triggers API should delete trigger by name not successful, retrying.."))
   }
 
   //// PUT /triggers/name
   it should "put should accept request with missing optional properties" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname())
-    val content = WhiskTriggerPut()
-    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteTrigger(trigger.docid)
-      status should be(OK)
-      val response = responseAs[WhiskTrigger]
-      checkWhiskEntityResponse(response, trigger.withoutRules)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname())
+          val content = WhiskTriggerPut()
+          Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteTrigger(trigger.docid)
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            checkWhiskEntityResponse(response, trigger.withoutRules)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should put should accept request with missing optional properties not successful, retrying.."))
   }
 
   it should "put should accept request with valid feed parameter" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "xyz"))
-    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteTrigger(trigger.docid)
-      status should be(OK)
-      val response = responseAs[WhiskTrigger]
-      checkWhiskEntityResponse(response, trigger.withoutRules)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "xyz"))
+          val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+          Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteTrigger(trigger.docid)
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            checkWhiskEntityResponse(response, trigger.withoutRules)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should put should accept request with valid feed parameter not successful, retrying.."))
   }
 
   it should "put should reject request with undefined feed parameter" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, ""))
-    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, ""))
+          val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+          Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should put should reject request with undefined feed parameter not successful, retrying.."))
   }
 
   it should "put should reject request with bad feed parameters" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "a,b"))
-    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-    Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(BadRequest)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "a,b"))
+          val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+          Put(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(BadRequest)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should put should reject request with bad feed parameters not successful, retrying.."))
   }
 
   it should "reject activation with entity which is too big" in {
-    implicit val tid = transid()
-    val code = "a" * (allowedActivationEntitySize.toInt + 1)
-    val content = s"""{"a":"$code"}""".stripMargin
-    Post(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
-      responseAs[String] should include {
-        Messages.entityTooBig(
-          SizeError(fieldDescriptionForSizeError, (content.length).B, allowedActivationEntitySize.B))
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val code = "a" * (allowedActivationEntitySize.toInt + 1)
+          val content = s"""{"a":"$code"}""".stripMargin
+          Post(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
+            status should be(PayloadTooLarge)
+            responseAs[String] should include {
+              Messages.entityTooBig(
+                SizeError(fieldDescriptionForSizeError, (content.length).B, allowedActivationEntitySize.B))
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject activation with entity which is too big not successful, retrying.."))
   }
 
   it should "reject create with parameters which are too big" in {
-    implicit val tid = transid()
-    val keys: List[Long] =
-      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-    val parameters = keys map { key =>
-      Parameters(key.toString, "a" * 10)
-    } reduce (_ ++ _)
-    val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
-    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
-      responseAs[String] should include {
-        Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val keys: List[Long] =
+            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+          val parameters = keys map { key =>
+            Parameters(key.toString, "a" * 10)
+          } reduce (_ ++ _)
+          val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
+          Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(PayloadTooLarge)
+            responseAs[String] should include {
+              Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject create with parameters which are too big not successful, retrying.."))
   }
 
   it should "reject create with annotations which are too big" in {
-    implicit val tid = transid()
-    val keys: List[Long] =
-      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-    val annotations = keys map { key =>
-      Parameters(key.toString, "a" * 10)
-    } reduce (_ ++ _)
-    val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
-    Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
-      responseAs[String] should include {
-        Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val keys: List[Long] =
+            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+          val annotations = keys map { key =>
+            Parameters(key.toString, "a" * 10)
+          } reduce (_ ++ _)
+          val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
+          Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(PayloadTooLarge)
+            responseAs[String] should include {
+              Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject create with annotations which are too big not successful, retrying.."))
   }
 
   it should "reject update with parameters which are too big" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname())
-    val keys: List[Long] =
-      List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
-    val parameters = keys map { key =>
-      Parameters(key.toString, "a" * 10)
-    } reduce (_ ++ _)
-    val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
-    put(entityStore, trigger)
-    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
-      responseAs[String] should include {
-        Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
-      }
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname())
+          val keys: List[Long] =
+            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+          val parameters = keys map { key =>
+            Parameters(key.toString, "a" * 10)
+          } reduce (_ ++ _)
+          val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
+          put(entityStore, trigger)
+          Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(PayloadTooLarge)
+            responseAs[String] should include {
+              Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should reject update with parameters which are too big not successful, retrying.."))
   }
 
   it should "put should accept update request with missing optional properties" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
-    val content = WhiskTriggerPut()
-    put(entityStore, trigger)
-    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteTrigger(trigger.docid)
-      status should be(OK)
-      val response = responseAs[WhiskTrigger]
-      checkWhiskEntityResponse(
-        response,
-        WhiskTrigger(
-          trigger.namespace,
-          trigger.name,
-          trigger.parameters,
-          version = trigger.version.upPatch,
-          updated = dummyInstant).withoutRules)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
+          val content = WhiskTriggerPut()
+          put(entityStore, trigger)
+          Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteTrigger(trigger.docid)
+            status should be(OK)
+            val response = responseAs[WhiskTrigger]
+            checkWhiskEntityResponse(
+              response,
+              WhiskTrigger(
+                trigger.namespace,
+                trigger.name,
+                trigger.parameters,
+                version = trigger.version.upPatch,
+                updated = dummyInstant).withoutRules)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should put should accept update request with missing optional properties not successful, retrying.."))
   }
 
   it should "put should reject update request for trigger with existing feed" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "xyz"))
-    val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
-    put(entityStore, trigger)
-    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteTrigger(trigger.docid)
-      status should be(OK)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "xyz"))
+          val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
+          put(entityStore, trigger)
+          Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteTrigger(trigger.docid)
+            status should be(OK)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should put should reject update request for trigger with existing feed not successful, retrying.."))
   }
 
   it should "put should reject update request for trigger with new feed" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname())
-    val content = WhiskTriggerPut(annotations = Some(Parameters(Parameters.Feed, "xyz")))
-    put(entityStore, trigger)
-    Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteTrigger(trigger.docid)
-      status should be(OK)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname())
+          val content = WhiskTriggerPut(annotations = Some(Parameters(Parameters.Feed, "xyz")))
+          put(entityStore, trigger)
+          Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteTrigger(trigger.docid)
+            status should be(OK)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should put should reject update request for trigger with new feed not successful, retrying.."))
   }
 
   //// POST /triggers/name
   it should "fire a trigger" in {
-    implicit val tid = transid()
-    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "bogus action"))
-    val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
-      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
-    })
-    val content = JsObject("xxx" -> "yyy".toJson)
-    put(entityStore, trigger)
-    put(entityStore, rule)
-    Post(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(Accepted)
-      val response = responseAs[JsObject]
-      val JsString(id) = response.fields("activationId")
-      val activationId = ActivationId.parse(id).get
-      response.fields("activationId") should not be None
-      headers should contain(RawHeader(ActivationIdHeader, response.fields("activationId").convertTo[String]))
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val rule =
+            WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "bogus action"))
+          val trigger = WhiskTrigger(namespace, rule.trigger.name, rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+          })
+          val content = JsObject("xxx" -> "yyy".toJson)
+          put(entityStore, trigger)
+          put(entityStore, rule)
+          Post(s"$collectionPath/${trigger.name}", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(Accepted)
+            val response = responseAs[JsObject]
+            val JsString(id) = response.fields("activationId")
+            val activationId = ActivationId.parse(id).get
+            response.fields("activationId") should not be None
+            headers should contain(RawHeader(ActivationIdHeader, response.fields("activationId").convertTo[String]))
 
-      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
-      org.apache.openwhisk.utils.retry({
-        println(s"trying to obtain async activation doc: '${activationDoc}'")
+            val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+            org.apache.openwhisk.utils.retry({
+              println(s"trying to obtain async activation doc: '${activationDoc}'")
 
-        val activation = getActivation(ActivationId(activationDoc.asString), context)
-        deleteActivation(ActivationId(activationDoc.asString), context)
-        activation.end should be(Instant.EPOCH)
-        activation.response.result should be(Some(content))
-      }, 30, Some(1.second))
-    }
+              val activation = getActivation(ActivationId(activationDoc.asString), context)
+              deleteActivation(ActivationId(activationDoc.asString), context)
+              activation.end should be(Instant.EPOCH)
+              activation.response.result should be(Some(content))
+            }, 30, Some(1.second))
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Triggers API should fire a trigger not successful, retrying.."))
   }
 
   it should "fire a trigger without args" in {
-    implicit val tid = transid()
-    val rule = WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "bogus action"))
-    val trigger = WhiskTrigger(namespace, rule.trigger.name, Parameters("x", "b"), rules = Some {
-      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
-    })
-    put(entityStore, trigger)
-    put(entityStore, rule)
-    Post(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-      val response = responseAs[JsObject]
-      val JsString(id) = response.fields("activationId")
-      val activationId = ActivationId.parse(id).get
-      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
-      org.apache.openwhisk.utils.retry({
-        println(s"trying to delete async activation doc: '${activationDoc}'")
-        deleteActivation(ActivationId(activationDoc.asString), context)
-        response.fields("activationId") should not be None
-        headers should contain(RawHeader(ActivationIdHeader, response.fields("activationId").convertTo[String]))
-      }, 30, Some(1.second))
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val rule =
+            WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "bogus action"))
+          val trigger = WhiskTrigger(namespace, rule.trigger.name, Parameters("x", "b"), rules = Some {
+            Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+          })
+          put(entityStore, trigger)
+          put(entityStore, rule)
+          Post(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+            val response = responseAs[JsObject]
+            val JsString(id) = response.fields("activationId")
+            val activationId = ActivationId.parse(id).get
+            val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+            org.apache.openwhisk.utils.retry({
+              println(s"trying to delete async activation doc: '${activationDoc}'")
+              deleteActivation(ActivationId(activationDoc.asString), context)
+              response.fields("activationId") should not be None
+              headers should contain(RawHeader(ActivationIdHeader, response.fields("activationId").convertTo[String]))
+            }, 30, Some(1.second))
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Triggers API should fire a trigger without args not successful, retrying.."))
   }
 
   it should "not fire a trigger without a rule" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname())
-    put(entityStore, trigger)
-    Post(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-      status shouldBe NoContent
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname())
+          put(entityStore, trigger)
+          Post(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+            status shouldBe NoContent
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should not fire a trigger without a rule not successful, retrying.."))
   }
 
   //// invalid resource
   it should "reject invalid resource" in {
-    implicit val tid = transid()
-    val trigger = WhiskTrigger(namespace, aname())
-    put(entityStore, trigger)
-    Get(s"$collectionPath/${trigger.name}/bar") ~> Route.seal(routes(creds)) ~> check {
-      status should be(NotFound)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = WhiskTrigger(namespace, aname())
+          put(entityStore, trigger)
+          Get(s"$collectionPath/${trigger.name}/bar") ~> Route.seal(routes(creds)) ~> check {
+            status should be(NotFound)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Triggers API should reject invalid resource not successful, retrying.."))
   }
 
   // migration path
   it should "be able to handle a trigger as of the old schema" in {
-    implicit val tid = transid()
-    val trigger = OldWhiskTrigger(namespace, aname())
-    put(entityStore, trigger)
-    Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
-      val response = responseAs[WhiskTrigger]
-      status should be(OK)
-      checkWhiskEntityResponse(response, trigger.toWhiskTrigger)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val trigger = OldWhiskTrigger(namespace, aname())
+          put(entityStore, trigger)
+          Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
+            val response = responseAs[WhiskTrigger]
+            status should be(OK)
+            checkWhiskEntityResponse(response, trigger.toWhiskTrigger)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should be able to handle a trigger as of the old schema not successful, retrying.."))
   }
 
   it should "report proper error when record is corrupted on delete" in {
-    implicit val tid = transid()
-    val entity = BadEntity(namespace, aname())
-    put(entityStore, entity)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val entity = BadEntity(namespace, aname())
+          put(entityStore, entity)
 
-    Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(InternalServerError)
-      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-    }
+          Delete(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(InternalServerError)
+            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > report proper error when record is corrupted on delete not successful, retrying.."))
   }
 
   it should "report proper error when record is corrupted on get" in {
-    implicit val tid = transid()
-    val entity = BadEntity(namespace, aname())
-    put(entityStore, entity)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val entity = BadEntity(namespace, aname())
+          put(entityStore, entity)
 
-    Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(InternalServerError)
-      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-    }
+          Get(s"$collectionPath/${entity.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(InternalServerError)
+            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should report proper error when record is corrupted on get not successful, retrying.."))
   }
 
   it should "report proper error when record is corrupted on put" in {
-    implicit val tid = transid()
-    val entity = BadEntity(namespace, aname())
-    put(entityStore, entity)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val entity = BadEntity(namespace, aname())
+          put(entityStore, entity)
 
-    val content = WhiskTriggerPut()
-    Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(InternalServerError)
-      responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
-    }
+          val content = WhiskTriggerPut()
+          Put(s"$collectionPath/${entity.name}", content) ~> Route.seal(routes(creds)) ~> check {
+            status should be(InternalServerError)
+            responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Triggers API should report proper error when record is corrupted on put not successful, retrying.."))
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
18:30:16  org.apache.openwhisk.core.controller.test.TriggersApiTests > Triggers API should list triggers by default/explicit namespace STANDARD_OUT
18:30:16      condition not met, retrying
18:30:16      condition not met, retrying
18:30:16      condition not met, retrying
18:30:16      condition not met, retrying
18:30:16  
18:30:16  org.apache.openwhisk.core.controller.test.TriggersApiTests > Triggers API should list triggers by default/explicit namespace FAILED
18:30:16      org.scalatest.exceptions.TestFailedException: 2 was not equal to 0
18:30:16          at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
18:30:16          at org.scalatest.Matchers$ShouldMethodHelper$.shouldMatcher(Matchers.scala:6723)
18:30:16          at org.scalatest.Matchers$AnyShouldWrapper.should(Matchers.scala:6759)
18:30:16          at org.apache.openwhisk.core.controller.test.TriggersApiTests.$anonfun$new$4(TriggersApiTests.scala:83)
18:30:16          at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
18:30:16          at akka.http.scaladsl.testkit.RouteTest.$anonfun$check$1(RouteTest.scala:56)
18:30:16          at akka.http.scaladsl.testkit.RouteTestResultComponent$RouteTestResult.$tilde$greater(RouteTestResultComponent.scala:50)
18:30:16          at org.apache.openwhisk.core.controller.test.TriggersApiTests.$anonfun$new$1(TriggersApiTests.scala:80)
18:30:16          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
18:30:16          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
18:30:16          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
18:30:16          at org.scalatest.Transformer.apply(Transformer.scala:22)
18:30:16          at org.scalatest.Transformer.apply(Transformer.scala:20)
18:30:16          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
18:30:16          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
18:30:16          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
18:30:16          at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1685)
18:30:16          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
18:30:16          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
18:30:16          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
18:30:16          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
18:30:16          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
18:30:16          at org.apache.openwhisk.core.controller.test.TriggersApiTests.org$scalatest$BeforeAndAfterEach$$super$runTest(TriggersApiTests.scala:58)
18:30:16          at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:221)
18:30:16          at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:214)
18:30:16          at org.apache.openwhisk.core.controller.test.TriggersApiTests.runTest(TriggersApiTests.scala:58)
18:30:16          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
18:30:16          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
18:30:16          at scala.collection.immutable.List.foreach(List.scala:392)
18:30:16          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
18:30:16          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
18:30:16          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
18:30:16          at scala.collection.immutable.List.foreach(List.scala:392)
18:30:16          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
18:30:16          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
18:30:16          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
18:30:16          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
18:30:16          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
18:30:16          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
18:30:16          at org.scalatest.Suite.run(Suite.scala:1124)
18:30:16          at org.scalatest.Suite.run$(Suite.scala:1106)
18:30:16          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
18:30:16          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
18:30:16          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
18:30:16          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
18:30:16          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
18:30:16          at org.apache.openwhisk.core.controller.test.TriggersApiTests.org$scalatest$BeforeAndAfterAll$$super$run(TriggersApiTests.scala:58)
18:30:16          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
18:30:16          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
18:30:16          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
18:30:16          at org.apache.openwhisk.core.controller.test.TriggersApiTests.run(TriggersApiTests.scala:58)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

