### PR TITLE
Disable controller pings by blacklisting invoker

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -161,7 +161,7 @@ class InvokerReactive(
       case Success(set) => {
         logging.info(this, s"updated blacklist to ${set.size} entries")
         if (set.contains(instance.displayedName.getOrElse(""))) {
-          logging.info(this, s"invoker ${instance.toString} is blacklisted, no controller pings will be done")
+          logging.info(this, s"invoker ${instance.toString} is blacklisted, no controller pings will be sent")
         }
       }
       case Failure(t) => logging.error(this, s"error on updating the blacklist: ${t.getMessage}")

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -215,9 +215,6 @@ class InvokerReactive(
   private val pool =
     actorSystem.actorOf(ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs))
 
-  private val namespaceWhiskSystem = "whisk.system"
-  private val actionInvokerHealthTest = "invokerHealthTestAction"
-
   /** Is called when an ActivationMessage is read from Kafka */
   def processActivationMessage(bytes: Array[Byte]): Future[Unit] = {
     Future(ActivationMessage.parse(new String(bytes, StandardCharsets.UTF_8)))

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -227,7 +227,7 @@ class InvokerReactive(
         WhiskTracerProvider.tracer.setTraceContext(transid, msg.traceContext)
 
         logging.info(this, s"${msg.user.subject} ${msg.user.namespace.name} ${msg.action.name} ${msg.activationId}")
-        if (namespaceBlacklist.isBlacklisted(EntityName(instance.uniqueName.getOrElse(""))) && msg.user.namespace.name == namespaceWhiskSystem && msg.action.name.asString
+        if (namespaceBlacklist.isBlacklisted(EntityName(instance.uniqueName.getOrElse(""))) && msg.user.namespace.name.asString == namespaceWhiskSystem && msg.action.name.asString
               .startsWith(actionInvokerHealthTest)) {
           activationFeed ! MessageFeed.Processed
           logging.warn(

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
@@ -19,7 +19,7 @@ package org.apache.openwhisk.core.invoker
 
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.database.StaleParameter
-import org.apache.openwhisk.core.entity.{Identity, View}
+import org.apache.openwhisk.core.entity.{EntityName, Identity, View}
 import org.apache.openwhisk.core.entity.types.AuthStore
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,6 +45,14 @@ class NamespaceBlacklist(authStore: AuthStore) {
    * @return whether or not the current identity is considered blacklisted
    */
   def isBlacklisted(identity: Identity): Boolean = blacklist.contains(identity.namespace.name.asString)
+
+  /**
+    * Check if the namespace, for which the activation is invoked, is in the blacklist.
+    *
+    * @param namespace for which the action is invoked.
+    * @return whether or not the current namespace is considered blacklisted
+    */
+  def isBlacklisted(name: EntityName): Boolean = blacklist.contains(name.asString)
 
   /** Refreshes the current blacklist from the database. */
   /** Limit query parameter set to 0 for limitless record query. */

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
@@ -47,11 +47,11 @@ class NamespaceBlacklist(authStore: AuthStore) {
   def isBlacklisted(identity: Identity): Boolean = blacklist.contains(identity.namespace.name.asString)
 
   /**
-    * Check if the namespace, for which the activation is invoked, is in the blacklist.
-    *
-    * @param namespace for which the action is invoked.
-    * @return whether or not the current namespace is considered blacklisted
-    */
+   * Check if the namespace, for which the activation is invoked, is in the blacklist.
+   *
+   * @param namespace for which the action is invoked.
+   * @return whether or not the current namespace is considered blacklisted
+   */
   def isBlacklisted(name: EntityName): Boolean = blacklist.contains(name.asString)
 
   /** Refreshes the current blacklist from the database. */


### PR DESCRIPTION
Blacklist invoker controller pings using same means as blacklisting namespaces

## Description
Blacklist controller pings sent every second to to inform controllers about general availability/healthiness using same means as blacklisting namespaces

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation