### PR TITLE
Fix testcase to also accept nodejs:12 as default.

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
@@ -493,7 +493,7 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
   it should "initialize exec manifest" in {
     val runtimes = ExecManifest.runtimesManifest
     val kind = runtimes.resolveDefaultRuntime("nodejs:default").get.kind
-    Some(kind) should contain oneOf ("nodejs:6", "nodejs:8", "nodejs:10")
+    Some(kind) should contain oneOf ("nodejs:6", "nodejs:8", "nodejs:10", "nodejs:12")
   }
 
   it should "properly deserialize and reserialize JSON" in {


### PR DESCRIPTION
Fix testcase to also accept `nodejs:12` as a nodejs default runtime, too.

## Description
The test `initialize exec manifest` did not accept `nodejs:12` as default runtime and failed in this case.
This change now modifies the test to also accept `nodejs:12` as the default nodejs runtime.

## Related issue and scope
- [x] none

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.
