### PR TITLE
Retry on failures for all WskRuleTests tests to stabilize mainBluewhisk

### DIFF
--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -29,6 +29,7 @@ import common.RuleActivationResult
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import java.time.Instant
+import scala.concurrent.duration.DurationInt
 
 @RunWith(classOf[JUnitRunner])
 abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
@@ -39,6 +40,9 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
   val secondAction = TestUtils.getTestActionFilename("hello.js")
   val testString = "this is a test"
   val testResult = JsObject("count" -> testString.split(" ").length.toJson)
+
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
 
   /**
    * Sets up trigger -> rule -> action triplets. Deduplicates triggers and rules
@@ -78,309 +82,398 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
   it should "invoke the action attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
-    val ruleName = withTimestamp("r1to1")
-    val triggerName = withTimestamp("t1to1")
-    val actionName = withTimestamp("a1 to 1") // spaces in name intended for greater test coverage
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val ruleName = withTimestamp("r1to1")
+          val triggerName = withTimestamp("t1to1")
+          val actionName = withTimestamp("a1 to 1") // spaces in name intended for greater test coverage
 
-    ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
+          ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
 
-    val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+          val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-    withActivation(wsk.activation, run) { triggerActivation =>
-      triggerActivation.cause shouldBe None
+          withActivation(wsk.activation, run) {
+            triggerActivation =>
+              triggerActivation.cause shouldBe None
 
-      val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-      ruleActivations should have size 1
-      val ruleActivation = ruleActivations.head
-      ruleActivation.success shouldBe true
-      ruleActivation.statusCode shouldBe 0
+              val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+              ruleActivations should have size 1
+              val ruleActivation = ruleActivations.head
+              ruleActivation.success shouldBe true
+              ruleActivation.statusCode shouldBe 0
 
-      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
-        actionActivation.response.result shouldBe Some(testResult)
-        actionActivation.cause shouldBe None
-      }
-    }
+              withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+                actionActivation.response.result shouldBe Some(testResult)
+                actionActivation.cause shouldBe None
+              }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Whisk rules should invoke the action attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
   }
 
   it should "invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
-    val ruleName = withTimestamp("pr1to1")
-    val triggerName = withTimestamp("pt1to1")
-    val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
-    val actionName = withTimestamp("a1 to 1")
-    val pkgActionName = s"$pkgName/$actionName"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val ruleName = withTimestamp("pr1to1")
+          val triggerName = withTimestamp("pt1to1")
+          val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
+          val actionName = withTimestamp("a1 to 1")
+          val pkgActionName = s"$pkgName/$actionName"
 
-    assetHelper.withCleaner(wsk.pkg, pkgName) { (pkg, name) =>
-      pkg.create(name)
-    }
+          assetHelper.withCleaner(wsk.pkg, pkgName) { (pkg, name) =>
+            pkg.create(name)
+          }
 
-    ruleSetup(Seq((ruleName, triggerName, (pkgActionName, pkgActionName, defaultAction))), assetHelper)
+          ruleSetup(Seq((ruleName, triggerName, (pkgActionName, pkgActionName, defaultAction))), assetHelper)
 
-    val now = Instant.now
-    val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+          val now = Instant.now
+          val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-    withActivation(wsk.activation, run) { triggerActivation =>
-      triggerActivation.cause shouldBe None
+          withActivation(wsk.activation, run) {
+            triggerActivation =>
+              triggerActivation.cause shouldBe None
 
-      val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-      ruleActivations should have size 1
-      val ruleActivation = ruleActivations.head
-      ruleActivation.success shouldBe true
-      ruleActivation.statusCode shouldBe 0
+              val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+              ruleActivations should have size 1
+              val ruleActivation = ruleActivations.head
+              ruleActivation.success shouldBe true
+              ruleActivation.statusCode shouldBe 0
 
-      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
-        actionActivation.response.result shouldBe Some(testResult)
-      }
-    }
+              withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+                actionActivation.response.result shouldBe Some(testResult)
+              }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Whisk rules should invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
   }
 
   it should "invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
-    val ruleName = withTimestamp("pr1to1")
-    val triggerName = withTimestamp("pt1to1")
-    val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
-    val pkgBindingName = withTimestamp("rule pkg binding")
-    val actionName = withTimestamp("a1 to 1")
-    val pkgActionName = s"$pkgName/$actionName"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val ruleName = withTimestamp("pr1to1")
+          val triggerName = withTimestamp("pt1to1")
+          val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
+          val pkgBindingName = withTimestamp("rule pkg binding")
+          val actionName = withTimestamp("a1 to 1")
+          val pkgActionName = s"$pkgName/$actionName"
 
-    assetHelper.withCleaner(wsk.pkg, pkgName) { (pkg, name) =>
-      pkg.create(name)
-    }
+          assetHelper.withCleaner(wsk.pkg, pkgName) { (pkg, name) =>
+            pkg.create(name)
+          }
 
-    assetHelper.withCleaner(wsk.pkg, pkgBindingName) { (pkg, name) =>
-      pkg.bind(pkgName, pkgBindingName)
-    }
+          assetHelper.withCleaner(wsk.pkg, pkgBindingName) { (pkg, name) =>
+            pkg.bind(pkgName, pkgBindingName)
+          }
 
-    ruleSetup(Seq((ruleName, triggerName, (pkgActionName, s"$pkgBindingName/$actionName", defaultAction))), assetHelper)
+          ruleSetup(
+            Seq((ruleName, triggerName, (pkgActionName, s"$pkgBindingName/$actionName", defaultAction))),
+            assetHelper)
 
-    val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+          val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-    withActivation(wsk.activation, run) { triggerActivation =>
-      triggerActivation.cause shouldBe None
+          withActivation(wsk.activation, run) {
+            triggerActivation =>
+              triggerActivation.cause shouldBe None
 
-      val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-      ruleActivations should have size 1
-      val ruleActivation = ruleActivations.head
-      ruleActivation.success shouldBe true
-      ruleActivation.statusCode shouldBe 0
+              val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+              ruleActivations should have size 1
+              val ruleActivation = ruleActivations.head
+              ruleActivation.success shouldBe true
+              ruleActivation.statusCode shouldBe 0
 
-      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
-        actionActivation.response.result shouldBe Some(testResult)
-        actionActivation.cause shouldBe None
-      }
-    }
+              withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+                actionActivation.response.result shouldBe Some(testResult)
+                actionActivation.cause shouldBe None
+              }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Whisk rules should invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
   }
 
   it should "not activate an action if the rule is deleted when the trigger is fired" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val ruleName = withTimestamp("ruleDelete")
-      val triggerName = withTimestamp("ruleDeleteTrigger")
-      val actionName = withTimestamp("ruleDeleteAction")
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val ruleName = withTimestamp("ruleDelete")
+            val triggerName = withTimestamp("ruleDeleteTrigger")
+            val actionName = withTimestamp("ruleDeleteAction")
 
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-        trigger.create(name)
-      }
-      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-        action.create(name, Some(defaultAction))
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
-        rule.create(name, triggerName, actionName)
-      }
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+              trigger.create(name)
+            }
+            assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+              action.create(name, Some(defaultAction))
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
+              rule.create(name, triggerName, actionName)
+            }
 
-      val first = wsk.trigger.fire(triggerName, Map("payload" -> "bogus".toJson))
-      wsk.rule.delete(ruleName)
-      val second = wsk.trigger.fire(triggerName, Map("payload" -> "bogus2".toJson))
+            val first = wsk.trigger.fire(triggerName, Map("payload" -> "bogus".toJson))
+            wsk.rule.delete(ruleName)
+            val second = wsk.trigger.fire(triggerName, Map("payload" -> "bogus2".toJson))
 
-      withActivation(wsk.activation, first)(activation => activation.logs.get should have size 1)
-    // there won't be an activation for the second fire since there is no rule
+            withActivation(wsk.activation, first)(activation => activation.logs.get should have size 1)
+            // there won't be an activation for the second fire since there is no rule
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(
+            s"${this.getClass.getName} > Whisk rules should not activate an action if the rule is deleted when the trigger is fired not successful, retrying.."))
   }
 
   it should "enable and disable a rule and check action is activated only when rule is enabled" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
-    val ruleName = withTimestamp("ruleDisable")
-    val triggerName = withTimestamp("ruleDisableTrigger")
-    val actionName = withTimestamp("ruleDisableAction")
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val ruleName = withTimestamp("ruleDisable")
+          val triggerName = withTimestamp("ruleDisableTrigger")
+          val actionName = withTimestamp("ruleDisableAction")
 
-    ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
+          ruleSetup(Seq((ruleName, triggerName, (actionName, actionName, defaultAction))), assetHelper)
 
-    val first = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
-    wsk.rule.disable(ruleName)
-    val second = wsk.trigger.fire(triggerName, Map("payload" -> s"$testString with added words".toJson))
-    wsk.rule.enable(ruleName)
-    val third = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+          val first = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+          wsk.rule.disable(ruleName)
+          val second = wsk.trigger.fire(triggerName, Map("payload" -> s"$testString with added words".toJson))
+          wsk.rule.enable(ruleName)
+          val third = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-    withActivation(wsk.activation, first) { triggerActivation =>
-      val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-      ruleActivations should have size 1
-      val ruleActivation = ruleActivations.head
-      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
-        actionActivation.response.result shouldBe Some(testResult)
-      }
-    }
-
-    // second fire will not write an activation
-
-    withActivation(wsk.activation, third) { triggerActivation =>
-      val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-      ruleActivations should have size 1
-      val ruleActivation = ruleActivations.head
-      withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
-        actionActivation.response.result shouldBe Some(testResult)
-      }
-    }
-  }
-
-  it should "be able to recreate a rule with the same name and match it successfully" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val ruleName = withTimestamp("ruleRecreate")
-      val triggerName1 = withTimestamp("ruleRecreateTrigger1")
-      val triggerName2 = withTimestamp("ruleRecreateTrigger2")
-      val actionName = withTimestamp("ruleRecreateAction")
-
-      assetHelper.withCleaner(wsk.trigger, triggerName1) { (trigger, name) =>
-        trigger.create(name)
-      }
-      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-        action.create(name, Some(defaultAction))
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
-        rule.create(name, triggerName1, actionName)
-      }
-
-      wsk.rule.delete(ruleName)
-
-      assetHelper.withCleaner(wsk.trigger, triggerName2) { (trigger, name) =>
-        trigger.create(name)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-        rule.create(name, triggerName2, actionName)
-      }
-
-      val first = wsk.trigger.fire(triggerName2, Map("payload" -> testString.toJson))
-      withActivation(wsk.activation, first) { triggerActivation =>
-        val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-        ruleActivations should have size 1
-        val ruleActivation = ruleActivations.head
-        withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
-          actionActivation.response.result shouldBe Some(testResult)
-        }
-      }
-  }
-
-  it should "connect two triggers via rules to one action and activate it accordingly" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val triggerName1 = withTimestamp("t2to1a")
-      val triggerName2 = withTimestamp("t2to1b")
-      val actionName = withTimestamp("a2to1")
-
-      ruleSetup(
-        Seq(
-          ("r2to1a", triggerName1, (actionName, actionName, defaultAction)),
-          ("r2to1b", triggerName2, (actionName, actionName, defaultAction))),
-        assetHelper)
-
-      val testPayloads = Seq("got three words", "got four words, period")
-      val runs = testPayloads.map(payload => wsk.trigger.fire(triggerName1, Map("payload" -> payload.toJson)))
-
-      runs.zip(testPayloads).foreach {
-        case (run, payload) =>
-          withActivation(wsk.activation, run) { triggerActivation =>
+          withActivation(wsk.activation, first) { triggerActivation =>
             val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
             ruleActivations should have size 1
             val ruleActivation = ruleActivations.head
             withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
-              actionActivation.response.result shouldBe Some(JsObject("count" -> payload.split(" ").length.toJson))
+              actionActivation.response.result shouldBe Some(testResult)
             }
           }
-      }
+
+          // second fire will not write an activation
+
+          withActivation(wsk.activation, third) { triggerActivation =>
+            val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+            ruleActivations should have size 1
+            val ruleActivation = ruleActivations.head
+            withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+              actionActivation.response.result shouldBe Some(testResult)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Whisk rules should enable and disable a rule and check action is activated only when rule is enabled not successful, retrying.."))
+  }
+
+  it should "be able to recreate a rule with the same name and match it successfully" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val ruleName = withTimestamp("ruleRecreate")
+            val triggerName1 = withTimestamp("ruleRecreateTrigger1")
+            val triggerName2 = withTimestamp("ruleRecreateTrigger2")
+            val actionName = withTimestamp("ruleRecreateAction")
+
+            assetHelper.withCleaner(wsk.trigger, triggerName1) { (trigger, name) =>
+              trigger.create(name)
+            }
+            assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+              action.create(name, Some(defaultAction))
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
+              rule.create(name, triggerName1, actionName)
+            }
+
+            wsk.rule.delete(ruleName)
+
+            assetHelper.withCleaner(wsk.trigger, triggerName2) { (trigger, name) =>
+              trigger.create(name)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+              rule.create(name, triggerName2, actionName)
+            }
+
+            val first = wsk.trigger.fire(triggerName2, Map("payload" -> testString.toJson))
+            withActivation(wsk.activation, first) { triggerActivation =>
+              val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+              ruleActivations should have size 1
+              val ruleActivation = ruleActivations.head
+              withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+                actionActivation.response.result shouldBe Some(testResult)
+              }
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(
+            s"${this.getClass.getName} > Whisk rules should be able to recreate a rule with the same name and match it successfully not successful, retrying.."))
+  }
+
+  it should "connect two triggers via rules to one action and activate it accordingly" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val triggerName1 = withTimestamp("t2to1a")
+            val triggerName2 = withTimestamp("t2to1b")
+            val actionName = withTimestamp("a2to1")
+
+            ruleSetup(
+              Seq(
+                ("r2to1a", triggerName1, (actionName, actionName, defaultAction)),
+                ("r2to1b", triggerName2, (actionName, actionName, defaultAction))),
+              assetHelper)
+
+            val testPayloads = Seq("got three words", "got four words, period")
+            val runs = testPayloads.map(payload => wsk.trigger.fire(triggerName1, Map("payload" -> payload.toJson)))
+
+            runs.zip(testPayloads).foreach {
+              case (run, payload) =>
+                withActivation(wsk.activation, run) { triggerActivation =>
+                  val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+                  ruleActivations should have size 1
+                  val ruleActivation = ruleActivations.head
+                  withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
+                    actionActivation.response.result shouldBe Some(
+                      JsObject("count" -> payload.split(" ").length.toJson))
+                  }
+                }
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(
+            s"${this.getClass.getName} > Whisk rules should connect two triggers via rules to one action and activate it accordingly not successful, retrying.."))
   }
 
   it should "connect one trigger to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val triggerName = withTimestamp("t1to2")
-      val actionName1 = withTimestamp("a1to2a")
-      val actionName2 = withTimestamp("a1to2b")
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val triggerName = withTimestamp("t1to2")
+            val actionName1 = withTimestamp("a1to2a")
+            val actionName2 = withTimestamp("a1to2b")
 
-      ruleSetup(
-        Seq(
-          ("r1to2a", triggerName, (actionName1, actionName1, defaultAction)),
-          ("r1to2b", triggerName, (actionName2, actionName2, secondAction))),
-        assetHelper)
+            ruleSetup(
+              Seq(
+                ("r1to2a", triggerName, (actionName1, actionName1, defaultAction)),
+                ("r1to2b", triggerName, (actionName2, actionName2, secondAction))),
+              assetHelper)
 
-      val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
+            val run = wsk.trigger.fire(triggerName, Map("payload" -> testString.toJson))
 
-      withActivation(wsk.activation, run) { triggerActivation =>
-        val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-        ruleActivations should have size 2
+            withActivation(wsk.activation, run) {
+              triggerActivation =>
+                val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+                ruleActivations should have size 2
 
-        val action1Result = ruleActivations.find(_.action.contains(actionName1)).get
-        val action2Result = ruleActivations.find(_.action.contains(actionName2)).get
+                val action1Result = ruleActivations.find(_.action.contains(actionName1)).get
+                val action2Result = ruleActivations.find(_.action.contains(actionName2)).get
 
-        withActivation(wsk.activation, action1Result.activationId) { actionActivation =>
-          actionActivation.response.result shouldBe Some(testResult)
-        }
-        withActivation(wsk.activation, action2Result.activationId) { actionActivation =>
-          actionActivation.logs.get.mkString(" ") should include(s"hello, $testString")
-        }
-      }
+                withActivation(wsk.activation, action1Result.activationId) { actionActivation =>
+                  actionActivation.response.result shouldBe Some(testResult)
+                }
+                withActivation(wsk.activation, action2Result.activationId) { actionActivation =>
+                  actionActivation.logs.get.mkString(" ") should include(s"hello, $testString")
+                }
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(
+            s"${this.getClass.getName} > Whisk rules should connect one trigger to two different actions, invoking them both eventually not successful, retrying.."))
   }
 
   it should "connect two triggers to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val triggerName1 = withTimestamp("t1to1a")
-      val triggerName2 = withTimestamp("t1to1b")
-      val actionName1 = withTimestamp("a1to1a")
-      val actionName2 = withTimestamp("a1to1b")
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val triggerName1 = withTimestamp("t1to1a")
+            val triggerName2 = withTimestamp("t1to1b")
+            val actionName1 = withTimestamp("a1to1a")
+            val actionName2 = withTimestamp("a1to1b")
 
-      ruleSetup(
-        Seq(
-          ("r2to2a", triggerName1, (actionName1, actionName1, defaultAction)),
-          ("r2to2b", triggerName1, (actionName2, actionName2, secondAction)),
-          ("r2to2c", triggerName2, (actionName1, actionName1, defaultAction)),
-          ("r2to2d", triggerName2, (actionName2, actionName2, secondAction))),
-        assetHelper)
+            ruleSetup(
+              Seq(
+                ("r2to2a", triggerName1, (actionName1, actionName1, defaultAction)),
+                ("r2to2b", triggerName1, (actionName2, actionName2, secondAction)),
+                ("r2to2c", triggerName2, (actionName1, actionName1, defaultAction)),
+                ("r2to2d", triggerName2, (actionName2, actionName2, secondAction))),
+              assetHelper)
 
-      val testPayloads = Seq("got three words", "got four words, period")
-      val runs = Seq(triggerName1, triggerName2).zip(testPayloads).map {
-        case (trigger, payload) =>
-          payload -> wsk.trigger.fire(trigger, Map("payload" -> payload.toJson))
-      }
-
-      runs.foreach {
-        case (payload, run) =>
-          withActivation(wsk.activation, run) { triggerActivation =>
-            val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
-            ruleActivations should have size 2 // each trigger has 2 actions attached
-
-            val action1Result = ruleActivations.find(_.action.contains(actionName1)).get
-            val action2Result = ruleActivations.find(_.action.contains(actionName2)).get
-
-            withActivation(wsk.activation, action1Result.activationId) { actionActivation =>
-              actionActivation.response.result shouldBe Some(JsObject("count" -> payload.split(" ").length.toJson))
+            val testPayloads = Seq("got three words", "got four words, period")
+            val runs = Seq(triggerName1, triggerName2).zip(testPayloads).map {
+              case (trigger, payload) =>
+                payload -> wsk.trigger.fire(trigger, Map("payload" -> payload.toJson))
             }
-            withActivation(wsk.activation, action2Result.activationId) { actionActivation =>
-              actionActivation.logs.get.mkString(" ") should include(s"hello, $payload")
+
+            runs.foreach {
+              case (payload, run) =>
+                withActivation(wsk.activation, run) {
+                  triggerActivation =>
+                    val ruleActivations = triggerActivation.logs.get.map(_.parseJson.convertTo[RuleActivationResult])
+                    ruleActivations should have size 2 // each trigger has 2 actions attached
+
+                    val action1Result = ruleActivations.find(_.action.contains(actionName1)).get
+                    val action2Result = ruleActivations.find(_.action.contains(actionName2)).get
+
+                    withActivation(wsk.activation, action1Result.activationId) { actionActivation =>
+                      actionActivation.response.result shouldBe Some(
+                        JsObject("count" -> payload.split(" ").length.toJson))
+                    }
+                    withActivation(wsk.activation, action2Result.activationId) { actionActivation =>
+                      actionActivation.logs.get.mkString(" ") should include(s"hello, $payload")
+                    }
+                }
             }
-          }
-      }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(
+            s"${this.getClass.getName} > Whisk rules should connect two triggers to two different actions, invoking them both eventually not successful, retrying.."))
   }
 
   it should "disable a rule and check its status is displayed when listed" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val ruleName = withTimestamp("ruleDisable")
-      val ruleName2 = withTimestamp("ruleEnable")
-      val triggerName = withTimestamp("ruleDisableTrigger")
-      val actionName = withTimestamp("ruleDisableAction")
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            val ruleName = withTimestamp("ruleDisable")
+            val ruleName2 = withTimestamp("ruleEnable")
+            val triggerName = withTimestamp("ruleDisableTrigger")
+            val actionName = withTimestamp("ruleDisableAction")
 
-      ruleSetup(
-        Seq(
-          (ruleName, triggerName, (actionName, actionName, defaultAction)),
-          (ruleName2, triggerName, (actionName, actionName, defaultAction))),
-        assetHelper)
+            ruleSetup(
+              Seq(
+                (ruleName, triggerName, (actionName, actionName, defaultAction)),
+                (ruleName2, triggerName, (actionName, actionName, defaultAction))),
+              assetHelper)
 
-      wsk.rule.disable(ruleName)
-      val ruleListResult = wsk.rule.list()
-      verifyRuleList(ruleListResult, ruleName2, ruleName)
+            wsk.rule.disable(ruleName)
+            val ruleListResult = wsk.rule.list()
+            verifyRuleList(ruleListResult, ruleName2, ruleName)
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(
+            s"${this.getClass.getName} > Whisk rules should disable a rule and check its status is displayed when listed not successful, retrying.."))
   }
 
   def verifyRuleList(ruleListResult: RunResult, ruleNameEnable: String, ruleName: String) = {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds.

```
00:34:43      Starting test Whisk rules should disable a rule and check its status is displayed when listed at 2020-07-08 18:34:43.027
00:34:47  
00:34:47  system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed STANDARD_OUT
00:34:47      Exception occurred during test execution: org.scalatest.exceptions.TestFailedException: false was not equal to true
00:34:47  
00:34:47  system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed STANDARD_ERROR
00:34:47      org.scalatest.exceptions.TestFailedException: false was not equal to true
00:34:47      	at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
00:34:47      	at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6919)
00:34:47      	at system.basic.WskRestRuleTests.verifyRuleList(WskRestRuleTests.scala:48)
00:34:47      	at system.basic.WskRuleTests.$anonfun$new$69(WskRuleTests.scala:383)
00:34:47      	at common.WskTestHelpers.withAssetCleaner(WskTestHelpers.scala:198)
00:34:47      	at common.WskTestHelpers.withAssetCleaner$(WskTestHelpers.scala:193)
00:34:47      	at system.basic.WskRuleTests.withAssetCleaner(WskRuleTests.scala:34)
00:34:47      	at system.basic.WskRuleTests.$anonfun$new$68(WskRuleTests.scala:369)
00:34:47      	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
00:34:47      	at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
00:34:47      	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
00:34:47      	at org.scalatest.Transformer.apply(Transformer.scala:22)
00:34:47      	at org.scalatest.Transformer.apply(Transformer.scala:20)
00:34:47      	at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
00:34:47      	at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
00:34:47      	at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
00:34:47      	at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1685)
00:34:47      	at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
00:34:47      	at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
00:34:47      	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
00:34:47      	at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
00:34:47      	at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
00:34:47      	at system.basic.WskRuleTests.org$scalatest$BeforeAndAfterEachTestData$$super$runTest(WskRuleTests.scala:34)
00:34:47      	at org.scalatest.BeforeAndAfterEachTestData.runTest(BeforeAndAfterEachTestData.scala:194)
00:34:47      	at org.scalatest.BeforeAndAfterEachTestData.runTest$(BeforeAndAfterEachTestData.scala:187)
00:34:47      	at system.basic.WskRuleTests.runTest(WskRuleTests.scala:34)
00:34:47      	at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
00:34:47      	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
00:34:47      	at scala.collection.immutable.List.foreach(List.scala:392)
00:34:47      	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
00:34:47      	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
00:34:47      	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
00:34:47      	at scala.collection.immutable.List.foreach(List.scala:392)
00:34:47      	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
00:34:47      	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
00:34:47      	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
00:34:47      	at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
00:34:47      	at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
00:34:47      	at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
00:34:47      	at org.scalatest.Suite.run(Suite.scala:1124)
00:34:47      	at org.scalatest.Suite.run$(Suite.scala:1106)
00:34:47      	at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
00:34:47      	at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
00:34:47      	at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
00:34:47      	at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
00:34:47      	at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
00:34:47      	at system.basic.WskRestRuleTests.org$scalatest$BeforeAndAfterAll$$super$run(WskRestRuleTests.scala:36)
00:34:47      	at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
00:34:47      	at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
00:34:47      	at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
00:34:47      	at system.basic.WskRestRuleTests.run(WskRestRuleTests.scala:36)
00:34:47      	at org.scalatest.junit.JUnitRunner.run(JUnitRunner.scala:100)
00:34:47      	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
00:34:47      	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
00:34:47      	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
00:34:47      	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
00:34:47      	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
00:34:47      	at sun.reflect.GeneratedMethodAccessor190.invoke(Unknown Source)
00:34:47      	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
00:34:47      	at java.lang.reflect.Method.invoke(Method.java:498)
00:34:47      	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
00:34:47      	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
00:34:47      	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
00:34:47      	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
00:34:47      	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
00:34:47      	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
00:34:47      	at sun.reflect.GeneratedMethodAccessor189.invoke(Unknown Source)
00:34:47      	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
00:34:47      	at java.lang.reflect.Method.invoke(Method.java:498)
00:34:47      	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
00:34:47      	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
00:34:47      	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:175)
00:34:47      	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:157)
00:34:47      	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
00:34:47      	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
00:34:47      	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
00:34:47      	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
00:34:47      	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
00:34:47      	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
00:34:47      	at java.lang.Thread.run(Thread.java:748)
00:34:48  
00:34:48  system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed FAILED
00:34:48      org.scalatest.exceptions.TestFailedException: false was not equal to true
00:34:48          at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
00:34:48          at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6919)
00:34:48          at system.basic.WskRestRuleTests.verifyRuleList(WskRestRuleTests.scala:48)
00:34:48          at system.basic.WskRuleTests.$anonfun$new$69(WskRuleTests.scala:383)
00:34:48          at common.WskTestHelpers.withAssetCleaner(WskTestHelpers.scala:198)
00:34:48          at common.WskTestHelpers.withAssetCleaner$(WskTestHelpers.scala:193)
00:34:48          at system.basic.WskRuleTests.withAssetCleaner(WskRuleTests.scala:34)
00:34:48          at system.basic.WskRuleTests.$anonfun$new$68(WskRuleTests.scala:369)
00:34:48          at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
00:34:48          at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
00:34:48          at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
00:34:48          at org.scalatest.Transformer.apply(Transformer.scala:22)
00:34:48          at org.scalatest.Transformer.apply(Transformer.scala:20)
00:34:48          at org.scalatest.FlatSpecLike$$anon$5.apply(FlatSpecLike.scala:1682)
00:34:48          at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
00:34:48          at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
00:34:48          at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1685)
00:34:48          at org.scalatest.FlatSpecLike.invokeWithFixture$1(FlatSpecLike.scala:1680)
00:34:48          at org.scalatest.FlatSpecLike.$anonfun$runTest$1(FlatSpecLike.scala:1692)
00:34:48          at org.scalatest.SuperEngine.runTestImpl(Engine.scala:286)
00:34:48          at org.scalatest.FlatSpecLike.runTest(FlatSpecLike.scala:1692)
00:34:48          at org.scalatest.FlatSpecLike.runTest$(FlatSpecLike.scala:1674)
00:34:48          at system.basic.WskRuleTests.org$scalatest$BeforeAndAfterEachTestData$$super$runTest(WskRuleTests.scala:34)
00:34:48          at org.scalatest.BeforeAndAfterEachTestData.runTest(BeforeAndAfterEachTestData.scala:194)
00:34:48          at org.scalatest.BeforeAndAfterEachTestData.runTest$(BeforeAndAfterEachTestData.scala:187)
00:34:48          at system.basic.WskRuleTests.runTest(WskRuleTests.scala:34)
00:34:48          at org.scalatest.FlatSpecLike.$anonfun$runTests$1(FlatSpecLike.scala:1750)
00:34:48          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:393)
00:34:48          at scala.collection.immutable.List.foreach(List.scala:392)
00:34:48          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
00:34:48          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:370)
00:34:48          at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:407)
00:34:48          at scala.collection.immutable.List.foreach(List.scala:392)
00:34:48          at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:381)
00:34:48          at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:376)
00:34:48          at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:458)
00:34:48          at org.scalatest.FlatSpecLike.runTests(FlatSpecLike.scala:1750)
00:34:48          at org.scalatest.FlatSpecLike.runTests$(FlatSpecLike.scala:1749)
00:34:48          at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
00:34:48          at org.scalatest.Suite.run(Suite.scala:1124)
00:34:48          at org.scalatest.Suite.run$(Suite.scala:1106)
00:34:48          at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
00:34:48          at org.scalatest.FlatSpecLike.$anonfun$run$1(FlatSpecLike.scala:1795)
00:34:48          at org.scalatest.SuperEngine.runImpl(Engine.scala:518)
00:34:48          at org.scalatest.FlatSpecLike.run(FlatSpecLike.scala:1795)
00:34:48          at org.scalatest.FlatSpecLike.run$(FlatSpecLike.scala:1793)
00:34:48          at system.basic.WskRestRuleTests.org$scalatest$BeforeAndAfterAll$$super$run(WskRestRuleTests.scala:36)
00:34:48          at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
00:34:48          at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
00:34:48          at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
00:34:48          at system.basic.WskRestRuleTests.run(WskRestRuleTests.scala:36)
00:34:48  
00:34:48  system.basic.WskRestRuleTests STANDARD_OUT
00:34:48  
00:34:48      Finished test Whisk rules should disable a rule and check its status is displayed when listed at 2020-07-08 18:34:48.137 
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

