### PR TITLE
Log first two characters of EK key in case of an error

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
@@ -122,13 +122,13 @@ object Identity extends MultipleReadersSingleWriterCache[Option[Identity], DocIn
                 val len = authkey.key.key.length
                 logger.info(
                   this,
-                  s"$viewName[${authkey.uuid},${authkey.key.key.substring(0, if (len > 1) 2 else len)}..] does not exist, user might have been deleted")
+                  s"$viewName[spaceguid:${authkey.uuid}, userkey:${authkey.key.key.substring(0, if (len > 1) 2 else len)}..] does not exist, user might have been deleted")
                 None
               case _ =>
                 val len = authkey.key.key.length
                 logger.error(
                   this,
-                  s"$viewName[${authkey.uuid},${authkey.key.key.substring(0, if (len > 1) 2 else len)}..] is not unique")
+                  s"$viewName[spaceguid:${authkey.uuid}, userkey:${authkey.key.key.substring(0, if (len > 1) 2 else len)}..] is not unique")
                 throw new IllegalStateException("uuid is not unique")
             }
         }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
@@ -113,17 +113,24 @@ object Identity extends MultipleReadersSingleWriterCache[Option[Identity], DocIn
 
     cacheLookup(
       CacheKey(authkey), {
-        list(datastore, List(authkey.uuid.asString, authkey.key.asString)) map { list =>
-          list.length match {
-            case 1 =>
-              Some(rowToIdentity(list.head, authkey.uuid.asString))
-            case 0 =>
-              logger.info(this, s"$viewName[${authkey.uuid}] does not exist")
-              None
-            case _ =>
-              logger.error(this, s"$viewName[${authkey.uuid}] is not unique")
-              throw new IllegalStateException("uuid is not unique")
-          }
+        list(datastore, List(authkey.uuid.asString, authkey.key.asString)) map {
+          list =>
+            list.length match {
+              case 1 =>
+                Some(rowToIdentity(list.head, authkey.uuid.asString))
+              case 0 =>
+                val len = authkey.key.key.length
+                logger.info(
+                  this,
+                  s"$viewName[${authkey.uuid},${authkey.key.key.substring(0, if (len > 1) 2 else len)}..] does not exist, user might have been deleted")
+                None
+              case _ =>
+                val len = authkey.key.key.length
+                logger.error(
+                  this,
+                  s"$viewName[${authkey.uuid},${authkey.key.key.substring(0, if (len > 1) 2 else len)}..] is not unique")
+                throw new IllegalStateException("uuid is not unique")
+            }
         }
       }).map(_.getOrElse(throw new NoDocumentException("namespace does not exist")))
   }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Log first two characters of EK key in case passed identity cannot be found in identities view

## Description
We recently received a severity 1 ticket where the customer complained that his trigger didn't work anymore.
After some debugging we found out that the passed identity was no longer valid. 
In order to support the error analysis the code now logs also the first two characters of the EK key in case it cannot be found and the authentication fails.
 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

