### PR TITLE
Make WskAdminTests independent of python unicode literal

### DIFF
--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -255,8 +255,8 @@ trait WskTestHelpers extends Matchers {
     wsk: ActivationOperations,
     run: RunResult,
     initialWait: Duration = 1.second,
-    pollPeriod: Duration = 1.second,
-    totalWait: Duration = 60.seconds)(check: ActivationResult => Unit)(implicit wskprops: WskProps): Unit = {
+    pollPeriod: Duration = 3.second,
+    totalWait: Duration = 180.seconds)(check: ActivationResult => Unit)(implicit wskprops: WskProps): Unit = {
     val activationId = wsk.extractActivationId(run)
 
     withClue(s"did not find an activation id in '$run'") {

--- a/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
@@ -325,7 +325,10 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
             // check correctly set
             val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.linesIterator.toSeq
             lines should have size 1
-            lines(0) shouldBe "allowedKinds = [u'nodejs:6', u'blackbox']"
+            lines(0).split(",") should have size 2
+            lines(0) should startWith("allowedKinds =")
+            lines(0) should include("nodejs:6")
+            lines(0) should include("blackbox")
           } finally {
             wskadmin.cli(Seq("limits", "delete", subject)).stdout should include("Limits deleted")
           }


### PR DESCRIPTION
Make test for strings (`allowedKinds`) independent of existence of Python unicode literal (`u'`).

## Description
Test should work independent if the Python unicode literal does exists as part of the string or not. 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation