### PR TITLE
Retry on testcase failures

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/utils/Retry.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/utils/Retry.scala
@@ -40,6 +40,11 @@ object retry {
 
     try fn
     catch {
+      case t: Throwable if N > 1 =>
+        println(s"caught exception: ${t.getMessage}")
+        retryMessage.foreach(println)
+        waitBeforeRetry.foreach(t => Thread.sleep(t.toMillis))
+        retry(fn, N - 1, waitBeforeRetry, retryMessage)
       case _ if N > 1 =>
         retryMessage.foreach(println)
         waitBeforeRetry.foreach(t => Thread.sleep(t.toMillis))

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -46,8 +46,12 @@ import scala.language.postfixOps
 @RunWith(classOf[JUnitRunner])
 class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
 
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
+
   /** Packages API tests */
-  behavior of "Packages API"
+  var behaviorname = "Packages API"
+  behavior of s"$behaviorname"
 
   val creds = WhiskAuthHelpers.newIdentity()
   val namespace = EntityPath(creds.subject.asString)
@@ -72,10 +76,12 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   //// GET /packages
-  it should "list all packages/references" in {
+  var testname = "list all packages/references"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           // create packages and package bindings, and confirm API lists all of them
           val providers = (1 to 4).map { i =>
@@ -109,15 +115,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should list all packages/references not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "list all public packages in explicit namespace excluding bindings" in {
+  testname = "list all public packages in explicit namespace excluding bindings"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           // create packages and package bindings, set some public and confirm API lists only public packages
           val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
@@ -161,16 +169,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should list all public packages in explicit namespace excluding bindings not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when limit is greater than maximum allowed value" in {
+  testname = "reject list when limit is greater than maximum allowed value"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val exceededMaxLimit = Collection.MAX_LIST_LIMIT + 1
           val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
@@ -180,13 +189,13 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject list when limit is greater than maximum allowed value not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when limit is not an integer" in {
+  testname = "reject list when limit is not an integer"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
@@ -199,16 +208,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject list when limit is not an integer not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when skip is negative" in {
+  testname = "reject list when skip is negative"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val negativeSkip = -1
           val response = Get(s"$collectionPath?skip=$negativeSkip") ~> Route.seal(routes(creds)) ~> check {
@@ -218,16 +228,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject list when skip is negative not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when skip is not an integer" in {
+  testname = "reject list when skip is not an integer"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val notAnInteger = "string"
           val response = Get(s"$collectionPath?skip=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
@@ -237,16 +248,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject list when skip is not an integer not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  ignore should "list all public packages excluding bindings" in {
+  testname = "list all public packages excluding bindings"
+  ignore should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           // create packages and package bindings, set some public and confirm API lists only public packages
           val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
@@ -273,14 +285,14 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             } should be(true)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should list all public packages excluding bindings not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   // ?public disabled
-  ignore should "list all public packages including ones with same name but in different namespaces" in {
+  testname = "list all public packages including ones with same name but in different namespaces"
+  ignore should s"$testname" in {
     implicit val tid = transid()
     // create packages and package bindings, set some public and confirm API lists only public packages
     val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
@@ -305,10 +317,12 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   // confirm ?public disabled
-  it should "ignore ?public on list all packages" in {
+  testname = "ignore ?public on list all packages"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           Get(s"$collectionPath?public=true") ~> Route.seal(routes(creds)) ~> check {
             implicit val tid = transid()
@@ -335,10 +349,9 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should ignore ?public on list all packages not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   // ?public disabled
@@ -350,10 +363,12 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   //// GET /packages/name
-  it should "get package" in {
+  testname = "get package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname(), None)
           put(entityStore, provider)
@@ -363,15 +378,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response should be(provider withActions ())
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should get package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "get package with updated field" in {
+  testname = "get package with updated field"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname(), None)
           put(entityStore, provider)
@@ -385,16 +402,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response should be(provider copy (updated = pkg.updated) withActions ())
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should get package with updated field not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "get package reference for private package in same namespace" in {
+  testname = "get package reference for private package in same namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname(), None, Parameters("a", "A") ++ Parameters("b", "B"))
           val reference = WhiskPackage(namespace, aname(), provider.bind, Parameters("b", "b") ++ Parameters("c", "C"))
@@ -408,16 +426,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response.wp.parameters should be(Parameters("a", "A") ++ Parameters("b", "b") ++ Parameters("c", "C"))
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should get package reference for private package in same namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not get package reference for a private package in other namespace" in {
+  testname = "not get package reference for a private package in other namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val privateCreds = WhiskAuthHelpers.newIdentity()
           val privateNamespace = EntityPath(privateCreds.subject.asString)
@@ -430,16 +449,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(Forbidden)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should not get package reference for a private package in other namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "get package with its actions and feeds" in {
+  testname = "get package with its actions and feeds"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
@@ -464,16 +484,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response should be(provider withActions (List(action, feed)))
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should get package with its actions and feeds not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "get package reference with its actions and feeds" in {
+  testname = "get package reference with its actions and feeds"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val reference = WhiskPackage(namespace, aname(), provider.bind)
@@ -503,16 +524,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response should be(reference withActions List(action, feed))
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should get package reference with its actions and feeds not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not get package reference with its actions and feeds from private package" in {
+  testname = "not get package reference with its actions and feeds from private package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val privateCreds = WhiskAuthHelpers.newIdentity()
           val privateNamespace = EntityPath(privateCreds.subject.asString)
@@ -539,17 +561,18 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(Forbidden)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should not get package reference with its actions and feeds from private package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// PUT /packages/name
-  it should "create package" in {
+  testname = "create package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname(), None, annotations = Parameters("a", "b"))
           // binding annotation should be removed
@@ -562,15 +585,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             checkWhiskEntityResponse(response, provider)
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should create package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create/update package when package name is reserved" in {
+  testname = "reject create/update package when package name is reserved"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           Set(true, false) foreach { overwrite =>
             RESERVED_NAMES foreach { reservedName =>
@@ -584,16 +609,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject create/update package when package name is reserved not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not allow package update of pre-existing package with a reserved" in {
+  testname = "not allow package update of pre-existing package with a reserved"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           RESERVED_NAMES foreach { reservedName =>
             val provider = WhiskPackage(namespace, EntityName(reservedName), None)
@@ -605,16 +631,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should not allow package update of pre-existing package with a reserved not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "allow package get/delete for pre-existing package with a reserved name" in {
+  testname = "allow package get/delete for pre-existing package with a reserved name"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           RESERVED_NAMES foreach {
             reservedName =>
@@ -630,16 +657,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
               }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should allow package get/delete for pre-existing package with a reserved name not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create package reference with explicit namespace" in {
+  testname = "create package reference with explicit namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val reference = WhiskPackage(
@@ -666,16 +694,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             checkWhiskEntityResponse(response, reference)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should create package reference with explicit namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not create package reference from private package in another namespace" in {
+  testname = "not create package reference from private package in another namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val privateCreds = WhiskAuthHelpers.newIdentity()
           val privateNamespace = EntityPath(privateCreds.subject.asString)
@@ -690,16 +719,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(Forbidden)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should not create package reference from private package in another namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create package reference with implicit namespace" in {
+  testname = "create package reference with implicit namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val reference = WhiskPackage(namespace, aname(), Some(Binding(EntityPath.DEFAULT.root, provider.name)))
@@ -718,16 +748,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
                 annotations = bindingAnnotation(provider.bind.get)))
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should create package reference with implicit namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create package reference when referencing non-existent package in same namespace" in {
+  testname = "reject create package reference when referencing non-existent package in same namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val binding = Some(Binding(namespace.root, aname()))
           val content = WhiskPackagePut(binding)
@@ -736,16 +767,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject create package reference when referencing non-existent package in same namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create package reference when referencing non-existent package in another namespace" in {
+  testname = "reject create package reference when referencing non-existent package in another namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val privateCreds = WhiskAuthHelpers.newIdentity()
           val privateNamespace = EntityPath(privateCreds.subject.asString)
@@ -756,16 +788,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(Forbidden)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > reject create package reference when referencing non-existent package in another namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create package reference when referencing a non-package" in {
+  testname = "reject create package reference when referencing a non-package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val reference = WhiskPackage(namespace, aname(), provider.bind)
@@ -777,19 +810,22 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[ErrorResponse].error should include(Messages.bindingCannotReferenceBinding)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject create package reference when referencing a non-package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create package reference when annotations are too big" in {
+  testname = "reject create package reference when annotations are too big"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
-            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+            List.range(
+              Math.pow(retriesOnTestFailures, 9) toLong,
+              (parametersLimit.toBytes / 20 + Math.pow(retriesOnTestFailures, 9) + 2) toLong)
           val annotations = keys map { key =>
             Parameters(key.toString, "a" * 10)
           } reduce (_ ++ _)
@@ -801,19 +837,22 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject create package reference when annotations are too bigreject create package reference when annotations are too big not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create package reference when parameters are too big" in {
+  testname = "reject create package reference when parameters are too big"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
-            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+            List.range(
+              Math.pow(retriesOnTestFailures, 9) toLong,
+              (parametersLimit.toBytes / 20 + Math.pow(retriesOnTestFailures, 9) + 2) toLong)
           val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
           } reduce (_ ++ _)
@@ -825,18 +864,22 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should list all packages/references not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject update package reference when parameters are too big" in {
+  testname = "reject update package reference when parameters are too big"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
-            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
+            List.range(
+              Math.pow(retriesOnTestFailures, 9) toLong,
+              (parametersLimit.toBytes / 20 + Math.pow(retriesOnTestFailures, 9) + 2) toLong)
           val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
           } reduce (_ ++ _)
@@ -850,16 +893,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             }
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject update package reference when parameters are too big not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "update package" in {
+  testname = "update package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val content = WhiskPackagePut(publish = Some(true))
@@ -880,15 +924,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
               WhiskPackage(namespace, provider.name, None, version = provider.version.upPatch, publish = true))
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should update package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "update package reference" in {
+  testname = "update package reference"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val reference =
@@ -921,15 +967,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
                 annotations = reference.annotations ++ Parameters("a", "b")))
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should update package reference not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject update package with binding" in {
+  testname = "reject update package with binding"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val content = WhiskPackagePut(provider.bind)
@@ -939,16 +987,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[ErrorResponse].error should include(Messages.packageCannotBecomeBinding)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject update package with binding not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject update package reference when new binding refers to non-existent package in same namespace" in {
+  testname = "reject update package reference when new binding refers to non-existent package in same namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val reference = WhiskPackage(namespace, aname(), provider.bind)
@@ -959,16 +1008,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[ErrorResponse].error should include(Messages.bindingDoesNotExist)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject update package reference when new binding refers to non-existent package in same namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject update package reference when new binding refers to non-existent package in another namespace" in {
+  testname = "reject update package reference when new binding refers to non-existent package in another namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val privateCreds = WhiskAuthHelpers.newIdentity()
           val privateNamespace = EntityPath(privateCreds.subject.asString)
@@ -981,16 +1031,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(Forbidden)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject update package reference when new binding refers to non-existent package in another namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject update package reference when new binding refers to itself" in {
+  testname = "reject update package reference when new binding refers to itself"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           // create package and valid reference binding to it
           val provider = WhiskPackage(namespace, aname())
@@ -1011,16 +1062,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response.binding should be(provider.bind)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject update package reference when new binding refers to itself not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject update package reference when new binding refers to private package in another namespace" in {
+  testname = "reject update package reference when new binding refers to private package in another namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val privateCreds = WhiskAuthHelpers.newIdentity()
           val privateNamespace = EntityPath(privateCreds.subject.asString)
@@ -1034,17 +1086,18 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(Forbidden)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject update package reference when new binding refers to private package in another namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// DEL /packages/name
-  it should "delete package" in {
+  testname = "delete package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           put(entityStore, provider)
@@ -1061,15 +1114,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response should be(provider)
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should delete package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "delete package reference regardless of package existence" in {
+  testname = "delete package reference regardless of package existence"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val reference = WhiskPackage(namespace, aname(), provider.bind)
@@ -1087,16 +1142,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response should be(reference)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should delete package reference regardless of package existence not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject delete non-empty package" in {
+  testname = "reject delete non-empty package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
@@ -1117,17 +1173,18 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             response.code.id should not be empty
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should reject delete non-empty package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// invalid resource
-  it should "reject invalid resource" in {
+  testname = "reject invalid resource"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val provider = WhiskPackage(namespace, aname())
           put(entityStore, provider)
@@ -1135,15 +1192,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(NotFound)
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should reject invalid resource not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "return empty list for invalid namespace" in {
+  testname = "return empty list for invalid namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val path = s"/whisk.systsdf/${collection.path}"
           Get(path) ~> Route.seal(routes(creds)) ~> check {
@@ -1151,16 +1210,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[List[JsObject]] should be(List.empty)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should return empty list for invalid namespace not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject bind to non-package" in {
+  testname = "reject bind to non-package"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val action = WhiskAction(namespace, aname(), jsDefault("??"))
           val reference = WhiskPackage(namespace, aname(), Some(Binding(action.namespace.root, action.name)))
@@ -1173,15 +1233,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[ErrorResponse].error should include(Messages.requestedBindingIsNotValid)
           }
         },
-        10,
-        Some(1.second),
-        Some(s"${this.getClass.getName} > Packages API should reject bind to non-package not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report proper error when record is corrupted on delete" in {
+  testname = "report proper error when record is corrupted on delete"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val entity = BadEntity(namespace, aname())
           put(entityStore, entity)
@@ -1191,16 +1253,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should report proper error when record is corrupted on delete not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report proper error when record is corrupted on get" in {
+  testname = "report proper error when record is corrupted on get"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val entity = BadEntity(namespace, aname())
           put(entityStore, entity)
@@ -1209,16 +1272,17 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             status should be(InternalServerError)
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should report proper error when record is corrupted on get not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report proper error when record is corrupted on put" in {
+  testname = "report proper error when record is corrupted on put"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val entity = BadEntity(namespace, aname())
           put(entityStore, entity)
@@ -1229,9 +1293,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
             responseAs[ErrorResponse].error shouldBe Messages.corruptedEntity
           }
         },
-        10,
-        Some(1.second),
-        Some(
-          s"${this.getClass.getName} > Packages API should report proper error when record is corrupted on put not successful, retrying.."))
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -823,9 +823,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
           afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
-            List.range(
-              Math.pow(retriesOnTestFailures, 9) toLong,
-              (parametersLimit.toBytes / 20 + Math.pow(retriesOnTestFailures, 9) + 2) toLong)
+            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
           val annotations = keys map { key =>
             Parameters(key.toString, "a" * 10)
           } reduce (_ ++ _)
@@ -850,9 +848,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
           afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
-            List.range(
-              Math.pow(retriesOnTestFailures, 9) toLong,
-              (parametersLimit.toBytes / 20 + Math.pow(retriesOnTestFailures, 9) + 2) toLong)
+            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
           val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
           } reduce (_ ++ _)
@@ -877,9 +873,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
           afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
-            List.range(
-              Math.pow(retriesOnTestFailures, 9) toLong,
-              (parametersLimit.toBytes / 20 + Math.pow(retriesOnTestFailures, 9) + 2) toLong)
+            List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
           val parameters = keys map { key =>
             Parameters(key.toString, "a" * 10)
           } reduce (_ ++ _)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
@@ -58,7 +58,8 @@ import org.apache.openwhisk.core.database.UserContext
 class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
 
   /** Triggers API tests */
-  behavior of "Triggers API"
+  val behaviorname = "Triggers API"
+  behavior of s"$behaviorname"
 
   val creds = WhiskAuthHelpers.newIdentity()
   val context = UserContext(creds)
@@ -73,10 +74,12 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   private val waitBeforeRetry = 1.second
 
   //// GET /triggers
-  it should "list triggers by default/explicit namespace" in {
+  var testname = "list triggers by default/explicit namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val triggers = (1 to 2).map { i =>
             WhiskTrigger(namespace, aname(), Parameters("x", "b"))
@@ -106,14 +109,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should list triggers by default/explicit namespace not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when limit is greater than maximum allowed value" in {
+  testname = "reject list when limit is greater than maximum allowed value"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val exceededMaxLimit = Collection.MAX_LIST_LIMIT + 1
           val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
@@ -125,14 +129,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject list when limit is greater than maximum allowed value not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when limit is not an integer" in {
+  testname = "reject list when limit is not an integer"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val notAnInteger = "string"
           val response = Get(s"$collectionPath?limit=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
@@ -144,14 +149,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject list when limit is not an integer not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when skip is negative" in {
+  testname = "reject list when skip is negative"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val negativeSkip = -1
           val response = Get(s"$collectionPath?skip=$negativeSkip") ~> Route.seal(routes(creds)) ~> check {
@@ -163,14 +169,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject list when skip is negative not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject list when skip is not an integer" in {
+  testname = "reject list when skip is not an integer"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val notAnInteger = "string"
           val response = Get(s"$collectionPath?skip=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
@@ -182,15 +189,16 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject list when skip is not an integer not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   // ?docs disabled
-  ignore should "list triggers by default namespace with full docs" in {
+  testname = "list triggers by default namespace with full docs"
+  ignore should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val triggers = (1 to 2).map { i =>
             WhiskTrigger(namespace, aname(), Parameters("x", "b"))
@@ -206,15 +214,16 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should list triggers by default namespace with full docs not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// GET /triggers/name
-  it should "get trigger by name in default/explicit namespace" in {
+  testname = "get trigger by name in default/explicit namespace"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
           put(entityStore, trigger)
@@ -239,14 +248,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should get trigger by name in default/explicit namespace not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "get trigger with updated field" in {
+  testname = "get trigger with updated field"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
           put(entityStore, trigger)
@@ -262,14 +272,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should get trigger with updated field not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report Conflict if the name was of a different type" in {
+  testname = "report Conflict if the name was of a different type"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val rule = WhiskRule(
             namespace,
@@ -283,15 +294,16 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should report Conflict if the name was of a different type not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// DEL /triggers/name
-  it should "delete trigger by name" in {
+  testname = "delete trigger by name"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
           put(entityStore, trigger)
@@ -303,14 +315,16 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Triggers API should delete trigger by name not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// PUT /triggers/name
-  it should "put should accept request with missing optional properties" in {
+  testname = "put should accept request with missing optional properties"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname())
           val content = WhiskTriggerPut()
@@ -323,14 +337,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should put should accept request with missing optional properties not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "put should accept request with valid feed parameter" in {
+  testname = "put should accept request with valid feed parameter"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "xyz"))
           val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
@@ -343,14 +358,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should put should accept request with valid feed parameter not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "put should reject request with undefined feed parameter" in {
+  testname = "put should reject request with undefined feed parameter"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, ""))
           val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
@@ -360,14 +376,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should put should reject request with undefined feed parameter not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "put should reject request with bad feed parameters" in {
+  testname = "put should reject request with bad feed parameters"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "a,b"))
           val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
@@ -377,14 +394,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should put should reject request with bad feed parameters not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject activation with entity which is too big" in {
+  testname = "reject activation with entity which is too big"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val code = "a" * (allowedActivationEntitySize.toInt + 1)
           val content = s"""{"a":"$code"}""".stripMargin
@@ -398,14 +416,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject activation with entity which is too big not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create with parameters which are too big" in {
+  testname = "reject create with parameters which are too big"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
             List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
@@ -422,14 +441,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject create with parameters which are too big not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create with annotations which are too big" in {
+  testname = "reject create with annotations which are too big"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val keys: List[Long] =
             List.range(Math.pow(10, 9) toLong, (parametersLimit.toBytes / 20 + Math.pow(10, 9) + 2) toLong)
@@ -446,14 +466,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject create with annotations which are too big not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject update with parameters which are too big" in {
+  testname = "reject update with parameters which are too big"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname())
           val keys: List[Long] =
@@ -472,14 +493,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should reject update with parameters which are too big not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "put should accept update request with missing optional properties" in {
+  testname = "put should accept update request with missing optional properties"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), Parameters("x", "b"))
           val content = WhiskTriggerPut()
@@ -500,14 +522,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should put should accept update request with missing optional properties not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "put should reject update request for trigger with existing feed" in {
+  testname = "put should reject update request for trigger with existing feed"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname(), annotations = Parameters(Parameters.Feed, "xyz"))
           val content = WhiskTriggerPut(annotations = Some(trigger.annotations))
@@ -519,14 +542,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should put should reject update request for trigger with existing feed not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "put should reject update request for trigger with new feed" in {
+  testname = "put should reject update request for trigger with new feed"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname())
           val content = WhiskTriggerPut(annotations = Some(Parameters(Parameters.Feed, "xyz")))
@@ -538,15 +562,16 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should put should reject update request for trigger with new feed not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// POST /triggers/name
-  it should "fire a trigger" in {
+  testname = "fire a trigger"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val rule =
             WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "bogus action"))
@@ -577,13 +602,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Triggers API should fire a trigger not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "fire a trigger without args" in {
+  testname = "fire a trigger without args"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val rule =
             WhiskRule(namespace, aname(), afullname(namespace, aname().name), afullname(namespace, "bogus action"))
@@ -607,13 +634,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Triggers API should fire a trigger without args not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not fire a trigger without a rule" in {
+  testname = "not fire a trigger without a rule"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname())
           put(entityStore, trigger)
@@ -623,15 +652,16 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should not fire a trigger without a rule not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //// invalid resource
-  it should "reject invalid resource" in {
+  testname = "reject invalid resource"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = WhiskTrigger(namespace, aname())
           put(entityStore, trigger)
@@ -641,14 +671,16 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Triggers API should reject invalid resource not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   // migration path
-  it should "be able to handle a trigger as of the old schema" in {
+  testname = "be able to handle a trigger as of the old schema"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val trigger = OldWhiskTrigger(namespace, aname())
           put(entityStore, trigger)
@@ -660,14 +692,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should be able to handle a trigger as of the old schema not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report proper error when record is corrupted on delete" in {
+  testname = "report proper error when record is corrupted on delete"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val entity = BadEntity(namespace, aname())
           put(entityStore, entity)
@@ -679,14 +712,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > report proper error when record is corrupted on delete not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report proper error when record is corrupted on get" in {
+  testname = "report proper error when record is corrupted on get"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val entity = BadEntity(namespace, aname())
           put(entityStore, entity)
@@ -698,14 +732,15 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should report proper error when record is corrupted on get not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report proper error when record is corrupted on put" in {
+  testname = "report proper error when record is corrupted on put"
+  it should s"$testname" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val entity = BadEntity(namespace, aname())
           put(entityStore, entity)
@@ -718,7 +753,6 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(
-          s"${this.getClass.getName} > Triggers API should report proper error when record is corrupted on put not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
@@ -32,6 +32,8 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
+import scala.concurrent.duration._
+
 import org.apache.openwhisk.core.controller.WhiskActionsApi
 import org.apache.openwhisk.core.controller.test.ControllerTestCommon
 import org.apache.openwhisk.core.controller.test.WhiskAuthHelpers
@@ -47,7 +49,11 @@ class SequenceActionApiMigrationTests
     with TestHelpers
     with WskTestHelpers {
 
-  behavior of "Sequence Action API Migration"
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
+
+  val behaviorname = "Sequence Action API Migration"
+  behavior of s"$behaviorname"
 
   val creds = WhiskAuthHelpers.newIdentity()
   val namespace = EntityPath(creds.subject.asString)
@@ -56,124 +62,178 @@ class SequenceActionApiMigrationTests
 
   private def seqParameters(seq: Vector[String]) = Parameters("_actions", seq.toJson)
 
-  it should "list old-style sequence action with explicit namespace" in {
-    implicit val tid = transid()
-    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
-    val actions = (1 to 2).map { i =>
-      WhiskAction(namespace, aname(), sequence(components))
-    }.toList
-    actions foreach { put(entityStore, _) }
-    waitOnView(entityStore, WhiskAction, namespace, 2)
-    Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[List[JsObject]]
-      actions.length should be(response.length)
-      response should contain theSameElementsAs actions.map(_.summaryAsJson)
-    }
+  var testname = "list old-style sequence action with explicit namespace"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
+          val actions = (1 to 2).map { i =>
+            WhiskAction(namespace, aname(), sequence(components))
+          }.toList
+          actions foreach { put(entityStore, _) }
+          waitOnView(entityStore, WhiskAction, namespace, 2)
+          Get(s"/$namespace/${collection.path}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[List[JsObject]]
+            actions.length should be(response.length)
+            response should contain theSameElementsAs actions.map(_.summaryAsJson)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "get old-style sequence action by name in default namespace" in {
-    implicit val tid = transid()
-    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname(), sequence(components))
-    put(entityStore, action)
-    Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response should be(action)
-    }
+  testname = "get old-style sequence action by name in default namespace"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
+          val action = WhiskAction(namespace, aname(), sequence(components))
+          put(entityStore, action)
+          Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
+            status should be(OK)
+            val response = responseAs[WhiskAction]
+            response should be(action)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   // this test is a repeat from ActionsApiTest BUT with old style sequence
-  it should "preserve new parameters when changing old-style sequence action to non sequence" in {
-    implicit val tid = transid()
-    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
-    val seqComponents = components.map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname(), sequence(seqComponents), seqParameters(components))
-    val content = WhiskActionPut(Some(jsDefault("")), parameters = Some(Parameters("a", "A")))
-    put(entityStore, action, false)
+  testname = "preserve new parameters when changing old-style sequence action to non sequence"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
+          val seqComponents = components.map(stringToFullyQualifiedName(_))
+          val action = WhiskAction(namespace, aname(), sequence(seqComponents), seqParameters(components))
+          val content = WhiskActionPut(Some(jsDefault("")), parameters = Some(Parameters("a", "A")))
+          put(entityStore, action, false)
 
-    // create an action sequence
-    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteAction(action.docid)
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response.exec.kind should be(NODEJS10)
-      response.parameters should be(Parameters("a", "A"))
-    }
+          // create an action sequence
+          Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteAction(action.docid)
+            status should be(OK)
+            val response = responseAs[WhiskAction]
+            response.exec.kind should be(NODEJS10)
+            response.parameters should be(Parameters("a", "A"))
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   // this test is a repeat from ActionsApiTest BUT with old style sequence
-  it should "reset parameters when changing old-style sequence action to non sequence" in {
-    implicit val tid = transid()
-    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
-    val seqComponents = components.map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname(), sequence(seqComponents), seqParameters(components))
-    val content = WhiskActionPut(Some(jsDefault("")))
-    put(entityStore, action, false)
+  testname = "reset parameters when changing old-style sequence action to non sequence"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
+          val seqComponents = components.map(stringToFullyQualifiedName(_))
+          val action = WhiskAction(namespace, aname(), sequence(seqComponents), seqParameters(components))
+          val content = WhiskActionPut(Some(jsDefault("")))
+          put(entityStore, action, false)
 
-    // create an action sequence
-    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteAction(action.docid)
-      status should be(OK)
-      val response = responseAs[WhiskAction]
-      response.exec.kind should be(NODEJS10)
-      response.parameters shouldBe Parameters()
-    }
+          // create an action sequence
+          Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteAction(action.docid)
+            status should be(OK)
+            val response = responseAs[WhiskAction]
+            response.exec.kind should be(NODEJS10)
+            response.parameters shouldBe Parameters()
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "update old-style sequence action with new annotations" in {
-    implicit val tid = transid()
-    val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
-    val seqComponents = components.map(stringToFullyQualifiedName(_))
-    val action = WhiskAction(namespace, aname(), sequence(seqComponents))
-    val content = """{"annotations":[{"key":"old","value":"new"}]}""".parseJson.asJsObject
-    put(entityStore, action, false)
+  testname = "update old-style sequence action with new annotations"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          val components = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c")
+          val seqComponents = components.map(stringToFullyQualifiedName(_))
+          val action = WhiskAction(namespace, aname(), sequence(seqComponents))
+          val content = """{"annotations":[{"key":"old","value":"new"}]}""".parseJson.asJsObject
+          put(entityStore, action, false)
 
-    // create an action sequence
-    Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteAction(action.docid)
-      status should be(OK)
-      val response = responseAs[String]
-      // contains the action
-      components map { c =>
-        response should include(c)
-      }
-      // contains the annotations
-      response should include("old")
-      response should include("new")
-    }
+          // create an action sequence
+          Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteAction(action.docid)
+            status should be(OK)
+            val response = responseAs[String]
+            // contains the action
+            components map { c =>
+              response should include(c)
+            }
+            // contains the annotations
+            response should include("old")
+            response should include("new")
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "update an old-style sequence with new sequence" in {
-    implicit val tid = transid()
-    // old sequence
-    val seqName = EntityName(s"${aname()}_new")
-    val oldComponents = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
-    val oldSequence = WhiskAction(namespace, seqName, sequence(oldComponents))
-    put(entityStore, oldSequence)
+  testname = "update an old-style sequence with new sequence"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          // old sequence
+          val seqName = EntityName(s"${aname()}_new")
+          val oldComponents = Vector("/_/a", "/_/x/b", "/n/a", "/n/x/c").map(stringToFullyQualifiedName(_))
+          val oldSequence = WhiskAction(namespace, seqName, sequence(oldComponents))
+          put(entityStore, oldSequence)
 
-    // new sequence
-    val limit = 5 // count of bogus actions in sequence
-    val bogus = s"${aname()}_bogus"
-    val bogusActionName = s"/_/${bogus}" // test that default namespace gets properly replaced
-    // put the action in the entity store so it exists
-    val bogusAction = WhiskAction(namespace, EntityName(bogus), jsDefault("??"), Parameters("x", "y"))
-    put(entityStore, bogusAction)
-    val seqComponents = for (i <- 1 to limit) yield stringToFullyQualifiedName(bogusActionName)
-    val seqAction = WhiskAction(namespace, seqName, sequence(seqComponents.toVector))
-    val content = WhiskActionPut(Some(seqAction.exec), Some(Parameters()))
+          // new sequence
+          val limit = 5 // count of bogus actions in sequence
+          val bogus = s"${aname()}_bogus"
+          val bogusActionName = s"/_/${bogus}" // test that default namespace gets properly replaced
+          // put the action in the entity store so it exists
+          val bogusAction = WhiskAction(namespace, EntityName(bogus), jsDefault("??"), Parameters("x", "y"))
+          put(entityStore, bogusAction)
+          val seqComponents = for (i <- 1 to limit) yield stringToFullyQualifiedName(bogusActionName)
+          val seqAction = WhiskAction(namespace, seqName, sequence(seqComponents.toVector))
+          val content = WhiskActionPut(Some(seqAction.exec), Some(Parameters()))
 
-    // update an action sequence
-    Put(s"$collectionPath/${seqName}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      deleteAction(seqAction.docid)
-      status should be(OK)
+          // update an action sequence
+          Put(s"$collectionPath/${seqName}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
+            deleteAction(seqAction.docid)
+            status should be(OK)
 
-      val response = responseAs[WhiskAction]
-      response.exec.kind should be(Exec.SEQUENCE)
-      response.limits should be(seqAction.limits)
-      response.publish should be(seqAction.publish)
-      response.version should be(seqAction.version.upPatch)
-    }
+            val response = responseAs[WhiskAction]
+            response.exec.kind should be(Exec.SEQUENCE)
+            response.limits should be(seqAction.limits)
+            response.publish should be(seqAction.publish)
+            response.version should be(seqAction.version.upPatch)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ViewTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ViewTests.scala
@@ -21,6 +21,7 @@ import java.time.Clock
 import java.time.Instant
 
 import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest._
@@ -77,6 +78,9 @@ class ViewTests
     activationStore.shutdown()
     super.afterAll()
   }
+
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 5.second
 
   behavior of "Datastore View"
 
@@ -206,219 +210,255 @@ class ViewTests
     result should be(expected reverse)
   }
 
-  it should "query whisk view by namespace, collection and entity name in whisk actions db" in {
-    implicit val tid = transid()
-    val exec = bb("image")
-    val pkgname1 = namespace1.addPath(aname())
-    val pkgname2 = namespace2.addPath(aname())
-    val actionName = aname()
-    def now = Instant.now(Clock.systemUTC())
+  var testname: String = "query whisk view by namespace, collection and entity name in whisk actions db"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val exec = bb("image")
+          val pkgname1 = namespace1.addPath(aname())
+          val pkgname2 = namespace2.addPath(aname())
+          val actionName = aname()
+          def now = Instant.now(Clock.systemUTC())
 
-    implicit val entities = Seq(
-      WhiskAction(namespace1, aname(), exec),
-      WhiskAction(namespace1, aname(), exec),
-      WhiskAction(namespace1.addPath(aname()), aname(), exec),
-      WhiskAction(namespace1.addPath(aname()), aname(), exec),
-      WhiskAction(pkgname1, aname(), exec),
-      WhiskAction(pkgname1, aname(), exec),
-      WhiskAction(pkgname1, actionName, exec),
-      WhiskTrigger(namespace1, aname()),
-      WhiskTrigger(namespace1, aname()),
-      WhiskRule(namespace1, aname(), trigger = afullname(namespace1), action = afullname(namespace1)),
-      WhiskRule(namespace1, aname(), trigger = afullname(namespace1), action = afullname(namespace1)),
-      WhiskPackage(namespace1, aname()),
-      WhiskPackage(namespace1, aname()),
-      WhiskPackage(namespace1, aname(), Some(Binding(namespace2.root, aname()))),
-      WhiskPackage(namespace1, aname(), Some(Binding(namespace2.root, aname()))),
-      WhiskAction(namespace2, aname(), exec),
-      WhiskAction(namespace2, aname(), exec),
-      WhiskAction(namespace2.addPath(aname()), aname(), exec),
-      WhiskAction(namespace2.addPath(aname()), aname(), exec),
-      WhiskAction(pkgname2, aname(), exec),
-      WhiskAction(pkgname2, aname(), exec),
-      WhiskTrigger(namespace2, aname()),
-      WhiskTrigger(namespace2, aname()),
-      WhiskRule(namespace2, aname(), trigger = afullname(namespace2), action = afullname(namespace2)),
-      WhiskRule(namespace2, aname(), trigger = afullname(namespace2), action = afullname(namespace2)),
-      WhiskPackage(namespace2, aname()),
-      WhiskPackage(namespace2, aname()),
-      WhiskPackage(namespace2, aname(), Some(Binding(namespace1.root, aname()))),
-      WhiskPackage(namespace2, aname(), Some(Binding(namespace1.root, aname()))))
+          implicit val entities = Seq(
+            WhiskAction(namespace1, aname(), exec),
+            WhiskAction(namespace1, aname(), exec),
+            WhiskAction(namespace1.addPath(aname()), aname(), exec),
+            WhiskAction(namespace1.addPath(aname()), aname(), exec),
+            WhiskAction(pkgname1, aname(), exec),
+            WhiskAction(pkgname1, aname(), exec),
+            WhiskAction(pkgname1, actionName, exec),
+            WhiskTrigger(namespace1, aname()),
+            WhiskTrigger(namespace1, aname()),
+            WhiskRule(namespace1, aname(), trigger = afullname(namespace1), action = afullname(namespace1)),
+            WhiskRule(namespace1, aname(), trigger = afullname(namespace1), action = afullname(namespace1)),
+            WhiskPackage(namespace1, aname()),
+            WhiskPackage(namespace1, aname()),
+            WhiskPackage(namespace1, aname(), Some(Binding(namespace2.root, aname()))),
+            WhiskPackage(namespace1, aname(), Some(Binding(namespace2.root, aname()))),
+            WhiskAction(namespace2, aname(), exec),
+            WhiskAction(namespace2, aname(), exec),
+            WhiskAction(namespace2.addPath(aname()), aname(), exec),
+            WhiskAction(namespace2.addPath(aname()), aname(), exec),
+            WhiskAction(pkgname2, aname(), exec),
+            WhiskAction(pkgname2, aname(), exec),
+            WhiskTrigger(namespace2, aname()),
+            WhiskTrigger(namespace2, aname()),
+            WhiskRule(namespace2, aname(), trigger = afullname(namespace2), action = afullname(namespace2)),
+            WhiskRule(namespace2, aname(), trigger = afullname(namespace2), action = afullname(namespace2)),
+            WhiskPackage(namespace2, aname()),
+            WhiskPackage(namespace2, aname()),
+            WhiskPackage(namespace2, aname(), Some(Binding(namespace1.root, aname()))),
+            WhiskPackage(namespace2, aname(), Some(Binding(namespace1.root, aname()))))
 
-    entities foreach { put(entityStore, _) }
-    waitOnView(entityStore, namespace1.root, 7, WhiskAction.view)
-    waitOnView(entityStore, namespace1.root, 2, WhiskTrigger.view)
-    waitOnView(entityStore, namespace1.root, 2, WhiskRule.view)
-    waitOnView(entityStore, namespace1.root, 4, WhiskPackage.view)
-    waitOnView(entityStore, namespace2.root, 6, WhiskAction.view)
-    waitOnView(entityStore, namespace2.root, 2, WhiskTrigger.view)
-    waitOnView(entityStore, namespace2.root, 2, WhiskRule.view)
-    waitOnView(entityStore, namespace2.root, 4, WhiskPackage.view)
+          entities foreach { put(entityStore, _) }
+          waitOnView(entityStore, namespace1.root, 7, WhiskAction.view)
+          waitOnView(entityStore, namespace1.root, 2, WhiskTrigger.view)
+          waitOnView(entityStore, namespace1.root, 2, WhiskRule.view)
+          waitOnView(entityStore, namespace1.root, 4, WhiskPackage.view)
+          waitOnView(entityStore, namespace2.root, 6, WhiskAction.view)
+          waitOnView(entityStore, namespace2.root, 2, WhiskTrigger.view)
+          waitOnView(entityStore, namespace2.root, 2, WhiskRule.view)
+          waitOnView(entityStore, namespace2.root, 4, WhiskPackage.view)
 
-    getKindInNamespace(entityStore, namespace1, "actions", {
-      case (e: WhiskAction) => true
-      case (_)              => false
-    })
-    getKindInNamespace(entityStore, namespace1, "triggers", {
-      case (e: WhiskTrigger) => true
-      case (_)               => false
-    })
-    getKindInNamespaceWithDoc[WhiskRule](namespace1, "rules", {
-      case (e: WhiskRule) => true
-      case (_)            => false
-    })
-    getKindInNamespace(entityStore, namespace1, "packages", {
-      case (e: WhiskPackage) => true
-      case (_)               => false
-    })
-    getKindInPackage(pkgname1, "actions", {
-      case (e: WhiskAction) => true
-      case (_)              => false
-    })
-    getKindInNamespaceByName(entityStore, pkgname1, "actions", actionName, {
-      case (e: WhiskAction) => (e.name == actionName)
-      case (_)              => false
-    })
+          getKindInNamespace(entityStore, namespace1, "actions", {
+            case (e: WhiskAction) => true
+            case (_)              => false
+          })
+          getKindInNamespace(entityStore, namespace1, "triggers", {
+            case (e: WhiskTrigger) => true
+            case (_)               => false
+          })
+          getKindInNamespaceWithDoc[WhiskRule](namespace1, "rules", {
+            case (e: WhiskRule) => true
+            case (_)            => false
+          })
+          getKindInNamespace(entityStore, namespace1, "packages", {
+            case (e: WhiskPackage) => true
+            case (_)               => false
+          })
+          getKindInPackage(pkgname1, "actions", {
+            case (e: WhiskAction) => true
+            case (_)              => false
+          })
+          getKindInNamespaceByName(entityStore, pkgname1, "actions", actionName, {
+            case (e: WhiskAction) => (e.name == actionName)
+            case (_)              => false
+          })
 
-    getKindInNamespace(entityStore, namespace2, "actions", {
-      case (e: WhiskAction) => true
-      case (_)              => false
-    })
-    getKindInNamespace(entityStore, namespace2, "triggers", {
-      case (e: WhiskTrigger) => true
-      case (_)               => false
-    })
-    getKindInNamespaceWithDoc[WhiskRule](namespace2, "rules", {
-      case (e: WhiskRule) => true
-      case (_)            => false
-    })
-    getKindInNamespace(entityStore, namespace2, "packages", {
-      case (e: WhiskPackage) => true
-      case (_)               => false
-    })
-    getKindInPackage(pkgname2, "actions", {
-      case (e: WhiskAction) => true
-      case (_)              => false
-    })
+          getKindInNamespace(entityStore, namespace2, "actions", {
+            case (e: WhiskAction) => true
+            case (_)              => false
+          })
+          getKindInNamespace(entityStore, namespace2, "triggers", {
+            case (e: WhiskTrigger) => true
+            case (_)               => false
+          })
+          getKindInNamespaceWithDoc[WhiskRule](namespace2, "rules", {
+            case (e: WhiskRule) => true
+            case (_)            => false
+          })
+          getKindInNamespace(entityStore, namespace2, "packages", {
+            case (e: WhiskPackage) => true
+            case (_)               => false
+          })
+          getKindInPackage(pkgname2, "actions", {
+            case (e: WhiskAction) => true
+            case (_)              => false
+          })
+          afterEach
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Datastore View should $testname not successful, retrying.."))
   }
 
-  it should "query whisk view by namespace, collection and entity name in whisk activations db" in {
-    implicit val tid = transid()
-    val actionName = aname()
-    def now = Instant.now(Clock.systemUTC())
+  testname = "query whisk view by namespace, collection and entity name in whisk activations db"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val actionName = aname()
+          def now = Instant.now(Clock.systemUTC())
 
-    // creates 5 entities in each namespace as follows:
-    // - some activations in each namespace (some may have prescribed action name to query by name)
-    implicit val entities = Seq(
-      WhiskActivation(namespace1, aname(), Subject(), ActivationId.generate(), start = now, end = now),
-      WhiskActivation(namespace1, aname(), Subject(), ActivationId.generate(), start = now, end = now),
-      WhiskActivation(namespace2, aname(), Subject(), ActivationId.generate(), start = now, end = now),
-      WhiskActivation(namespace2, actionName, Subject(), ActivationId.generate(), start = now, end = now),
-      WhiskActivation(namespace2, actionName, Subject(), ActivationId.generate(), start = now, end = now))
+          // creates 5 entities in each namespace as follows:
+          // - some activations in each namespace (some may have prescribed action name to query by name)
+          implicit val entities = Seq(
+            WhiskActivation(namespace1, aname(), Subject(), ActivationId.generate(), start = now, end = now),
+            WhiskActivation(namespace1, aname(), Subject(), ActivationId.generate(), start = now, end = now),
+            WhiskActivation(namespace2, aname(), Subject(), ActivationId.generate(), start = now, end = now),
+            WhiskActivation(namespace2, actionName, Subject(), ActivationId.generate(), start = now, end = now),
+            WhiskActivation(namespace2, actionName, Subject(), ActivationId.generate(), start = now, end = now))
 
-    entities foreach { put(activationStore, _) }
-    waitOnView(activationStore, namespace1.root, 2, WhiskActivation.view)
-    waitOnView(activationStore, namespace2.root, 3, WhiskActivation.view)
+          entities foreach { put(activationStore, _) }
+          waitOnView(activationStore, namespace1.root, 2, WhiskActivation.view)
+          waitOnView(activationStore, namespace2.root, 3, WhiskActivation.view)
 
-    getAllActivationsInNamespace(activationStore, namespace1)
-    getKindInNamespace(activationStore, namespace1, "activations", {
-      case (e: WhiskActivation) => true
-      case (_)                  => false
-    })
+          getAllActivationsInNamespace(activationStore, namespace1)
+          getKindInNamespace(activationStore, namespace1, "activations", {
+            case (e: WhiskActivation) => true
+            case (_)                  => false
+          })
 
-    getAllActivationsInNamespace(activationStore, namespace2)
-    getKindInNamespace(activationStore, namespace2, "activations", {
-      case (e: WhiskActivation) => true
-      case (_)                  => false
-    })
-    getActivationsInNamespaceByName(activationStore, namespace2, actionName, {
-      case (e: WhiskActivation) => (e.name == actionName)
-      case (_)                  => false
-    })
+          getAllActivationsInNamespace(activationStore, namespace2)
+          getKindInNamespace(activationStore, namespace2, "activations", {
+            case (e: WhiskActivation) => true
+            case (_)                  => false
+          })
+          getActivationsInNamespaceByName(activationStore, namespace2, actionName, {
+            case (e: WhiskActivation) => (e.name == actionName)
+            case (_)                  => false
+          })
+          afterEach
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Datastore View should $testname not successful, retrying.."))
   }
 
-  it should "query whisk view for activations sorted by date" in {
-    implicit val tid = transid()
-    val actionName = aname()
-    val now = Instant.now(Clock.systemUTC())
-    implicit val entities = Seq(
-      WhiskActivation(namespace1, actionName, Subject(), ActivationId.generate(), start = now, end = now),
-      WhiskActivation(
-        namespace1,
-        actionName,
-        Subject(),
-        ActivationId.generate(),
-        start = now.plusSeconds(20),
-        end = now.plusSeconds(20)),
-      WhiskActivation(
-        namespace1,
-        actionName,
-        Subject(),
-        ActivationId.generate(),
-        start = now.plusSeconds(10),
-        end = now.plusSeconds(20)),
-      WhiskActivation(
-        namespace1,
-        actionName,
-        Subject(),
-        ActivationId.generate(),
-        start = now.plusSeconds(40),
-        end = now.plusSeconds(20)),
-      WhiskActivation(
-        namespace1,
-        actionName,
-        Subject(),
-        ActivationId.generate(),
-        start = now.plusSeconds(30),
-        end = now.plusSeconds(20)))
+  testname = "query whisk view for activations sorted by date"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val actionName = aname()
+          val now = Instant.now(Clock.systemUTC())
+          implicit val entities = Seq(
+            WhiskActivation(namespace1, actionName, Subject(), ActivationId.generate(), start = now, end = now),
+            WhiskActivation(
+              namespace1,
+              actionName,
+              Subject(),
+              ActivationId.generate(),
+              start = now.plusSeconds(20),
+              end = now.plusSeconds(20)),
+            WhiskActivation(
+              namespace1,
+              actionName,
+              Subject(),
+              ActivationId.generate(),
+              start = now.plusSeconds(10),
+              end = now.plusSeconds(20)),
+            WhiskActivation(
+              namespace1,
+              actionName,
+              Subject(),
+              ActivationId.generate(),
+              start = now.plusSeconds(40),
+              end = now.plusSeconds(20)),
+            WhiskActivation(
+              namespace1,
+              actionName,
+              Subject(),
+              ActivationId.generate(),
+              start = now.plusSeconds(30),
+              end = now.plusSeconds(20)))
 
-    entities foreach { put(activationStore, _) }
-    waitOnView(activationStore, namespace1.addPath(actionName), entities.length, WhiskActivation.filtersView)
+          entities foreach { put(activationStore, _) }
+          waitOnView(activationStore, namespace1.addPath(actionName), entities.length, WhiskActivation.filtersView)
 
-    getActivationsInNamespaceByNameSortedByDate(
-      activationStore,
-      namespace1,
-      "activations",
-      actionName,
-      0,
-      5,
-      None,
-      None, {
-        case (e: WhiskActivation) => e.name == actionName
-        case (_)                  => false
-      })
+          getActivationsInNamespaceByNameSortedByDate(
+            activationStore,
+            namespace1,
+            "activations",
+            actionName,
+            0,
+            5,
+            None,
+            None, {
+              case (e: WhiskActivation) => e.name == actionName
+              case (_)                  => false
+            })
 
-    val since = entities(1).start
-    val upto = entities(4).start
-    getActivationsInNamespaceByNameSortedByDate(
-      activationStore,
-      namespace1,
-      "activations",
-      actionName,
-      0,
-      5,
-      Some(since),
-      Some(upto), {
-        case (e: WhiskActivation) =>
-          e.name == actionName && (e.start.equals(since) || e.start
-            .equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
-        case (_) => false
-      })
+          val since = entities(1).start
+          val upto = entities(4).start
+          getActivationsInNamespaceByNameSortedByDate(
+            activationStore,
+            namespace1,
+            "activations",
+            actionName,
+            0,
+            5,
+            Some(since),
+            Some(upto), {
+              case (e: WhiskActivation) =>
+                e.name == actionName && (e.start.equals(since) || e.start
+                  .equals(upto) || (e.start.isAfter(since) && e.start.isBefore(upto)))
+              case (_) => false
+            })
+          afterEach
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Datastore View should $testname not successful, retrying.."))
   }
 
-  it should "list actions and retrieve full documents" in {
-    implicit val tid = transid()
-    val actionName = aname()
-    val now = Instant.now(Clock.systemUTC())
-    implicit val entities =
-      Seq(WhiskAction(namespace1, aname(), jsDefault("??")), WhiskAction(namespace1, aname(), jsDefault("??")))
+  testname = "list actions and retrieve full documents"
+  it should s"testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val tid = transid()
+          val actionName = aname()
+          val now = Instant.now(Clock.systemUTC())
+          implicit val entities =
+            Seq(WhiskAction(namespace1, aname(), jsDefault("??")), WhiskAction(namespace1, aname(), jsDefault("??")))
 
-    entities foreach { put(entityStore, _) }
-    waitOnView(entityStore, namespace1.root, 2, WhiskAction.view)
+          entities foreach { put(entityStore, _) }
+          waitOnView(entityStore, namespace1.root, 2, WhiskAction.view)
 
-    getKindInNamespaceWithDoc[WhiskAction](namespace1, "actions", {
-      case (e: WhiskAction) => true
-      case (_)              => false
-    })
+          getKindInNamespaceWithDoc[WhiskAction](namespace1, "actions", {
+            case (e: WhiskAction) => true
+            case (_)              => false
+          })
+          afterEach
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > Datastore View should $testname not successful, retrying.."))
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds as well as the health tests performed as part of the production deployments.

```
15:18:28  system.basic.WskConductorTests > Whisk conductor actions should invoke a conductor action with a continuation STANDARD_OUT
15:18:28      Exception occurred during test execution: org.scalatest.exceptions.TestFailedException: The future returned an exception of type: akka.http.impl.engine.client.OutgoingConnectionBlueprint$UnexpectedConnectionClosureException, with message: The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests.
15:18:28  
15:18:28  system.basic.WskConductorTests > Whisk conductor actions should invoke a conductor action with a continuation STANDARD_ERROR
15:18:28      org.scalatest.exceptions.TestFailedException: The future returned an exception of type: akka.http.impl.engine.client.OutgoingConnectionBlueprint$UnexpectedConnectionClosureException, with message: The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests.
15:18:28      	at org.scalatest.concurrent.Futures$FutureConcept.tryTryAgain$1(Futures.scala:531)
15:18:28      	at org.scalatest.concurrent.Futures$FutureConcept.futureValueImpl(Futures.scala:550)
15:18:28      	at org.scalatest.concurrent.Futures$FutureConcept.futureValueImpl$(Futures.scala:479)
15:18:28      	at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValueImpl(ScalaFutures.scala:275)
15:18:28      	at org.scalatest.concurrent.Futures$FutureConcept.futureValue(Futures.scala:476)
15:18:28      	at org.scalatest.concurrent.Futures$FutureConcept.futureValue$(Futures.scala:475)
15:18:28      	at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValue(ScalaFutures.scala:275)
15:18:28      	at common.rest.RunRestCmd.requestEntity(WskRestOperations.scala:1190)
15:18:28      	at common.rest.RunRestCmd.requestEntity$(WskRestOperations.scala:1170)
15:18:28      	at common.rest.RestActionOperations.requestEntity(WskRestOperations.scala:244)
15:18:28      	at common.rest.RunRestCmd.invokeAction(WskRestOperations.scala:1347)
15:18:28      	at common.rest.RunRestCmd.invokeAction$(WskRestOperations.scala:1328)
15:18:28      	at common.rest.RestActionOperations.invoke(WskRestOperations.scala:385)
15:18:28      	at common.rest.RestActionOperations.invoke(WskRestOperations.scala:244)
15:18:28      	at system.basic.WskConductorTests.$anonfun$new$13(WskConductorTests.scala:145)
15:18:28      	at system.basic.WskConductorTests.$anonfun$new$13$adapted(WskConductorTests.scala:122)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

