### PR TITLE
Consider second controller for too many (concurrent) requests errors

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/ActivationThrottler.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/ActivationThrottler.scala
@@ -58,17 +58,17 @@ sealed trait RateLimit {
 case class ConcurrentRateLimit(count: Int, allowed: Int, clusterSize: Int) extends RateLimit {
   val ok: Boolean = count < allowed // must have slack for the current activation request
   val allowedNoOvercommit = if (clusterSize > 1) Math.ceil(allowed.toDouble / 1.2).toInt else allowed
-  val countSecondCluster = if (clusterSize > 1) allowedNoOvercommit else 0
+  val countOtherControllers = allowedNoOvercommit * (clusterSize - 1)
   override def errorMsg: String =
-    Messages.tooManyConcurrentRequests(count + countSecondCluster, allowedNoOvercommit * clusterSize)
+    Messages.tooManyConcurrentRequests(count + countOtherControllers, allowedNoOvercommit * clusterSize)
   val limitName: String = "ConcurrentRateLimit"
 }
 
 case class TimedRateLimit(count: Int, allowed: Int, clusterSize: Int) extends RateLimit {
   val ok: Boolean = count <= allowed // the count is already updated to account for the current request
   val allowedNoOvercommit = if (clusterSize > 1) Math.ceil(allowed.toDouble / 1.2).toInt else allowed
-  val countSecondCluster = if (clusterSize > 1) allowedNoOvercommit else 0
+  val countOtherControllers = allowedNoOvercommit * (clusterSize - 1)
   override def errorMsg: String =
-    Messages.tooManyRequests(count + countSecondCluster, allowedNoOvercommit * clusterSize)
+    Messages.tooManyRequests(count + countOtherControllers, allowedNoOvercommit * clusterSize)
   val limitName: String = "TimedRateLimit"
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
@@ -135,10 +135,12 @@ protected[core] abstract class EntitlementProvider(
 
   private val invokeRateThrottler =
     new RateThrottler(
+      loadBalancer,
       "actions per minute",
       calculateIndividualLimit(config.actionInvokePerMinuteLimit.toInt, _.limits.invocationsPerMinute))
   private val triggerRateThrottler =
     new RateThrottler(
+      loadBalancer,
       "triggers per minute",
       calculateIndividualLimit(config.triggerFirePerMinuteLimit.toInt, _.limits.firesPerMinute))
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/RateThrottler.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/RateThrottler.scala
@@ -50,7 +50,7 @@ class RateThrottler(loadBalancer: LoadBalancer, description: String, maxPerMinut
     val uuid = user.namespace.uuid // this is namespace identifier
     val throttle = rateMap.getOrElseUpdate(uuid, new RateInfo)
     val limit = maxPerMinute(user)
-    val rate = TimedRateLimit(throttle.update(limit), limit, loadBalancer.clusterSize)
+    val rate = TimedRateLimit(throttle.update(limit), limit, loadBalancer.clusterSize.max(1))
     logging.debug(this, s"namespace = ${uuid.asString} rate = ${rate.count}, limit = $limit")
     rate
   }

--- a/tests/src/test/scala/limits/ThrottleTests.scala
+++ b/tests/src/test/scala/limits/ThrottleTests.scala
@@ -437,7 +437,7 @@ class NamespaceSpecificThrottleTests
             }
             results.map(_.exitCode) should contain(TestUtils.THROTTLED)
             results.map(_.stderr).mkString should {
-              include(prefix(tooManyRequests(0, 0))) and include("allowed: 1")
+              include(prefix(tooManyRequests(0, 0))) and include("allowed: 2")
             }
           }, 2, Some(1.second))
 
@@ -450,7 +450,7 @@ class NamespaceSpecificThrottleTests
             }
             results.map(_.exitCode) should contain(TestUtils.THROTTLED)
             results.map(_.stderr).mkString should {
-              include(prefix(tooManyRequests(0, 0))) and include("allowed: 1")
+              include(prefix(tooManyRequests(0, 0))) and include("allowed: 2")
             }
           }, 2, Some(1.second))
         },
@@ -494,7 +494,7 @@ class NamespaceSpecificThrottleTests
           }
           results.map(_.exitCode) should contain(TestUtils.THROTTLED)
           results.map(_.stderr).mkString should {
-            include(prefix(tooManyRequests(0, 0))) and include("allowed: 1")
+            include(prefix(tooManyRequests(0, 0))) and include("allowed: 2")
           }
         }, 2, Some(1.second))
       },

--- a/tests/src/test/scala/limits/ThrottleTests.scala
+++ b/tests/src/test/scala/limits/ThrottleTests.scala
@@ -427,6 +427,8 @@ class NamespaceSpecificThrottleTests
           }
 
           val deployedControllers = WhiskProperties.getControllerHosts.split(",").length
+          System.out.println(
+            s"deployedControllers: ${WhiskProperties.getControllerHosts.split(",")}, count: $deployedControllers")
 
           // One invoke should be allowed, the second one throttled.
           // Due to the current implementation of the rate throttling,
@@ -437,7 +439,7 @@ class NamespaceSpecificThrottleTests
             }
             results.map(_.exitCode) should contain(TestUtils.THROTTLED)
             results.map(_.stderr).mkString should {
-              include(prefix(tooManyRequests(0, 0))) and include("allowed: 2")
+              include(prefix(tooManyRequests(0, 0))) and include(s"allowed: $deployedControllers")
             }
           }, 2, Some(1.second))
 
@@ -450,7 +452,7 @@ class NamespaceSpecificThrottleTests
             }
             results.map(_.exitCode) should contain(TestUtils.THROTTLED)
             results.map(_.stderr).mkString should {
-              include(prefix(tooManyRequests(0, 0))) and include("allowed: 2")
+              include(prefix(tooManyRequests(0, 0))) and include(s"allowed: $deployedControllers")
             }
           }, 2, Some(1.second))
         },
@@ -479,6 +481,8 @@ class NamespaceSpecificThrottleTests
         }
 
         val deployedControllers = WhiskProperties.getControllerHosts.split(",").length
+        System.out.println(
+          s"deployedControllers: ${WhiskProperties.getControllerHosts.split(",")}, count: $deployedControllers")
 
         // One invoke should be allowed.
         wsk.action
@@ -494,7 +498,7 @@ class NamespaceSpecificThrottleTests
           }
           results.map(_.exitCode) should contain(TestUtils.THROTTLED)
           results.map(_.stderr).mkString should {
-            include(prefix(tooManyRequests(0, 0))) and include("allowed: 2")
+            include(prefix(tooManyRequests(0, 0))) and include(s"allowed: $deployedControllers")
           }
         }, 2, Some(1.second))
       },


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Consider second controller for `Too many (concurrent) requests` messages.

## Description
Today the response provided by the API/CLI is misleading because it's indicating that e.g. the default limit of invocations per minute is 3000, which is actually not the case. The reason is that the limit is spread over/enforced by 2 controller in the cluster where each controller maintains the half + 10% overhead. For a limit of 5000 for invocations per minute this leads to (5000 + 20%)/#controller = 6000/2 = *3000*

The code change in this PR addresses this problem by taking the number (2) of controller in the cluster into account. As the number of requests handled by the other controller is not known by the controller that returns the error in case the limit is violated the count value in the error is still not 100% accurate. However the assumption is that at the time of the error the second controller has handled a least 50% of the guaranteed number of requests. This should be guaranteed as the code allows 20% of additional requests on top of the limit to mitigate possible unfair round-robin loadbalancing between both controllers. The count returned in the error will be therefore the sum of the number of requests handled by the controller raising the error and half of the limit assumed to be handled by the second controller. 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).