### PR TITLE
Provide details on DocumentConflictException for CouchDB and do retries in AssetCleaner on 409 for all operations 

### DIFF
--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -213,8 +213,45 @@ trait WskTestHelpers extends Matchers {
                 val rr = cli.sanitize(n)(wskprops)
                 rr.exitCode match {
                   case CONFLICT | StatusCodes.Conflict.intValue =>
+                    org.apache.openwhisk.utils.retry(
+                      {
+                        println(
+                          s"package deletion conflict for $n (details: ${rr.toString}), view computation delay likely, retrying...")
+                        cli.delete(n)(wskprops)
+                      },
+                      5,
+                      Some(1.second))
+                  case _ => rr
+                }
+              case _: ActionOperations if delete =>
+                // sanitize ignores the exit code, so we can inspect the actual result and retry accordingly
+                val rr = cli.sanitize(n)(wskprops)
+                rr.exitCode match {
+                  case CONFLICT | StatusCodes.Conflict.intValue =>
                     org.apache.openwhisk.utils.retry({
-                      println("package deletion conflict, view computation delay likely, retrying...")
+                      println(s"action deletion conflict for $n (details: ${rr.toString}), retrying...")
+                      cli.delete(n)(wskprops)
+                    }, 5, Some(1.second))
+                  case _ => rr
+                }
+              case _: TriggerOperations if delete =>
+                // sanitize ignores the exit code, so we can inspect the actual result and retry accordingly
+                val rr = cli.sanitize(n)(wskprops)
+                rr.exitCode match {
+                  case CONFLICT | StatusCodes.Conflict.intValue =>
+                    org.apache.openwhisk.utils.retry({
+                      println(s"trigger deletion conflict for $n (details: ${rr.toString}), retrying...")
+                      cli.delete(n)(wskprops)
+                    }, 5, Some(1.second))
+                  case _ => rr
+                }
+              case _: RuleOperations if delete =>
+                // sanitize ignores the exit code, so we can inspect the actual result and retry accordingly
+                val rr = cli.sanitize(n)(wskprops)
+                rr.exitCode match {
+                  case CONFLICT | StatusCodes.Conflict.intValue =>
+                    org.apache.openwhisk.utils.retry({
+                      println(s"rule deletion conflict for $n (details: ${rr.toString}), retrying...")
                       cli.delete(n)(wskprops)
                     }, 5, Some(1.second))
                   case _ => rr


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from one of these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

The PR add the error details to the `DocumentConflictException` if 409 errors occur for CouchDB delete requests. It also does retries in the AssetCleaner logic for 409 errors for all asset types/operations.

```
org.apache.openwhisk.core.cli.test.ApiGwRestTests > Wsk api should verify get API name that uses custom package STANDARD_OUT
    Action invokes within last minute: 0
    Action invokes within last minute: 1
    Action invokes within last minute: 2
    exit code = 153
    stdout: {"code":"7320dae4b7e896ee0d86c0ecc5dbde42","error":"Package not empty (contains 1 entity)"}
    stderr: Package not empty (contains 1 entity)
    statusCode: 409 Conflict
    tid: 7320dae4b7e896ee0d86c0ecc5dbde42
    respData: {"code":"7320dae4b7e896ee0d86c0ecc5dbde42","error":"Package not empty (contains 1 entity)"}
```


```
09:19:06      Starting test Wsk Trigger REST should create and fire a trigger with a rule whose action has been deleted at 2020-07-07 03:19:05.157
09:19:12  
09:19:12  system.basic.WskRestBasicTests > Wsk Trigger REST should create and fire a trigger with a rule whose action has been deleted STANDARD_OUT
09:19:12      ERROR: deleting asset failed for r1toa1-1594106345159: org.scalatest.exceptions.TestFailedException: HTTP request or response did not match the Swagger spec.
09:19:12      Request: HttpRequest(HttpMethod(DELETE),https://fn-dev-build.us-south.containers.appdomain.cloud/api/v1/namespaces/_/rules/r1toa1-1594106345159,List(Authorization: Basic OWNmZTU3YTAtN2FjMS00YmY0LTkwMjYtZDdlOWU1OTEyNzFmOnJtYTZxOHlZVU1aS0FmeEpackdtalM5RzBvWWRwS3NvZEJ0ZzVOaDd4SndhcVRyOENvekpVb0FGVDVGSFdqT3I=),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
09:19:12      Response: HttpResponse(409 Conflict,List(Date: Tue, 07 Jul 2020 07:19:11 GMT, Connection: keep-alive, X-Request-ID: a8e9d7aa056326799fa2f443d95864d3, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent, Access-Control-Allow-Methods: GET, DELETE, POST, PUT, HEAD, IBM_Cloud_Functions: OpenWhisk),HttpEntity.Strict(application/json,99 bytes total),HttpProtocol(HTTP/1.1))
09:19:12      Validation Error: ArrayBuffer(ERROR - Response status 409 not defined for path '/namespaces/{namespace}/rules/{ruleName}'.: [])
09:19:12  
09:19:12  system.basic.WskRestBasicTests > Wsk Trigger REST should create and fire a trigger with a rule whose action has been deleted FAILED
09:19:12      org.scalatest.exceptions.TestFailedException: deletedAll was false some assets were not deleted
09:19:12          at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:530)
09:19:12          at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:529)
09:19:12          at org.scalatest.FlatSpec.newAssertionFailedException(FlatSpec.scala:1685)
09:19:12          at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:503)
09:19:12          at common.WskTestHelpers.withAssetCleaner(WskTestHelpers.scala:232)
09:19:12          at common.WskTestHelpers.withAssetCleaner$(WskTestHelpers.scala:193)
09:19:12          at system.basic.WskRestBasicTests.withAssetCleaner(WskRestBasicTests.scala:40)
09:19:12          at system.basic.WskRestBasicTests.$anonfun$new$139(WskRestBasicTests.scala:820)
09:19:12          at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
09:19:12          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
09:19:12          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
09:19:12          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
09:19:12          at org.scalatest.Transformer.apply(Transformer.scala:22)
09:19:12          at org.scalatest.Transformer.apply(Transformer.scala:20)
09:19:12          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
09:19:12          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
09:19:12          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
09:19:12          at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1685)
09:19:12          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
09:19:12          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
09:19:12          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
09:19:12          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
09:19:12          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
09:19:12          at system.basic.WskRestBasicTests.org$scalatest$BeforeAndAfterEachTestData$$super$runTest(WskRestBasicTests.scala:40)
09:19:12          at org.scalatest.BeforeAndAfterEachTestData.runTest(BeforeAndAfterEachTestData.scala:194)
09:19:12          at org.scalatest.BeforeAndAfterEachTestData.runTest$(BeforeAndAfterEachTestData.scala:187)
09:19:12          at system.basic.WskRestBasicTests.runTest(WskRestBasicTests.scala:40)
09:19:12          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
09:19:12          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
09:19:12          at scala.collection.immutable.List.foreach(List.scala:392)
09:19:12          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
09:19:12          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
09:19:12          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
09:19:12          at scala.collection.immutable.List.foreach(List.scala:392)
09:19:12          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
09:19:12          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
09:19:12          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
09:19:12          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
09:19:12          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
09:19:12          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
09:19:12          at org.scalatest.Suite.run(Suite.scala:1124)
09:19:12          at org.scalatest.Suite.run$(Suite.scala:1106)
09:19:12          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
09:19:12          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
09:19:12          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
09:19:12          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
09:19:12          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
09:19:12          at system.basic.WskRestBasicTests.org$scalatest$BeforeAndAfterAll$$super$run(WskRestBasicTests.scala:40)
09:19:12          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
09:19:12          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
09:19:12          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
09:19:12          at system.basic.WskRestBasicTests.run(WskRestBasicTests.scala:40)
09:19:12  
09:19:12  system.basic.WskRestBasicTests STANDARD_OUT
09:19:12  
09:19:12      Finished test Wsk Trigger REST should create and fire a trigger with a rule whose action has been deleted at 2020-07-07 03:19:11.634
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

