### PR TITLE
Log how much memory is still available on the chosen invoker per invocation

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -304,7 +304,7 @@ class ShardingContainerPoolBalancer(
             s"mem limit ${memoryLimit.megabytes} MB (${memoryLimitInfo}), " +
             s"time limit ${timeLimit.duration.toMillis} ms (${timeLimitInfo}) " +
             s"to ${invoker} " +
-            s"(${schedulingState.invokerSlots(invoker.instance).availablePermits} of ${invoker.userMemory.toMB} MB free)")
+            s"(${schedulingState.invokerSlots(invoker.instance).availablePermits} of ${invoker.userMemory.toMB / schedulingState.clusterSize} MB free)")
         val activationResult = setupActivation(msg, action, invoker)
         sendActivationToInvoker(messageProducer, msg, invoker).map(_ => activationResult)
       }
@@ -337,12 +337,12 @@ class ShardingContainerPoolBalancer(
     logging.info(
       this,
       s"released activation ${entry.id}, " +
-        s"action '${entry.fullyQualifiedEntityName.name}' ('${if (entry.isBlackbox) "blackbox" else "managed"}'), " +
+        s"action '${entry.fullyQualifiedEntityName}' ('${if (entry.isBlackbox) "blackbox" else "managed"}'), " +
         s"ns '${entry.fullyQualifiedEntityName.namespace}', " +
-        s"mem limit ${entry.memoryLimit.toMB} MB), " +
-        s"time limit ${entry.timeLimit} ms) " +
-        s"to ${invoker} " +
-        s"(${schedulingState.invokerSlots(invoker.instance).availablePermits} of ${invoker.userMemory.toMB} MB free)")
+        s"mem limit ${entry.memoryLimit.toMB} MB, " +
+        s"time limit ${entry.timeLimit.toMillis} ms " +
+        s"from ${invoker} " +
+        s"(${schedulingState.invokerSlots(invoker.instance).availablePermits} of ${invoker.userMemory.toMB / schedulingState.clusterSize} MB free)")
   }
 }
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -334,7 +334,7 @@ class ShardingContainerPoolBalancer(
     schedulingState.invokerSlots
       .lift(invoker.toInt)
       .foreach(_.releaseConcurrent(entry.fullyQualifiedEntityName, entry.maxConcurrent, entry.memoryLimit.toMB.toInt))
-    logging.info(
+    logging.debug(
       this,
       s"released activation ${entry.id}, " +
         s"action '${entry.fullyQualifiedEntityName}' ('${if (entry.isBlackbox) "blackbox" else "managed"}'), " +

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -182,6 +182,20 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
               // Try to process the next item in buffer (or get another message from feed, if buffer is now empty)
               processBufferOrFeed()
             }
+
+            logging.info(
+              this,
+              s"@StR Going to schedule Run message, " +
+                s"activation: ${r.msg.activationId}, " +
+                s"action: ${r.msg.action.name}, " +
+                s"ns: ${r.msg.action.namespace}, " +
+                s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
+                s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
+                s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +
+                s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}, " +
+                s"needed memory: ${r.action.limits.memory.megabytes} MB, " +
+                s"waiting messages: ${runBuffer.size}")(r.msg.transid)
+
             actor ! r // forwards the run request to the container
             logContainerStart(r, containerState, newData.activeActivationCount, container)
           case None =>
@@ -193,6 +207,9 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
               logging.warn(
                 this,
                 s"Rescheduling Run message, too many message in the pool, " +
+                  s"activation: ${r.msg.activationId}, " +
+                  s"action: ${r.msg.action.name}, " +
+                  s"ns: ${r.msg.action.namespace}, " +
                   s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
                   s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
                   s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -182,20 +182,6 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
               // Try to process the next item in buffer (or get another message from feed, if buffer is now empty)
               processBufferOrFeed()
             }
-
-            logging.info(
-              this,
-              s"@StR Going to schedule Run message, " +
-                s"activation: ${r.msg.activationId}, " +
-                s"action: ${r.msg.action.name}, " +
-                s"ns: ${r.msg.action.namespace}, " +
-                s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
-                s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
-                s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +
-                s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}, " +
-                s"needed memory: ${r.action.limits.memory.megabytes} MB, " +
-                s"waiting messages: ${runBuffer.size}")(r.msg.transid)
-
             actor ! r // forwards the run request to the container
             logContainerStart(r, containerState, newData.activeActivationCount, container)
           case None =>
@@ -208,8 +194,6 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
                 this,
                 s"Rescheduling Run message, too many message in the pool, " +
                   s"activation: ${r.msg.activationId}, " +
-                  s"action: ${r.msg.action.name}, " +
-                  s"ns: ${r.msg.action.namespace}, " +
                   s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
                   s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
                   s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +


### PR DESCRIPTION
Log how much memory is still available on the chosen invoker per invocation

## Description
As we still see `rescheduling Run message, too many message in the pool` for no obvious reason this is to log more details to further analyze the situation.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation