### PR TITLE
Provide activation id in response error payload of web actions that time out

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/WebActions.scala
@@ -55,6 +55,7 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.types._
 import org.apache.openwhisk.core.loadBalancer.LoadBalancerException
 import org.apache.openwhisk.http.ErrorResponse.terminate
+import org.apache.openwhisk.http.ErrorResponseWithActivationId.terminateWithActivationId
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.http.LenientSprayJsonSupport._
 import org.apache.openwhisk.spi.SpiLoader
@@ -762,7 +763,7 @@ trait WhiskWebActionsApi
         // this should not happen, instead it should be a blocking invoke timeout
         logging.debug(this, "activation waiting period expired")
         respondWithActivationIdHeader(activationId) {
-          terminate(Accepted, Messages.responseNotReady)
+          terminateWithActivationId(Accepted, Messages.responseNotReady, activationId.toString)
         }
 
       case Failure(t: RejectRequest) => terminate(t.code, t.message)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
@@ -349,6 +349,19 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
     error.fields.get("code").get shouldBe an[JsString]
   }
 
+  def confirmErrorWithTidAndAid(error: JsObject, message: Option[String] = None) = {
+    println(s"error: $error")
+    error.fields.size shouldBe 3
+    error.fields.get("error") shouldBe defined
+    message.foreach { m =>
+      error.fields.get("error").get shouldBe JsString(m)
+    }
+    error.fields.get("code") shouldBe defined
+    error.fields.get("code").get shouldBe an[JsString]
+    error.fields.get("activationId") shouldBe defined
+    error.fields.get("activationId").get shouldBe an[JsString]
+  }
+
   Seq(None, Some(WhiskAuthHelpers.newIdentity())).foreach { creds =>
     it should s"not match invalid routes (auth? ${creds.isDefined})" in {
       implicit val tid = transid()
@@ -481,7 +494,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
         m(s"$testRoutePath/$systemId/proxy/export_c.json") ~> Route.seal(routes(creds)) ~> check {
           status should be(Accepted)
           val response = responseAs[JsObject]
-          confirmErrorWithTid(response, Some("Response not yet ready."))
+          confirmErrorWithTidAndAid(response, Some("Response not yet ready."))
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Provide the activation id in response error payload of web actions that time out

## Description
When invoking an action, there are two modes possible, blocking or non-blocking.
The default for regular action invocations is 'non-blocking', for web actions it is blocking.
Blocking invocations use a request-response style and wait for the activation result to be available.
The wait period is the lesser of 60 seconds or the action's timeout limit.
At the end of the wait period (i.e. after 60 sec), ALL invocations will switch to non-blocking and instead of the result they return the activation id such as
```
{
  "activationId": "27eca80056d54f93aca80056d5cf93b9"
}
```
If an invocation of a web action reaches the end of wait period, the response will just show the transaction id and an indication that the request is returned, but the action continues to run.
```
{
  "code": "7744082c6a0d2d579786547023602357",
  "error": "Response not yet ready."
}
```
In addition, independent on the invocation type, the HTTP response header field x-openwhisk-activation-id is set to the activation id of the invocation.

In order to be more consistent this code change adds the activation id to the response error payload for web actions that times out.
```
{
  "activationId": "27eca80056d54f93aca80056d5cf93b9",
  "code": "7744082c6a0d2d579786547023602357",
  "error": "Response not yet ready."
}
```

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

