### PR TITLE
Retry on failures for all ActivationStoreQueryBehaviors tests to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ActivationStoreQueryBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ActivationStoreQueryBehaviors.scala
@@ -19,6 +19,7 @@ package org.apache.openwhisk.core.database.test.behavior
 
 import java.time.Instant
 
+import scala.concurrent.duration.DurationInt
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.database.UserContext
 import org.apache.openwhisk.core.entity.{EntityPath, WhiskActivation}
@@ -27,6 +28,9 @@ import spray.json.{JsNumber, JsObject}
 import scala.util.Random
 
 trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
+
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
 
   protected def checkQueryActivations(namespace: String,
                                       name: Option[String] = None,
@@ -94,260 +98,408 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
   behavior of s"${storeType}ActivationStore listActivationsInNamespace"
 
   it should "find all entities" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
-    val action2 = s"action2_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+          val action2 = s"action2_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    val activations2 = (1000 until 1100 by 10).map(newActivation(namespace, action2, _))
-    activations2 foreach (store(_, context))
+          val activations2 = (1000 until 1100 by 10).map(newActivation(namespace, action2, _))
+          activations2 foreach (store(_, context))
 
-    checkQueryActivations(namespace, context = context, expected = activations ++ activations2)
+          checkQueryActivations(namespace, context = context, expected = activations ++ activations2)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsInNamespace should find all entities not successful, retrying.."))
   }
 
   it should "support since and upto filters" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(
-      namespace,
-      since = Some(Instant.ofEpochMilli(1060)),
-      context = context,
-      expected = activations.takeRight(4))
+          checkQueryActivations(
+            namespace,
+            since = Some(Instant.ofEpochMilli(1060)),
+            context = context,
+            expected = activations.takeRight(4))
 
-    checkQueryActivations(
-      namespace,
-      upto = Some(Instant.ofEpochMilli(1060)),
-      context = context,
-      expected = activations.take(7))
+          checkQueryActivations(
+            namespace,
+            upto = Some(Instant.ofEpochMilli(1060)),
+            context = context,
+            expected = activations.take(7))
 
-    checkQueryActivations(
-      namespace,
-      since = Some(Instant.ofEpochMilli(1030)),
-      upto = Some(Instant.ofEpochMilli(1060)),
-      context = context,
-      expected = activations.take(7).takeRight(4))
+          checkQueryActivations(
+            namespace,
+            since = Some(Instant.ofEpochMilli(1030)),
+            upto = Some(Instant.ofEpochMilli(1060)),
+            context = context,
+            expected = activations.take(7).takeRight(4))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsInNamespace should support since and upto filters not successful, retrying.."))
   }
 
   it should "support skipping results" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(namespace, skip = 5, context = context, expected = activations.take(5))
+          checkQueryActivations(namespace, skip = 5, context = context, expected = activations.take(5))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsInNamespace should support skipping results not successful, retrying.."))
   }
 
   it should "support limiting results" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(namespace, limit = 5, context = context, expected = activations.takeRight(5))
+          checkQueryActivations(namespace, limit = 5, context = context, expected = activations.takeRight(5))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsInNamespace should support limiting results not successful, retrying.."))
   }
 
   it should "support including complete docs" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(namespace, includeDocs = true, context = context, expected = activations)
+          checkQueryActivations(namespace, includeDocs = true, context = context, expected = activations)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsInNamespace should support including complete docs not successful, retrying.."))
   }
 
   it should "throw exception for negative limits and skip" in {
-    implicit val tid: TransactionId = transId()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
 
-    a[IllegalArgumentException] should be thrownBy activationStore
-      .listActivationsInNamespace(EntityPath("test"), skip = -1, limit = 10, context = context)
+          a[IllegalArgumentException] should be thrownBy activationStore
+            .listActivationsInNamespace(EntityPath("test"), skip = -1, limit = 10, context = context)
 
-    a[IllegalArgumentException] should be thrownBy activationStore
-      .listActivationsInNamespace(EntityPath("test"), skip = 0, limit = -1, context = context)
+          a[IllegalArgumentException] should be thrownBy activationStore
+            .listActivationsInNamespace(EntityPath("test"), skip = 0, limit = -1, context = context)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsInNamespace should throw exception for negative limits and skip not successful, retrying.."))
   }
 
   behavior of s"${storeType}ActivationStore listActivationsMatchingName"
 
   it should "find all entities matching name" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
-    val action2 = s"action2_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+          val action2 = s"action2_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    val activations2 = (1000 until 1100 by 10).map(newActivation(namespace, action2, _))
-    activations2 foreach (store(_, context))
+          val activations2 = (1000 until 1100 by 10).map(newActivation(namespace, action2, _))
+          activations2 foreach (store(_, context))
 
-    checkQueryActivations(namespace, Some(action1), context = context, expected = activations)
+          checkQueryActivations(namespace, Some(action1), context = context, expected = activations)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsMatchingName should find all entities matching name not successful, retrying.."))
   }
 
   it should "support since and upto filters" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(
-      namespace,
-      Some(action1),
-      since = Some(Instant.ofEpochMilli(1060)),
-      context = context,
-      expected = activations.takeRight(4))
+          checkQueryActivations(
+            namespace,
+            Some(action1),
+            since = Some(Instant.ofEpochMilli(1060)),
+            context = context,
+            expected = activations.takeRight(4))
 
-    checkQueryActivations(
-      namespace,
-      Some(action1),
-      upto = Some(Instant.ofEpochMilli(1060)),
-      context = context,
-      expected = activations.take(7))
+          checkQueryActivations(
+            namespace,
+            Some(action1),
+            upto = Some(Instant.ofEpochMilli(1060)),
+            context = context,
+            expected = activations.take(7))
 
-    checkQueryActivations(
-      namespace,
-      Some(action1),
-      since = Some(Instant.ofEpochMilli(1030)),
-      upto = Some(Instant.ofEpochMilli(1060)),
-      context = context,
-      expected = activations.take(7).takeRight(4))
+          checkQueryActivations(
+            namespace,
+            Some(action1),
+            since = Some(Instant.ofEpochMilli(1030)),
+            upto = Some(Instant.ofEpochMilli(1060)),
+            context = context,
+            expected = activations.take(7).takeRight(4))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsMatchingName should support since and upto filters not successful, retrying.."))
   }
 
   it should "support skipping results" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(namespace, Some(action1), skip = 5, context = context, expected = activations.take(5))
+          checkQueryActivations(namespace, Some(action1), skip = 5, context = context, expected = activations.take(5))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsMatchingName should support skipping results not successful, retrying.."))
   }
 
   it should "support limiting results" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(namespace, Some(action1), limit = 5, context = context, expected = activations.takeRight(5))
+          checkQueryActivations(
+            namespace,
+            Some(action1),
+            limit = 5,
+            context = context,
+            expected = activations.takeRight(5))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsMatchingName should support limiting results not successful, retrying.."))
   }
 
   it should "support including complete docs" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkQueryActivations(namespace, Some(action1), includeDocs = true, context = context, expected = activations)
+          checkQueryActivations(namespace, Some(action1), includeDocs = true, context = context, expected = activations)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsMatchingName should support including complete docs not successful, retrying.."))
   }
 
   it should "throw exception for negative limits and skip" in {
-    implicit val tid: TransactionId = transId()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
 
-    a[IllegalArgumentException] should be thrownBy activationStore.listActivationsMatchingName(
-      EntityPath("test"),
-      name = EntityPath("testact"),
-      skip = -1,
-      limit = 10,
-      context = context)
+          a[IllegalArgumentException] should be thrownBy activationStore.listActivationsMatchingName(
+            EntityPath("test"),
+            name = EntityPath("testact"),
+            skip = -1,
+            limit = 10,
+            context = context)
 
-    a[IllegalArgumentException] should be thrownBy activationStore.listActivationsMatchingName(
-      EntityPath("test"),
-      name = EntityPath("testact"),
-      skip = 0,
-      limit = -1,
-      context = context)
+          a[IllegalArgumentException] should be thrownBy activationStore.listActivationsMatchingName(
+            EntityPath("test"),
+            name = EntityPath("testact"),
+            skip = 0,
+            limit = -1,
+            context = context)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore listActivationsMatchingName should throw exception for negative limits and skip not successful, retrying.."))
   }
 
   behavior of s"${storeType}ActivationStore countActivationsInNamespace"
 
   it should "should count all created activations" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkCountActivations(namespace, None, context = context, expected = 10)
+          checkCountActivations(namespace, None, context = context, expected = 10)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore countActivationsInNamespace should should count all created activations not successful, retrying.."))
   }
 
   it should "count with option name" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
-    val action2 = s"action2_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+          val action2 = s"action2_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    val activations2 = (1000 until 1100 by 10).map(newActivation(namespace, action2, _))
-    activations2 foreach (store(_, context))
+          val activations2 = (1000 until 1100 by 10).map(newActivation(namespace, action2, _))
+          activations2 foreach (store(_, context))
 
-    checkCountActivations(namespace, Some(EntityPath(action1)), context = context, expected = 10)
+          checkCountActivations(namespace, Some(EntityPath(action1)), context = context, expected = 10)
 
-    checkCountActivations(namespace, Some(EntityPath(action2)), context = context, expected = 10)
+          checkCountActivations(namespace, Some(EntityPath(action2)), context = context, expected = 10)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore countActivationsInNamespace should should count with option name not successful, retrying.."))
   }
 
   it should "count with since and upto" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkCountActivations(namespace, None, since = Some(Instant.ofEpochMilli(1060L)), context = context, expected = 4)
+          checkCountActivations(
+            namespace,
+            None,
+            since = Some(Instant.ofEpochMilli(1060L)),
+            context = context,
+            expected = 4)
 
-    checkCountActivations(namespace, None, upto = Some(Instant.ofEpochMilli(1060L)), context = context, expected = 7)
+          checkCountActivations(
+            namespace,
+            None,
+            upto = Some(Instant.ofEpochMilli(1060L)),
+            context = context,
+            expected = 7)
 
-    checkCountActivations(
-      namespace,
-      None,
-      since = Some(Instant.ofEpochMilli(1030L)),
-      upto = Some(Instant.ofEpochMilli(1060L)),
-      context = context,
-      expected = 4)
+          checkCountActivations(
+            namespace,
+            None,
+            since = Some(Instant.ofEpochMilli(1030L)),
+            upto = Some(Instant.ofEpochMilli(1060L)),
+            context = context,
+            expected = 4)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore countActivationsInNamespace should should count with since and upto not successful, retrying.."))
   }
 
   it should "count with skip" in {
-    implicit val tid: TransactionId = transId()
-    val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
-    val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
+          val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
+          val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
 
-    val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
-    activations foreach (store(_, context))
+          val activations = (1000 until 1100 by 10).map(newActivation(namespace, action1, _))
+          activations foreach (store(_, context))
 
-    checkCountActivations(namespace, None, skip = 4, context = context, expected = 10 - 4)
-    checkCountActivations(namespace, None, skip = 1000, context = context, expected = 0)
+          checkCountActivations(namespace, None, skip = 4, context = context, expected = 10 - 4)
+          checkCountActivations(namespace, None, skip = 1000, context = context, expected = 0)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore countActivationsInNamespace should should count with skip not successful, retrying.."))
   }
 
   it should "throw exception for negative skip" in {
-    implicit val tid: TransactionId = transId()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid: TransactionId = transId()
 
-    a[IllegalArgumentException] should be thrownBy activationStore.countActivationsInNamespace(
-      namespace = EntityPath("test"),
-      name = None,
-      skip = -1,
-      context = context)
+          a[IllegalArgumentException] should be thrownBy activationStore
+            .countActivationsInNamespace(namespace = EntityPath("test"), name = None, skip = -1, context = context)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > ${storeType}ActivationStore countActivationsInNamespace should should throw exception for negative skip not successful, retrying.."))
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
14:41:02  org.apache.openwhisk.core.database.ArtifactActivationStoreTests > ArtifactActivationStore listActivationsMatchingName should support limiting results STANDARD_OUT
14:41:02      [2020-07-05T12:40:38.893Z] [DEBUG] [#tid_AO8L5yB0PNpNm4NRS9x89x1Zd7bX7Sk1] [ArtifactActivationStore] recording activation 'f7a16c73837c476ba16c73837cb76b02'
14:41:02      [2020-07-05T12:40:38.893Z] [INFO] [#tid_AO8L5yB0PNpNm4NRS9x89x1Zd7bX7Sk1] [CouchDbRestStore] [PUT] 'fn-dev-build_activations' saving document: 'id: ns_avrn/f7a16c73837c476ba16c73837cb76b02, rev: null' [marker:database_saveDocument_start:2]
..
14:41:02      [2020-07-05T12:41:01.354Z] [INFO] [#tid_AO8L5yB0PNpNm4NRS9x89x1Zd7bX7Sk1] [CouchDbRestStore] [QUERY] 'fn-dev-build_activations' searching 'whisks-filters.v2.1.0/activations [marker:database_queryView_start:22463]
14:41:02      [2020-07-05T12:41:01.449Z] [INFO] [#tid_AO8L5yB0PNpNm4NRS9x89x1Zd7bX7Sk1] [CouchDbRestStore] [marker:database_queryView_finish:22558:95]
14:41:02  
14:41:02  org.apache.openwhisk.core.database.ArtifactActivationStoreTests > ArtifactActivationStore listActivationsMatchingName should support limiting results FAILED
14:41:02      org.scalatest.exceptions.TestFailedException: List({"activationId":"07e6cdd716334f0aa6cdd716333f0ac4","annotations":[],"duration":1000,"end":2070,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1070,"statusCode":0,"version":"0.0.1"}, {"activationId":"e4235e31df4b45e6a35e31df4b45e675","annotations":[],"duration":1000,"end":2060,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1060,"statusCode":0,"version":"0.0.1"}, {"activationId":"f2ab5df1d3064be7ab5df1d3064be722","annotations":[],"duration":1000,"end":2050,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1050,"statusCode":0,"version":"0.0.1"}, {"activationId":"44a8af0762d0415da8af0762d0615d9e","annotations":[],"duration":1000,"end":2040,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1040,"statusCode":0,"version":"0.0.1"}, {"activationId":"704d96970dcf4b8f8d96970dcffb8f16","annotations":[],"duration":1000,"end":2030,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1030,"statusCode":0,"version":"0.0.1"}) did not contain the same elements as Vector({"activationId":"f2ab5df1d3064be7ab5df1d3064be722","annotations":[],"duration":1000,"end":2050,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1050,"statusCode":0,"version":"0.0.1"}, {"activationId":"e4235e31df4b45e6a35e31df4b45e675","annotations":[],"duration":1000,"end":2060,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1060,"statusCode":0,"version":"0.0.1"}, {"activationId":"07e6cdd716334f0aa6cdd716333f0ac4","annotations":[],"duration":1000,"end":2070,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1070,"statusCode":0,"version":"0.0.1"}, {"activationId":"c3cda5c54c47473d8da5c54c47473dd6","annotations":[],"duration":1000,"end":2080,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1080,"statusCode":0,"version":"0.0.1"}, {"activationId":"fa7badd8423e4db2bbadd8423e0db294","annotations":[],"duration":1000,"end":2090,"name":"action1_dnqS","namespace":"ns_avrn","publish":false,"start":1090,"statusCode":0,"version":"0.0.1"})
14:41:02          at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
14:41:02          at org.scalatest.words.ResultOfContainWord.theSameElementsAs(ResultOfContainWord.scala:184)
14:41:02          at org.apache.openwhisk.core.database.test.behavior.ActivationStoreQueryBehaviors.checkQueryActivations(ActivationStoreQueryBehaviors.scala:70)
14:41:02          at org.apache.openwhisk.core.database.test.behavior.ActivationStoreQueryBehaviors.checkQueryActivations$(ActivationStoreQueryBehaviors.scala:31)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.super$checkQueryActivations(ArtifactActivationStoreTests.scala:45)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.$anonfun$checkQueryActivations$1(ArtifactActivationStoreTests.scala:45)
14:41:02          at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:41)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:46)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.checkQueryActivations(ArtifactActivationStoreTests.scala:45)
14:41:02          at org.apache.openwhisk.core.database.test.behavior.ActivationStoreQueryBehaviors.$anonfun$$init$$32(ActivationStoreQueryBehaviors.scala:249)
14:41:02          at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
14:41:02          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
14:41:02          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
14:41:02          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
14:41:02          at org.scalatest.Transformer.apply(Transformer.scala:22)
14:41:02          at org.scalatest.Transformer.apply(Transformer.scala:20)
14:41:02          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
14:41:02          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
14:41:02          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.org$apache$openwhisk$core$database$test$behavior$ActivationStoreBehaviorBase$$super$withFixture(ArtifactActivationStoreTests.scala:31)
14:41:02          at org.apache.openwhisk.core.database.test.behavior.ActivationStoreBehaviorBase.withFixture(ActivationStoreBehaviorBase.scala:65)
14:41:02          at org.apache.openwhisk.core.database.test.behavior.ActivationStoreBehaviorBase.withFixture$(ActivationStoreBehaviorBase.scala:63)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.withFixture(ArtifactActivationStoreTests.scala:31)
14:41:02          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
14:41:02          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
14:41:02          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
14:41:02          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
14:41:02          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.org$scalatest$BeforeAndAfterEach$$super$runTest(ArtifactActivationStoreTests.scala:31)
14:41:02          at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:221)
14:41:02          at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:214)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.runTest(ArtifactActivationStoreTests.scala:31)
14:41:02          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
14:41:02          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
14:41:02          at scala.collection.immutable.List.foreach(List.scala:392)
14:41:02          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
14:41:02          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
14:41:02          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
14:41:02          at scala.collection.immutable.List.foreach(List.scala:392)
14:41:02          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
14:41:02          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
14:41:02          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
14:41:02          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
14:41:02          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
14:41:02          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
14:41:02          at org.scalatest.Suite.run(Suite.scala:1124)
14:41:02          at org.scalatest.Suite.run$(Suite.scala:1106)
14:41:02          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
14:41:02          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
14:41:02          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
14:41:02          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
14:41:02          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.org$scalatest$BeforeAndAfterAll$$super$run(ArtifactActivationStoreTests.scala:31)
14:41:02          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
14:41:02          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
14:41:02          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
14:41:02          at org.apache.openwhisk.core.database.ArtifactActivationStoreTests.run(ArtifactActivationStoreTests.scala:31)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

