### PR TITLE
[AT] AT logs to cover responses with status >= 400 on action/trigger POST 

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
@@ -310,7 +310,8 @@ trait ActivityUtils {
         null
       else {
         val method = if (httpMethod == null) "UNKNOWN" else httpMethod.toUpperCase
-        if (isCrudController) // code is running as crudController
+        // code is running as crudController
+        if (isCrudController)
           matchAPI(transid, "action", actionsAPIMatcher, method, urlPath, reasonCode) // actions API
             .getOrElse(
               matchAPI(transid, "package", packagesAPIMatcher, method, urlPath, reasonCode) // packages API
@@ -319,11 +320,16 @@ trait ActivityUtils {
                     .getOrElse(
                       matchAPI(transid, "trigger", triggersAPIMatcher, method, urlPath, reasonCode) // triggers API
                         .getOrElse(matchOther(transid, method, urlPath, logger).orNull)))) // nothing to add to the log
-        else // code is running  as controller (handles POST rule API call for enable/disable rule)
-          matchFailedActionInvocation(transid, "action", actionsAPIMatcher, method, urlPath, reasonCode) // actions API
+        else {
+          // code is running  as controller
+          // (e.g., handles POST rule API call for enable/disable rule, runs invocations (POST) of actions and triggers)
+          // we only want to log failed invocations of actions and triggers
+          matchFailedInvocation(transid, "action", actionsAPIMatcher, method, urlPath, reasonCode) // actions API
             .getOrElse(
-              matchRulesAPI(transid, method, urlPath, logger, reasonCode) // rules API
-                .getOrElse(matchOther(transid, method, urlPath, logger).orNull)) // nothing to add to the log
+              matchFailedInvocation(transid, "trigger", triggersAPIMatcher, method, urlPath, reasonCode) // actions API
+                .getOrElse(matchRulesAPI(transid, method, urlPath, logger, reasonCode) // rules API
+                  .getOrElse(matchOther(transid, method, urlPath, logger).orNull)))
+        } // nothing to add to the log
       }
     }
   }
@@ -469,7 +475,7 @@ trait ActivityUtils {
   }
 
   /**
-   * a matcher for failed action invocations (we do not log successful invocations)
+   * a matcher for failed invocations (we do not log successful invocations)
    *
    * @param transid transaction id
    * @param entityType action, trigger, package
@@ -478,12 +484,12 @@ trait ActivityUtils {
    * @param uri uri of the request
    * @return Some(ApiMatcherResult) or None
    */
-  def matchFailedActionInvocation(transid: TransactionId,
-                                  entityType: String,
-                                  matcher: Regex,
-                                  method: String,
-                                  uri: String,
-                                  reasonCode: String): Option[ApiMatcherResult] = {
+  def matchFailedInvocation(transid: TransactionId,
+                            entityType: String,
+                            matcher: Regex,
+                            method: String,
+                            uri: String,
+                            reasonCode: String): Option[ApiMatcherResult] = {
 
     // ignored: invoke action, list all actions
     val entityTypePathSelector = entityType + "s" // plural of entityType

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivityEvent.scala
@@ -320,9 +320,10 @@ trait ActivityUtils {
                       matchAPI(transid, "trigger", triggersAPIMatcher, method, urlPath, reasonCode) // triggers API
                         .getOrElse(matchOther(transid, method, urlPath, logger).orNull)))) // nothing to add to the log
         else // code is running  as controller (handles POST rule API call for enable/disable rule)
-          matchRulesAPI(transid, method, urlPath, logger, reasonCode) // rules API
-            .getOrElse(matchOther(transid, method, urlPath, logger).orNull) // nothing to add to the log
-
+          matchFailedActionInvocation(transid, "action", actionsAPIMatcher, method, urlPath, reasonCode) // actions API
+            .getOrElse(
+              matchRulesAPI(transid, method, urlPath, logger, reasonCode) // rules API
+                .getOrElse(matchOther(transid, method, urlPath, logger).orNull)) // nothing to add to the log
       }
     }
   }
@@ -441,7 +442,7 @@ trait ActivityUtils {
                 targetType = targetType,
                 severity = adjustSeverityByReasonCode(reasonCode, severity_normal)))
           case "PUT" =>
-            val isUpdate = !transid.getTag(TransactionId.tagUpdateInfo).isEmpty
+            val isUpdate = transid.getTag(TransactionId.tagUpdateInfo).nonEmpty
             val operation = if (isUpdate) "update" else "create"
             Some(
               ApiMatcherResult(
@@ -460,6 +461,52 @@ trait ActivityUtils {
                 targetName = targetName,
                 targetType = targetType,
                 severity = adjustSeverityByReasonCode(reasonCode, severity_critical)))
+          case _ => None
+        }
+      case _ =>
+        None
+    }
+  }
+
+  /**
+   * a matcher for failed action invocations (we do not log successful invocations)
+   *
+   * @param transid transaction id
+   * @param entityType action, trigger, package
+   * @param matcher actionsAPIMatcher, packagesAPIMatcher, triggersAPIMatcher
+   * @param method http method of the request
+   * @param uri uri of the request
+   * @return Some(ApiMatcherResult) or None
+   */
+  def matchFailedActionInvocation(transid: TransactionId,
+                                  entityType: String,
+                                  matcher: Regex,
+                                  method: String,
+                                  uri: String,
+                                  reasonCode: String): Option[ApiMatcherResult] = {
+
+    // ignored: invoke action, list all actions
+    val entityTypePathSelector = entityType + "s" // plural of entityType
+    val targetType = prefixTypeURI + entityType
+    val actionTypePrefix = thisService + "." + entityType
+    val targetIdentifier = entityType + "Name"
+
+    uri match {
+      case matcher() =>
+        val pos = uri.indexOf("/" + entityTypePathSelector + "/") + ("/" + entityTypePathSelector + "/").length
+        val targetName = uri.substring(pos)
+        method match {
+          case "POST" =>
+            if ((Array("action", "trigger") contains entityType) && Try { reasonCode.toInt }.getOrElse(0) >= 400) {
+              Some(
+                ApiMatcherResult(
+                  actionType = actionTypePrefix + ".activate",
+                  logMessage = messagePrefix + "activate " + entityType + " " + targetName,
+                  targetIdentifier = targetIdentifier,
+                  targetName = targetName,
+                  targetType = targetType,
+                  severity = adjustSeverityByReasonCode(reasonCode, severity_critical)))
+            } else None
           case _ => None
         }
       case _ =>
@@ -497,7 +544,7 @@ trait ActivityUtils {
                 targetType = targetType,
                 severity = adjustSeverityByReasonCode(reasonCode, severity_normal)))
           case "PUT" =>
-            val isUpdate = !transid.getTag(TransactionId.tagUpdateInfo).isEmpty
+            val isUpdate = transid.getTag(TransactionId.tagUpdateInfo).nonEmpty
             val operation = if (isUpdate) "update" else "create"
             Some(
               ApiMatcherResult(

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -1144,6 +1144,7 @@ class ActivityTrackerTests()
     val reasonType = getReasonType(reasonCode.toString)
     val entityName = "hello123"
     val entityType = "action"
+    val entityTypePlural = entityType + "s"
     val namespace = "a88c0a24-853b-4477-82f8-6876e72bebf2"
     val account = "eb2e36585c91a27a709c44e2652a381a"
     val resourceGroup = "ca23a1a3f0a84e2ab6b70c22ec6b1324"
@@ -1152,9 +1153,10 @@ class ActivityTrackerTests()
     val ipAdress = "192.168.0.1"
     val region = "us-south"
     val agent = "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"
+    val targetId = s"crn:v1:bluemix:public:functions:$region:a/$account::$namespace::"
 
     val url =
-      s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/$entityName"
+      s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/$entityTypePlural/$entityName"
 
     val settings = Seq(
       (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
@@ -1165,7 +1167,7 @@ class ActivityTrackerTests()
       (TransactionId.tagNamespaceId, namespace),
       (TransactionId.tagRequestedStatus, ""), // only filled for rules
       (TransactionId.tagResourceGroupId, resourceGroup),
-      (TransactionId.tagTargetId, "crn:v1:bluemix:public:functions:us-south:a/" + account + "::" + namespace + "::"),
+      (TransactionId.tagTargetId, targetId),
       (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
       (TransactionId.tagUri, url),
       (TransactionId.tagUserAgent, agent))
@@ -1197,7 +1199,7 @@ class ActivityTrackerTests()
   "eventTime": "2021-02-22T01:17:18.85+0000",
   "message": "Functions: activate $entityType $entityName for namespace $namespace -failure",
   "target": {
-    "id": "crn:v1:bluemix:public:functions:$region:a/$account::$namespace::",
+    "id": "$targetId",
     "name": "",
     "typeURI": "functions/namespace/$entityType"
   },
@@ -1225,7 +1227,7 @@ class ActivityTrackerTests()
     verifyEvent(eventString, expectedString)
   }
 
-  it should "create no event for firing a trigger (controller)" in {
+  it should "create no event for firing a trigger in case of success (controller)" in {
 
     var eventString: String = null
 
@@ -1262,6 +1264,106 @@ class ActivityTrackerTests()
     Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
 
     eventString shouldBe null
+  }
+
+  it should "create an event for firing a trigger in case of a failure (controller)" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def getIsCrudController: Boolean = false
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    val method = "POST"
+    val reasonCode = 401
+    val reasonType = getReasonType(reasonCode.toString)
+    val entityName = "hello123"
+    val entityType = "trigger"
+    val entityTapePlural = entityType + "s"
+    val namespace = "a88c0a24-853b-4477-82f8-6876e72bebf2"
+    val account = "eb2e36585c91a27a709c44e2652a381a"
+    val resourceGroup = "ca23a1a3f0a84e2ab6b70c22ec6b1324"
+    val initiatorId = "IBMid-310000GN7M"
+    val initiator = "john.doe@acme.com"
+    val ipAdress = "192.168.0.1"
+    val region = "us-south"
+    val agent = "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"
+    val targetId = s"crn:v1:bluemix:public:functions:$region:a/$account::$namespace::"
+
+    val url =
+      s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/$entityTapePlural/$entityName"
+
+    val settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, method),
+      (TransactionId.tagInitiatorId, initiatorId),
+      (TransactionId.tagInitiatorIp, ipAdress),
+      (TransactionId.tagInitiatorName, initiator),
+      (TransactionId.tagNamespaceId, namespace),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, resourceGroup),
+      (TransactionId.tagTargetId, targetId),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (TransactionId.tagUri, url),
+      (TransactionId.tagUserAgent, agent))
+
+    val transid = TransactionId("test_api")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.Unauthorized)), waitTime)
+
+    val expectedString = s"""
+{
+  "requestData": {
+    "requestId": "test_api",
+    "method": "$method",
+    "url": "https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/triggers/hello123",
+    "triggerName": "hello123"
+  },
+  "observer": {
+    "name": "ActivityTracker"
+  },
+  "resourceGroupId": "crn:v1:bluemix:public:resource-controller:global:a/$account::resource-group:$resourceGroup",
+  "outcome": "failure",
+  "saveServiceCopy": true,
+  "reason": {
+    "reasonCode": $reasonCode,
+    "reasonType": "$reasonType",
+    "reasonForFailure": "$reasonType"
+  },
+  "eventTime": "2021-02-22T17:37:50.05+0000",
+  "message": "Functions: activate $entityType $entityName for namespace $namespace -failure",
+  "target": {
+    "id": "$targetId",
+    "name": "",
+    "typeURI": "functions/namespace/$entityType"
+  },
+  "severity": "critical",
+  "logSourceCRN": "crn:v1:bluemix:public:functions:us-south:a/$account:::",
+  "action": "functions.$entityType.activate",
+  "initiator": {
+    "name": "$initiator",
+    "host": {
+      "address": "$ipAdress",
+      "addressType": "IPv4",
+      "agent": "$agent"
+    },
+    "id": "$initiatorId",
+    "typeURI": "service/security/account/user",
+    "credential": {
+      "type": "apikey"
+    }
+  },
+  "dataEvent": true,
+  "responseData": {}
+}
+"""
+
+    verifyEvent(eventString, expectedString)
   }
 
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivityTrackerTests.scala
@@ -1088,7 +1088,7 @@ class ActivityTrackerTests()
     }
   }
 
-  it should "create no event for an action invocation (controller)" in {
+  it should "create no event for a successful action invocation (controller)" in {
 
     var eventString: String = null
 
@@ -1125,6 +1125,104 @@ class ActivityTrackerTests()
     Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.OK)), waitTime)
 
     eventString shouldBe null
+  }
+
+  it should "create an event for a failed action invocation (controller)" in {
+
+    var eventString: String = null
+
+    val activityTracker = new ActivityTracker(actorSystem, materializer, logging) {
+      override def isActive = true
+      override def getIsCrudController: Boolean = false
+      override def store(line: String): Unit = {
+        eventString = line
+      }
+    }
+
+    val method = "POST"
+    val reasonCode = 401
+    val reasonType = getReasonType(reasonCode.toString)
+    val entityName = "hello123"
+    val entityType = "action"
+    val namespace = "a88c0a24-853b-4477-82f8-6876e72bebf2"
+    val account = "eb2e36585c91a27a709c44e2652a381a"
+    val resourceGroup = "ca23a1a3f0a84e2ab6b70c22ec6b1324"
+    val initiatorId = "IBMid-310000GN7M"
+    val initiator = "john.doe@acme.com"
+    val ipAdress = "192.168.0.1"
+    val region = "us-south"
+    val agent = "CloudFunctions-Plugin/1.0 (2020-03-27T16:04:13+00:00) darwin amd64"
+
+    val url =
+      s"https://fn-dev-pg4.us-south.containers.appdomain.cloud/api/v1/namespaces/_/actions/$entityName"
+
+    val settings = Seq(
+      (TransactionId.tagGrantType, "urn:ibm:params:oauth:grant-type:apikey"),
+      (TransactionId.tagHttpMethod, method),
+      (TransactionId.tagInitiatorId, initiatorId),
+      (TransactionId.tagInitiatorIp, ipAdress),
+      (TransactionId.tagInitiatorName, initiator),
+      (TransactionId.tagNamespaceId, namespace),
+      (TransactionId.tagRequestedStatus, ""), // only filled for rules
+      (TransactionId.tagResourceGroupId, resourceGroup),
+      (TransactionId.tagTargetId, "crn:v1:bluemix:public:functions:us-south:a/" + account + "::" + namespace + "::"),
+      (TransactionId.tagTargetIdEncoded, ""), // only filled for BasicAuth (in this case tagTargetId is empty)
+      (TransactionId.tagUri, url),
+      (TransactionId.tagUserAgent, agent))
+
+    val transid = TransactionId("test_api")
+    for (setting <- settings) transid.setTag(setting._1, setting._2)
+
+    Await.result(activityTracker.responseHandlerAsync(transid, HttpResponse(StatusCodes.Unauthorized)), waitTime)
+
+    val expectedString = s"""
+  {
+  "requestData": {
+    "method": "$method",
+    "url": "$url",
+    "actionName": "$entityName",
+    "requestId": "test_api"
+  },
+  "observer": {
+    "name": "ActivityTracker"
+  },
+  "resourceGroupId": "crn:v1:bluemix:public:resource-controller:global:a/$account::resource-group:$resourceGroup",
+  "outcome": "failure",
+  "saveServiceCopy": true,
+  "reason": {
+    "reasonCode": $reasonCode,
+    "reasonType": "$reasonType",
+    "reasonForFailure": "$reasonType"
+  },
+  "eventTime": "2021-02-22T01:17:18.85+0000",
+  "message": "Functions: activate $entityType $entityName for namespace $namespace -failure",
+  "target": {
+    "id": "crn:v1:bluemix:public:functions:$region:a/$account::$namespace::",
+    "name": "",
+    "typeURI": "functions/namespace/$entityType"
+  },
+  "severity": "critical",
+  "logSourceCRN": "crn:v1:bluemix:public:functions:$region:a/$account:::",
+  "action": "functions.$entityType.activate",
+  "initiator": {
+    "name": "$initiator",
+    "host": {
+      "address": "$ipAdress",
+      "addressType": "IPv4",
+      "agent": "$agent"
+    },
+    "id": "$initiatorId",
+    "typeURI": "service/security/account/user",
+    "credential": {
+      "type": "apikey"
+    }
+  },
+  "dataEvent": true,
+  "responseData": {}
+}
+"""
+
+    verifyEvent(eventString, expectedString)
   }
 
   it should "create no event for firing a trigger (controller)" in {


### PR DESCRIPTION
AT logs to cover responses with status >= 400 on action/trigger POST

## Description
Failed action/trigger POSTs are logged now as `functions.action.activate` failures

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).
