### PR TITLE
Retry on failures for all BasicAuthenticateTests tests to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/BasicAuthenticateTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/BasicAuthenticateTests.scala
@@ -19,6 +19,8 @@ package org.apache.openwhisk.core.controller.test
 
 import scala.concurrent.Await
 
+import scala.concurrent.duration.DurationInt
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -42,121 +44,181 @@ import org.apache.openwhisk.core.entitlement.Privilege
  */
 @RunWith(classOf[JUnitRunner])
 class BasicAuthenticateTests extends ControllerTestCommon {
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
+
   behavior of "Authenticate"
 
   it should "authorize a known user using different namespaces and cache key, and reject invalid secret" in {
-    implicit val tid = transid()
-    val subject = Subject()
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val subject = Subject()
 
-    val uuid1 = UUID()
-    val uuid2 = UUID()
+          val uuid1 = UUID()
+          val uuid2 = UUID()
 
-    val namespaces = Set(
-      WhiskNamespace(
-        Namespace(MakeName.next("authenticatev_tests"), uuid1),
-        BasicAuthenticationAuthKey(uuid1, Secret())),
-      WhiskNamespace(
-        Namespace(MakeName.next("authenticatev_tests"), uuid2),
-        BasicAuthenticationAuthKey(uuid2, Secret())))
-    val entry = WhiskAuth(subject, namespaces)
-    put(authStore, entry) // this test entry is reclaimed when the test completes
+          val namespaces = Set(
+            WhiskNamespace(
+              Namespace(MakeName.next("authenticatev_tests"), uuid1),
+              BasicAuthenticationAuthKey(uuid1, Secret())),
+            WhiskNamespace(
+              Namespace(MakeName.next("authenticatev_tests"), uuid2),
+              BasicAuthenticationAuthKey(uuid2, Secret())))
+          val entry = WhiskAuth(subject, namespaces)
+          put(authStore, entry) // this test entry is reclaimed when the test completes
 
-    // Try to login with each specific namespace
-    namespaces.foreach { ns =>
-      withClue(s"Trying to login to $ns") {
-        waitOnView(authStore, ns.authkey, 1) // wait for the view to be updated
-        val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
-        val user = Await.result(
-          BasicAuthenticationDirective
-            .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
-          dbOpTimeout)
-        user.get shouldBe Identity(subject, ns.namespace, ns.authkey, rights = Privilege.ALL)
+          // Try to login with each specific namespace
+          namespaces.foreach {
+            ns =>
+              withClue(s"Trying to login to $ns") {
+                waitOnView(authStore, ns.authkey, 1) // wait for the view to be updated
+                val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
+                val user = Await.result(
+                  BasicAuthenticationDirective
+                    .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+                  dbOpTimeout)
+                user.get shouldBe Identity(subject, ns.namespace, ns.authkey, rights = Privilege.ALL)
 
-        // first lookup should have been from datastore
-        stream.toString should include(s"serving from datastore: ${CacheKey(ns.authkey)}")
-        stream.reset()
+                // first lookup should have been from datastore
+                stream.toString should include(s"serving from datastore: ${CacheKey(ns.authkey)}")
+                stream.reset()
 
-        // repeat query, now should be served from cache
-        val cachedUser = Await.result(
-          BasicAuthenticationDirective
-            .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
-          dbOpTimeout)
-        cachedUser.get shouldBe Identity(subject, ns.namespace, ns.authkey, rights = Privilege.ALL)
+                // repeat query, now should be served from cache
+                val cachedUser = Await.result(
+                  BasicAuthenticationDirective
+                    .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+                  dbOpTimeout)
+                cachedUser.get shouldBe Identity(subject, ns.namespace, ns.authkey, rights = Privilege.ALL)
 
-        stream.toString should include(s"serving from cache: ${CacheKey(ns.authkey)}")
-        stream.reset()
-      }
-    }
+                stream.toString should include(s"serving from cache: ${CacheKey(ns.authkey)}")
+                stream.reset()
+              }
+          }
 
-    // check that invalid keys are rejected
-    val ns = namespaces.head
-    val key = ns.authkey.key.asString
-    Seq(key.drop(1), key.dropRight(1), key + "x", BasicAuthenticationAuthKey().key.asString).foreach { k =>
-      val pass = BasicHttpCredentials(ns.authkey.uuid.asString, k)
-      val user = Await.result(
-        BasicAuthenticationDirective
-          .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
-        dbOpTimeout)
-      user shouldBe empty
-    }
+          // check that invalid keys are rejected
+          val ns = namespaces.head
+          val key = ns.authkey.key.asString
+          Seq(key.drop(1), key.dropRight(1), key + "x", BasicAuthenticationAuthKey().key.asString).foreach { k =>
+            val pass = BasicHttpCredentials(ns.authkey.uuid.asString, k)
+            val user = Await.result(
+              BasicAuthenticationDirective
+                .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+              dbOpTimeout)
+            user shouldBe empty
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Authenticate should authorize a known user using different namespaces and cache key, and reject invalid secret not successful, retrying.."))
   }
 
   it should "not log key during validation" in {
-    implicit val tid = transid()
-    val creds = WhiskAuthHelpers.newIdentity()
-    val pass = creds.authkey.getCredentials.asInstanceOf[Option[BasicHttpCredentials]]
-    val user = Await.result(
-      BasicAuthenticationDirective.validateCredentials(pass)(transid, executionContext, logging, authStore),
-      dbOpTimeout)
-    user should be(None)
-    stream.toString should not include pass.get.password
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val creds = WhiskAuthHelpers.newIdentity()
+          val pass = creds.authkey.getCredentials.asInstanceOf[Option[BasicHttpCredentials]]
+          val user = Await.result(
+            BasicAuthenticationDirective.validateCredentials(pass)(transid, executionContext, logging, authStore),
+            dbOpTimeout)
+          user should be(None)
+          stream.toString should not include pass.get.password
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Authenticate should not log key during validation not successful, retrying.."))
   }
 
   it should "not authorize an unknown user" in {
-    implicit val tid = transid()
-    val creds = WhiskAuthHelpers.newIdentity()
-    val pass = creds.authkey.getCredentials.asInstanceOf[Option[BasicHttpCredentials]]
-    val user = Await.result(
-      BasicAuthenticationDirective.validateCredentials(pass)(transid, executionContext, logging, authStore),
-      dbOpTimeout)
-    user should be(None)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val creds = WhiskAuthHelpers.newIdentity()
+          val pass = creds.authkey.getCredentials.asInstanceOf[Option[BasicHttpCredentials]]
+          val user = Await.result(
+            BasicAuthenticationDirective.validateCredentials(pass)(transid, executionContext, logging, authStore),
+            dbOpTimeout)
+          user should be(None)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Authenticate should not authorize an unknown user not successful, retrying.."))
   }
 
   it should "not authorize when no user creds are provided" in {
-    implicit val tid = transid()
-    val user = Await.result(
-      BasicAuthenticationDirective.validateCredentials(None)(transid, executionContext, logging, authStore),
-      dbOpTimeout)
-    user should be(None)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val user = Await.result(
+            BasicAuthenticationDirective.validateCredentials(None)(transid, executionContext, logging, authStore),
+            dbOpTimeout)
+          user should be(None)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Authenticate should not authorize when no user creds are provided not successful, retrying.."))
   }
 
   it should "not authorize when malformed user is provided" in {
-    implicit val tid = transid()
-    val pass = BasicHttpCredentials("x", Secret().asString)
-    val user = Await.result(
-      BasicAuthenticationDirective
-        .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
-      dbOpTimeout)
-    user should be(None)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val pass = BasicHttpCredentials("x", Secret().asString)
+          val user = Await.result(
+            BasicAuthenticationDirective
+              .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+            dbOpTimeout)
+          user should be(None)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Authenticate should not authorize when malformed user is provided not successful, retrying.."))
   }
 
   it should "not authorize when malformed secret is provided" in {
-    implicit val tid = transid()
-    val pass = BasicHttpCredentials(UUID().asString, "x")
-    val user = Await.result(
-      BasicAuthenticationDirective
-        .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
-      dbOpTimeout)
-    user should be(None)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val pass = BasicHttpCredentials(UUID().asString, "x")
+          val user = Await.result(
+            BasicAuthenticationDirective
+              .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+            dbOpTimeout)
+          user should be(None)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Authenticate should not authorize when malformed secret is provided not successful, retrying.."))
   }
 
   it should "not authorize when malformed creds are provided" in {
-    implicit val tid = transid()
-    val pass = BasicHttpCredentials("x", "y")
-    val user = Await.result(
-      BasicAuthenticationDirective
-        .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
-      dbOpTimeout)
-    user should be(None)
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val pass = BasicHttpCredentials("x", "y")
+          val user = Await.result(
+            BasicAuthenticationDirective
+              .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+            dbOpTimeout)
+          user should be(None)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Authenticate should not authorize when malformed creds are provided not successful, retrying.."))
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
20:36:13  org.apache.openwhisk.core.controller.test.BasicAuthenticateTests > Authenticate should authorize a known user using different namespaces and cache key, and reject invalid secret STANDARD_OUT
20:36:13      condition not met, retrying
20:36:13  
20:36:13  org.apache.openwhisk.core.controller.test.BasicAuthenticateTests > Authenticate should authorize a known user using different namespaces and cache key, and reject invalid secret FAILED
20:36:13      java.util.NoSuchElementException: None.get
20:36:13          at scala.None$.get(Option.scala:529)
20:36:13          at scala.None$.get(Option.scala:527)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.$anonfun$new$3(BasicAuthenticateTests.scala:73)
20:36:13          at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
20:36:13          at org.scalatest.Assertions.withClue(Assertions.scala:1223)
20:36:13          at org.scalatest.Assertions.withClue$(Assertions.scala:1210)
20:36:13          at org.scalatest.FlatSpec.withClue(FlatSpec.scala:1685)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.$anonfun$new$2(BasicAuthenticateTests.scala:66)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.$anonfun$new$2$adapted(BasicAuthenticateTests.scala:65)
20:36:13          at scala.collection.immutable.Set$Set2.foreach(Set.scala:132)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.$anonfun$new$1(BasicAuthenticateTests.scala:65)
20:36:13          at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
20:36:13          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
20:36:13          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
20:36:13          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
20:36:13          at org.scalatest.Transformer.apply(Transformer.scala:22)
20:36:13          at org.scalatest.Transformer.apply(Transformer.scala:20)
20:36:13          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
20:36:13          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
20:36:13          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
20:36:13          at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1685)
20:36:13          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
20:36:13          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
20:36:13          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
20:36:13          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
20:36:13          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.org$scalatest$BeforeAndAfterEach$$super$runTest(BasicAuthenticateTests.scala:44)
20:36:13          at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:221)
20:36:13          at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:214)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.runTest(BasicAuthenticateTests.scala:44)
20:36:13          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
20:36:13          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
20:36:13          at scala.collection.immutable.List.foreach(List.scala:392)
20:36:13          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
20:36:13          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
20:36:13          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
20:36:13          at scala.collection.immutable.List.foreach(List.scala:392)
20:36:13          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
20:36:13          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
20:36:13          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
20:36:13          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
20:36:13          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
20:36:13          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
20:36:13          at org.scalatest.Suite.run(Suite.scala:1124)
20:36:13          at org.scalatest.Suite.run$(Suite.scala:1106)
20:36:13          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
20:36:13          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
20:36:13          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
20:36:13          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
20:36:13          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.org$scalatest$BeforeAndAfterAll$$super$run(BasicAuthenticateTests.scala:44)
20:36:13          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
20:36:13          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
20:36:13          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
20:36:13          at org.apache.openwhisk.core.controller.test.BasicAuthenticateTests.run(BasicAuthenticateTests.scala:44)
20:36:13  
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

