### PR TITLE
Disable invoker supervision for crudcontrollers

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -238,6 +238,7 @@
       "METRICS_KAMON": "{{ metrics.kamon.enabled | default(false) | lower }}"
       "METRICS_KAMON_TAGS": "{{ metrics.kamon.tags | default() | lower }}"
       "METRICS_LOG": "{{ metrics.log.enabled | default(false) | lower }}"
+      "CONFIG_whisk_controller_name": "controller"
       "CONFIG_whisk_controller_protocol": "{{ controller.protocol }}"
       "CONFIG_whisk_controller_https_keystorePath":
         "/conf/{{ controller.ssl.keystore.name }}"

--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -238,7 +238,7 @@
       "METRICS_KAMON": "{{ metrics.kamon.enabled | default(false) | lower }}"
       "METRICS_KAMON_TAGS": "{{ metrics.kamon.tags | default() | lower }}"
       "METRICS_LOG": "{{ metrics.log.enabled | default(false) | lower }}"
-      "CONFIG_whisk_controller_name": "controller"
+      "CONTROLLER_NAME": "controller"
       "CONFIG_whisk_controller_protocol": "{{ controller.protocol }}"
       "CONFIG_whisk_controller_https_keystorePath":
         "/conf/{{ controller.ssl.keystore.name }}"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -66,6 +66,7 @@ class WhiskConfig(requiredProperties: Map[String, String],
       s"${this(WhiskConfig.wskApiProtocol)}://${this(WhiskConfig.wskApiHostname)}:${this(WhiskConfig.wskApiPort)}"))
     .getOrElse("")
 
+  val controllerName = this(WhiskConfig.controllerName)
   val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
 
   val edgeHost = this(WhiskConfig.edgeHostName) + ":" + this(WhiskConfig.edgeHostApiPort)
@@ -167,6 +168,7 @@ object WhiskConfig {
 
   val mainDockerEndpoint = "main.docker.endpoint"
 
+  val controllerName = "controller.name"
   val controllerBlackboxFraction = "controller.blackboxFraction"
   val dbInstances = "db.instances"
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -177,7 +177,6 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
       case Success(p: PingMessage) =>
         self ! p
         invokerPingFeed ! MessageFeed.Processed
-        logging.info(this, s"@StR succeeded processing message: $raw with $p")
 
       case Failure(t) =>
         invokerPingFeed ! MessageFeed.Processed

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -177,6 +177,7 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
       case Success(p: PingMessage) =>
         self ! p
         invokerPingFeed ! MessageFeed.Processed
+        logging.info(this, s"@StR succeeded processing message: $raw with $p")
 
       case Failure(t) =>
         invokerPingFeed ! MessageFeed.Processed

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -338,7 +338,8 @@ object ShardingContainerPoolBalancer extends LoadBalancerProvider {
     logging: Logging,
     materializer: ActorMaterializer): LoadBalancer = {
 
-    logging.info(this, s"@StR controller name: ${whiskConfig.controllerName}")(TransactionId.controller)
+    logging.info(this, s"@StR whisk config: $whiskConfig, controller name: ${whiskConfig.controllerName}")(
+      TransactionId.controller)
 
     val invokerPoolFactory = new InvokerPoolFactory {
       override def createInvokerPool(
@@ -368,7 +369,9 @@ object ShardingContainerPoolBalancer extends LoadBalancerProvider {
       invokerPoolFactory)
   }
 
-  def requiredProperties: Map[String, String] = kafkaHosts
+  def requiredProperties: Map[String, String] =
+    kafkaHosts ++
+      Map(WhiskConfig.controllerName -> null)
 
   /** Generates a hash based on the string representation of namespace and action */
   def generateHash(namespace: EntityName, action: FullyQualifiedEntityName): Int = {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -338,8 +338,7 @@ object ShardingContainerPoolBalancer extends LoadBalancerProvider {
     logging: Logging,
     materializer: ActorMaterializer): LoadBalancer = {
 
-    logging.info(this, s"@StR whisk config: $whiskConfig, controller name: ${whiskConfig.controllerName}")(
-      TransactionId.controller)
+    logging.info(this, s"controller name: ${whiskConfig.controllerName}")(TransactionId.controller)
 
     val invokerPoolFactory = new InvokerPoolFactory {
       override def createInvokerPool(


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Disable invoker supervision for crudcontrollers

## Description
One reason for overloading invokers ( `rescheduling Run message, too many message in the pool`) is the fact that the crudcontrollers are also sending health actions to the invokers as the behave as regular controllers, which is NOT considered in the bookkeeping of the regular controllers. Usually this should not hurt, but in high load scenarios it could make the situation worse. For crudcontrollers this is not needed! .. and should be 'switched off' (based on discussion in [#whisk-teams](https://ibm-argonauts.slack.com/archives/GA651JS2F/p1601637587011200?thread_ts=1601478109.006700&cid=GA651JS2F))

With this PR the following changes are done:
- Define an additional controller environment property `controller.name` set to `controller` or `crudcontroller` respectively to be able to differentiate between two controller types
- Create a dummy actor (`ActorRef.noSender`) for crudcontrollers to disable the sending of health messages

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).