### PR TITLE
Always calculate half of the capacity

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -504,7 +504,7 @@ case class ShardingContainerPoolBalancerState(
    * @return calculated invoker slot
    */
   private def getInvokerSlot(memory: ByteSize): ByteSize = {
-    val invokerShardMemorySize = memory / _clusterSize
+    val invokerShardMemorySize = memory / (_clusterSize max 2) // if cluster size < 2 calculate half of the invoker capacity anyway
     val newTreshold = if (invokerShardMemorySize < MemoryLimit.MIN_MEMORY) {
       logging.error(
         this,


### PR DESCRIPTION
Consider always half the invoker slot capacity

## Description
Consider only half of the invoker slot capacity also if akka cluster is temporary fallen apart (split brain). Intention is to avoid that both controller work with the full invoker capacity in case of a split brain situation which leads to invoker overloads (rescheduling run messages).

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation