### PR TITLE
Retry on testcase failures (cont.)

### DIFF
--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -168,7 +168,6 @@ object RuleActivationResult extends DefaultJsonProtocol {
 trait WskTestHelpers extends Matchers {
   type Assets = ListBuffer[(DeleteFromCollectionOperations, String, Boolean)]
 
-
   /**
    * Helper to register an entity to delete once a test completes.
    * The helper sanitizes (deletes) a previous instance of the entity if it exists

--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -168,6 +168,7 @@ object RuleActivationResult extends DefaultJsonProtocol {
 trait WskTestHelpers extends Matchers {
   type Assets = ListBuffer[(DeleteFromCollectionOperations, String, Boolean)]
 
+
   /**
    * Helper to register an entity to delete once a test completes.
    * The helper sanitizes (deletes) a previous instance of the entity if it exists
@@ -181,31 +182,14 @@ trait WskTestHelpers extends Matchers {
       cli.sanitize(name)(wskprops)
 
       assetsToDeleteAfterTest += ((cli, name, confirmDelete))
+      println(s"assetsToDeleteAfterTest += $cli,$name,$confirmDelete")
       cmd(cli, name)
     }
-  }
-
-  /**
-   * Creates a test closure which records all entities created inside the test into a
-   * list that is iterated at the end of the test so that these entities are deleted
-   * (from most recently created to oldest).
-   */
-  def withAssetCleaner[T](wskprops: WskProps)(test: (WskProps, AssetCleaner) => T): T = {
-    // create new asset list to track what must be deleted after test completes
-    val assetsToDeleteAfterTest = new Assets()
-
-    try {
-      test(wskprops, new AssetCleaner(assetsToDeleteAfterTest, wskprops))
-    } catch {
-      case t: Throwable =>
-        // log the exception that occurred in the test and rethrow it
-        println(s"Exception occurred during test execution: $t")
-        t.printStackTrace()
-        throw t
-    } finally {
-      // delete assets in reverse order so that was created last is deleted first
+    def deleteAssets(): Unit = {
       val deletedAll = assetsToDeleteAfterTest.reverse map {
         case (cli, n, delete) =>
+          assetsToDeleteAfterTest -= ((cli, n, delete))
+          println(s"assetsToDeleteAfterTest -= $cli,$n,$delete")
           n -> Try {
             cli match {
               case _: PackageOperations if delete =>
@@ -243,6 +227,29 @@ trait WskTestHelpers extends Matchers {
           true
       }
       assert(deletedAll, "some assets were not deleted")
+    }
+  }
+
+  /**
+   * Creates a test closure which records all entities created inside the test into a
+   * list that is iterated at the end of the test so that these entities are deleted
+   * (from most recently created to oldest).
+   */
+  def withAssetCleaner[T](wskprops: WskProps)(test: (WskProps, AssetCleaner) => T): T = {
+    // create new asset list to track what must be deleted after test completes
+    val assetsToDeleteAfterTest = new Assets()
+
+    try {
+      test(wskprops, new AssetCleaner(assetsToDeleteAfterTest, wskprops))
+    } catch {
+      case t: Throwable =>
+        // log the exception that occurred in the test and rethrow it
+        println(s"Exception occurred during test execution: $t")
+        t.printStackTrace()
+        throw t
+    } finally {
+      // delete assets in reverse order so that was created last is deleted first
+      new AssetCleaner(assetsToDeleteAfterTest, wskprops).deleteAssets()
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskEntitlementTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskEntitlementTests.scala
@@ -129,61 +129,63 @@ abstract class WskEntitlementTests()
   private val retriesOnTestFailures = 5
   private val waitBeforeRetry = 1.second
 
-  var behaviorname = "Wsk Package Entitlement"
-  behavior of s"$behaviorname"
+  behavior of "Wsk Package Entitlement"
 
-  var testname = "not allow unauthorized subject to operate on private action"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val privateAction = "privateAction"
+  it should "not allow unauthorized subject to operate on private action" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk Package Entitlement"
+      val testname = "not allow unauthorized subject to operate on private action"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val privateAction = "privateAction"
 
-          assetHelper.withCleaner(wsk.action, privateAction) { (action, name) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))(wp)
-          }
+            assetHelper.withCleaner(wsk.action, privateAction) { (action, name) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))(wp)
+            }
 
-          val fullyQualifiedActionName = s"/$guestNamespace/$privateAction"
-          wsk.action
-            .get(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
-            .stderr should include("not authorized")
+            val fullyQualifiedActionName = s"/$guestNamespace/$privateAction"
+            wsk.action
+              .get(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+              .stderr should include("not authorized")
 
-          withAssetCleaner(defaultWskProps) {
-            (wp, assetHelper) =>
-              assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
-                val rr = action.create(name, None, update = true, expectedExitCode = forbiddenCode)(wp)
-                rr.stderr should include("not authorized")
-                rr
-              }
+            withAssetCleaner(defaultWskProps) {
+              (wp, assetHelper) =>
+                assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
+                  val rr = action.create(name, None, update = true, expectedExitCode = forbiddenCode)(wp)
+                  rr.stderr should include("not authorized")
+                  rr
+                }
 
-              assetHelper.withCleaner(wsk.action, "unauthorized sequence", confirmDelete = false) { (action, name) =>
-                val rr = action.create(
-                  name,
-                  Some(fullyQualifiedActionName),
-                  kind = Some("sequence"),
-                  update = true,
-                  expectedExitCode = forbiddenCode)(wp)
-                rr.stderr should include("not authorized")
-                rr
-              }
-          }
+                assetHelper.withCleaner(wsk.action, "unauthorized sequence", confirmDelete = false) { (action, name) =>
+                  val rr = action.create(
+                    name,
+                    Some(fullyQualifiedActionName),
+                    kind = Some("sequence"),
+                    update = true,
+                    expectedExitCode = forbiddenCode)(wp)
+                  rr.stderr should include("not authorized")
+                  rr
+                }
+            }
 
-          wsk.action
-            .delete(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
-            .stderr should include("not authorized")
+            wsk.action
+              .delete(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+              .stderr should include("not authorized")
 
-          wsk.action
-            .invoke(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
-            .stderr should include("not authorized")
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            wsk.action
+              .invoke(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+              .stderr should include("not authorized")
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject deleting action in shared package not owned by authkey"
-  it should s"$testname" in withAssetCleaner(guestWskProps) {
+  it should "reject deleting action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+    val behaviorname = "Wsk Package Entitlement"
+    val testname = "reject deleting action in shared package not owned by authkey"
     val samplePackage = "samplePackage-" + System.currentTimeMillis()
     val sampleAction = "sampleAction"
     val fullSampleActionName = s"$samplePackage/$sampleAction"
@@ -211,8 +213,9 @@ abstract class WskEntitlementTests()
           Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create action in shared package not owned by authkey"
-  it should s"$testname" in withAssetCleaner(guestWskProps) {
+  it should "reject create action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+    val behaviorname = "Wsk Package Entitlement"
+    val testname = "reject create action in shared package not owned by authkey"
     val samplePackage = "samplePackage-" + System.currentTimeMillis()
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
@@ -237,8 +240,9 @@ abstract class WskEntitlementTests()
           Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update action in shared package not owned by authkey"
   it should "reject update action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+    val behaviorname = "Wsk Package Entitlement"
+    val testname = "reject update action in shared package not owned by authkey"
     val samplePackage = "samplePackage-" + System.currentTimeMillis()
     val sampleAction = "sampleAction"
     val fullSampleActionName = s"$samplePackage/$sampleAction"
@@ -266,11 +270,11 @@ abstract class WskEntitlementTests()
           Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Package Listing"
-  behavior of s"$behaviorname"
+  behavior of "Wsk Package Listing"
 
-  testname = "list shared packages"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+  it should "list shared packages" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Listing"
+    val testname = "list shared packages"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -290,8 +294,9 @@ abstract class WskEntitlementTests()
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "list shared packages when package is turned into public"
-  it should s"$testname" in withAssetCleaner(guestWskProps) {
+  it should "list shared packages when package is turned into public" in withAssetCleaner(guestWskProps) {
+    val behaviorname = "Wsk Package Listing"
+    val testname = "list shared packages when package is turned into public"
     val samplePackage = "samplePackage-" + System.currentTimeMillis()
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
@@ -320,8 +325,9 @@ abstract class WskEntitlementTests()
   }
 
   //TODO: convert to API-level test under whisk.core.controller once issues/3959 is resolved
-  testname = "reject getting package from invalid namespace"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+  it should "reject getting package from invalid namespace" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Listing"
+    val testname = "reject getting package from invalid namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -336,19 +342,21 @@ abstract class WskEntitlementTests()
   }
 
   //TODO: convert to API-level test under whisk.core.controller once issues/3959 is resolved
-  testname = "reject getting invalid package from valid namespace"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val invalidPackage = "utilssss"
-          wsk.pkg.get(s"/whisk.system/${invalidPackage}", expectedExitCode = forbiddenCode)(wp).stderr should include(
-            "not authorized")
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+  it should "reject getting invalid package from valid namespace" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk Package Listing"
+      val testname = "reject getting invalid package from valid namespace"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val invalidPackage = "utilssss"
+            wsk.pkg.get(s"/whisk.system/${invalidPackage}", expectedExitCode = forbiddenCode)(wp).stderr should include(
+              "not authorized")
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   def verifyPackageSharedList(packageList: RunResult, namespace: String, packageName: String): Unit = {
@@ -358,6 +366,8 @@ abstract class WskEntitlementTests()
   }
 
   it should "not list private packages" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Listing"
+    val testname = "not list private packages"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -384,6 +394,8 @@ abstract class WskEntitlementTests()
   }
 
   it should "list shared package actions" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Listing"
+    val testname = "list shared package actions"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -417,11 +429,11 @@ abstract class WskEntitlementTests()
     result should include(s"/$namespace/$packageName/$actionName")
   }
 
-  behaviorname = "Wsk Package Binding"
-  behavior of s"$behaviorname"
+  behavior of "Wsk Package Binding"
 
-  testname = "create a package binding"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+  it should "create a package binding" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Binding"
+    val testname = "create a package binding"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -454,8 +466,9 @@ abstract class WskEntitlementTests()
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not create a package binding for private package"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+  it should "not create a package binding for private package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Binding"
+    val testname = "not create a package binding for private package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -478,11 +491,11 @@ abstract class WskEntitlementTests()
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Package Action"
-  behavior of s"$behaviorname"
+  behavior of "Wsk Package Action"
 
-  testname = "get and invoke an action from package"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+  it should "get and invoke an action from package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Action"
+    val testname = "get and invoke an action from package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -524,8 +537,9 @@ abstract class WskEntitlementTests()
     stdout should include(""""value": "A"""")
   }
 
-  testname = "invoke an action sequence from package"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+  it should "invoke an action sequence from package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    val behaviorname = "Wsk Package Action"
+    val testname = "invoke an action sequence from package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -561,8 +575,11 @@ abstract class WskEntitlementTests()
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not allow invoke an action sequence with more than one component from package after entitlement change"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (guestwp, assetHelper) =>
+  it should "not allow invoke an action sequence with more than one component from package after entitlement change" in withAssetCleaner(
+    guestWskProps) { (guestwp, assetHelper) =>
+    val behaviorname = "Wsk Package Action"
+    val testname =
+      "not allow invoke an action sequence with more than one component from package after entitlement change"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -605,8 +622,10 @@ abstract class WskEntitlementTests()
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke a packaged action not owned by the subject to get the subject's namespace"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (_, assetHelper) =>
+  it should "invoke a packaged action not owned by the subject to get the subject's namespace" in withAssetCleaner(
+    guestWskProps) { (_, assetHelper) =>
+    val behaviorname = "Wsk Package Action"
+    val testname = "invoke a packaged action not owned by the subject to get the subject's namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -639,39 +658,39 @@ abstract class WskEntitlementTests()
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Trigger Feed"
-  behavior of s"$behaviorname"
+  behavior of "Wsk Trigger Feed"
 
-  testname = "not create a trigger with timeout error when feed fails to initialize"
-  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
-          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-            pkg.create(samplePackage, shared = Some(true))(wp)
-          }
-
-          val sampleFeed = s"$samplePackage/sampleFeed"
-          assetHelper.withCleaner(wsk.action, sampleFeed) {
-            val file = Some(TestUtils.getTestActionFilename("empty.js"))
-            (action, _) =>
-              action.create(sampleFeed, file, kind = Some("nodejs:default"))(wp)
-          }
-
-          val fullyQualifiedFeedName = s"/$guestNamespace/$sampleFeed"
-          withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
-            assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
-              trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = timeoutCode)(wp)
+  it should "not create a trigger with timeout error when feed fails to initialize" in withAssetCleaner(guestWskProps) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk Trigger Feed"
+      val testname = "not create a trigger with timeout error when feed fails to initialize"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val samplePackage = "samplePackage-" + System.currentTimeMillis()
+            assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+              pkg.create(samplePackage, shared = Some(true))(wp)
             }
-            // with several active controllers race condition with cache invalidation might occur, thus retry
-            retry(wsk.trigger.get("badfeed", expectedExitCode = notFoundCode)(wp))
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
-  }
 
+            val sampleFeed = s"$samplePackage/sampleFeed"
+            assetHelper.withCleaner(wsk.action, sampleFeed) {
+              val file = Some(TestUtils.getTestActionFilename("empty.js"))
+              (action, _) =>
+                action.create(sampleFeed, file, kind = Some("nodejs:default"))(wp)
+            }
+
+            val fullyQualifiedFeedName = s"/$guestNamespace/$sampleFeed"
+            withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+              assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
+                trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = timeoutCode)(wp)
+              }
+              // with several active controllers race condition with cache invalidation might occur, thus retry
+              retry(wsk.trigger.get("badfeed", expectedExitCode = notFoundCode)(wp))
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskEntitlementTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskEntitlementTests.scala
@@ -70,9 +70,9 @@ abstract class WskEntitlementTests()
 
   def retry[A](block: => A) = org.apache.openwhisk.utils.retry(block, 10, Some(500.milliseconds))
 
-  val samplePackage = "samplePackage"
-  val sampleAction = "sampleAction"
-  val fullSampleActionName = s"$samplePackage/$sampleAction"
+  //val samplePackage = "samplePackage"
+  //val sampleAction = "sampleAction"
+  //val fullSampleActionName = s"$samplePackage/$sampleAction"
   val guestNamespace = guestWskProps.namespace
   println(s"guestWskProps: $guestWskProps, guestNamespace: $guestNamespace, authKey: ${guestWskProps.authKey}")
 
@@ -126,144 +126,229 @@ abstract class WskEntitlementTests()
   val viewEntriesResult = waitForEntriesToAppear(subjectsDbClient, guestWskProps.authKey, 1)
   println(s"viewEntriesResult: $viewEntriesResult")
 
-  behavior of "Wsk Package Entitlement"
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
 
-  it should "not allow unauthorized subject to operate on private action" in withAssetCleaner(guestWskProps) {
-    (wp, assetHelper) =>
-      val privateAction = "privateAction"
+  var behaviorname = "Wsk Package Entitlement"
+  behavior of s"$behaviorname"
 
-      assetHelper.withCleaner(wsk.action, privateAction) { (action, name) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))(wp)
-      }
+  var testname = "not allow unauthorized subject to operate on private action"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val privateAction = "privateAction"
 
-      val fullyQualifiedActionName = s"/$guestNamespace/$privateAction"
-      wsk.action
-        .get(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
-        .stderr should include("not authorized")
+          assetHelper.withCleaner(wsk.action, privateAction) { (action, name) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))(wp)
+          }
 
-      withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
-        assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
-          val rr = action.create(name, None, update = true, expectedExitCode = forbiddenCode)(wp)
-          rr.stderr should include("not authorized")
-          rr
-        }
+          val fullyQualifiedActionName = s"/$guestNamespace/$privateAction"
+          wsk.action
+            .get(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+            .stderr should include("not authorized")
 
-        assetHelper.withCleaner(wsk.action, "unauthorized sequence", confirmDelete = false) { (action, name) =>
-          val rr = action.create(
-            name,
-            Some(fullyQualifiedActionName),
-            kind = Some("sequence"),
-            update = true,
-            expectedExitCode = forbiddenCode)(wp)
-          rr.stderr should include("not authorized")
-          rr
-        }
-      }
+          withAssetCleaner(defaultWskProps) {
+            (wp, assetHelper) =>
+              assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
+                val rr = action.create(name, None, update = true, expectedExitCode = forbiddenCode)(wp)
+                rr.stderr should include("not authorized")
+                rr
+              }
 
-      wsk.action
-        .delete(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
-        .stderr should include("not authorized")
+              assetHelper.withCleaner(wsk.action, "unauthorized sequence", confirmDelete = false) { (action, name) =>
+                val rr = action.create(
+                  name,
+                  Some(fullyQualifiedActionName),
+                  kind = Some("sequence"),
+                  update = true,
+                  expectedExitCode = forbiddenCode)(wp)
+                rr.stderr should include("not authorized")
+                rr
+              }
+          }
 
-      wsk.action
-        .invoke(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
-        .stderr should include("not authorized")
+          wsk.action
+            .delete(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+            .stderr should include("not authorized")
+
+          wsk.action
+            .invoke(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+            .stderr should include("not authorized")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject deleting action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+  testname = "reject deleting action in shared package not owned by authkey"
+  it should s"$testname" in withAssetCleaner(guestWskProps) {
+    val samplePackage = "samplePackage-" + System.currentTimeMillis()
+    val sampleAction = "sampleAction"
+    val fullSampleActionName = s"$samplePackage/$sampleAction"
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-        pkg.create(samplePackage, shared = Some(true))(wp)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+              pkg.create(samplePackage, shared = Some(true))(wp)
+            }
 
-      assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-        val file = Some(TestUtils.getTestActionFilename("empty.js"))
-        (action, _) =>
-          action.create(fullSampleActionName, file)(wp)
-      }
+            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+              val file = Some(TestUtils.getTestActionFilename("empty.js"))
+              (action, _) =>
+                action.create(fullSampleActionName, file)(wp)
+            }
 
-      val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-      wsk.action.get(fullyQualifiedActionName)(defaultWskProps)
-      wsk.action.delete(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+            wsk.action.get(fullyQualifiedActionName)(defaultWskProps)
+            wsk.action.delete(fullyQualifiedActionName, expectedExitCode = forbiddenCode)(defaultWskProps)
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+  testname = "reject create action in shared package not owned by authkey"
+  it should s"$testname" in withAssetCleaner(guestWskProps) {
+    val samplePackage = "samplePackage-" + System.currentTimeMillis()
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, name) =>
-        pkg.create(name, shared = Some(true))(wp)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, name) =>
+              pkg.create(name, shared = Some(true))(wp)
+            }
 
-      val fullyQualifiedActionName = s"/$guestNamespace/notallowed"
-      val file = Some(TestUtils.getTestActionFilename("empty.js"))
+            val fullyQualifiedActionName = s"/$guestNamespace/notallowed"
+            val file = Some(TestUtils.getTestActionFilename("empty.js"))
 
-      withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
-        assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
-          action.create(name, file, expectedExitCode = forbiddenCode)(wp)
-        }
-      }
+            withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+              assetHelper.withCleaner(wsk.action, fullyQualifiedActionName, confirmDelete = false) { (action, name) =>
+                action.create(name, file, expectedExitCode = forbiddenCode)(wp)
+              }
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
+  testname = "reject update action in shared package not owned by authkey"
   it should "reject update action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
+    val samplePackage = "samplePackage-" + System.currentTimeMillis()
+    val sampleAction = "sampleAction"
+    val fullSampleActionName = s"$samplePackage/$sampleAction"
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-        pkg.create(samplePackage, shared = Some(true))(wp)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+              pkg.create(samplePackage, shared = Some(true))(wp)
+            }
 
-      assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-        val file = Some(TestUtils.getTestActionFilename("empty.js"))
-        (action, _) =>
-          action.create(fullSampleActionName, file)(wp)
-      }
+            assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+              val file = Some(TestUtils.getTestActionFilename("empty.js"))
+              (action, _) =>
+                action.create(fullSampleActionName, file)(wp)
+            }
 
-      val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-      wsk.action.create(fullyQualifiedActionName, None, update = true, expectedExitCode = forbiddenCode)(
-        defaultWskProps)
+            val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+            wsk.action.create(fullyQualifiedActionName, None, update = true, expectedExitCode = forbiddenCode)(
+              defaultWskProps)
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Package Listing"
+  behaviorname = "Wsk Package Listing"
+  behavior of s"$behaviorname"
 
-  it should "list shared packages" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-      pkg.create(samplePackage, shared = Some(true))(wp)
-    }
+  testname = "list shared packages"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage, shared = Some(true))(wp)
+          }
 
-    retry {
-      val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
-      verifyPackageSharedList(packageList, guestNamespace, samplePackage)
-    }
+          retry {
+            val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
+            verifyPackageSharedList(packageList, guestNamespace, samplePackage)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "list shared packages when package is turned into public" in withAssetCleaner(guestWskProps) {
+  testname = "list shared packages when package is turned into public"
+  it should s"$testname" in withAssetCleaner(guestWskProps) {
+    val samplePackage = "samplePackage-" + System.currentTimeMillis()
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-        pkg.create(samplePackage)(wp)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+              pkg.create(samplePackage)(wp)
+            }
 
-      retry {
-        val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
-        verifyPackageNotSharedList(packageList, guestNamespace, samplePackage)
-      }
+            retry {
+              val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
+              verifyPackageNotSharedList(packageList, guestNamespace, samplePackage)
+            }
 
-      wsk.pkg.create(samplePackage, update = true, shared = Some(true))(wp)
+            wsk.pkg.create(samplePackage, update = true, shared = Some(true))(wp)
 
-      retry {
-        val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
-        verifyPackageSharedList(packageList, guestNamespace, samplePackage)
-      }
+            retry {
+              val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
+              verifyPackageSharedList(packageList, guestNamespace, samplePackage)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //TODO: convert to API-level test under whisk.core.controller once issues/3959 is resolved
-  it should "reject getting package from invalid namespace" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    val invalidNamespace = "whisk.systsdf"
-    wsk.pkg.get(s"/${invalidNamespace}/utils", expectedExitCode = forbiddenCode)(wp).stderr should include(
-      "not authorized")
+  testname = "reject getting package from invalid namespace"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val invalidNamespace = "whisk.systsdf"
+          wsk.pkg.get(s"/${invalidNamespace}/utils", expectedExitCode = forbiddenCode)(wp).stderr should include(
+            "not authorized")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   //TODO: convert to API-level test under whisk.core.controller once issues/3959 is resolved
-  it should "reject getting invalid package from valid namespace" in withAssetCleaner(guestWskProps) {
-    (wp, assetHelper) =>
-      val invalidPackage = "utilssss"
-      wsk.pkg.get(s"/whisk.system/${invalidPackage}", expectedExitCode = forbiddenCode)(wp).stderr should include(
-        "not authorized")
+  testname = "reject getting invalid package from valid namespace"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val invalidPackage = "utilssss"
+          wsk.pkg.get(s"/whisk.system/${invalidPackage}", expectedExitCode = forbiddenCode)(wp).stderr should include(
+            "not authorized")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   def verifyPackageSharedList(packageList: RunResult, namespace: String, packageName: String): Unit = {
@@ -273,14 +358,23 @@ abstract class WskEntitlementTests()
   }
 
   it should "not list private packages" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-      pkg.create(samplePackage)(wp)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage)(wp)
+          }
 
-    retry {
-      val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
-      verifyPackageNotSharedList(packageList, guestNamespace, samplePackage)
-    }
+          retry {
+            val packageList = wsk.pkg.list(Some(s"/$guestNamespace"))(defaultWskProps)
+            verifyPackageNotSharedList(packageList, guestNamespace, samplePackage)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   def verifyPackageNotSharedList(packageList: RunResult, namespace: String, packageName: String): Unit = {
@@ -290,21 +384,32 @@ abstract class WskEntitlementTests()
   }
 
   it should "list shared package actions" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-      pkg.create(samplePackage, shared = Some(true))(wp)
-    }
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val sampleAction = "sampleAction"
+          val fullSampleActionName = s"$samplePackage/$sampleAction"
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage, shared = Some(true))(wp)
+          }
 
-    assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-      val file = Some(TestUtils.getTestActionFilename("empty.js"))
-      (action, _) =>
-        action.create(fullSampleActionName, file, kind = Some("nodejs:default"))(wp)
-    }
+          assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+            val file = Some(TestUtils.getTestActionFilename("empty.js"))
+            (action, _) =>
+              action.create(fullSampleActionName, file, kind = Some("nodejs:default"))(wp)
+          }
 
-    val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
-    retry {
-      val packageList = wsk.action.list(Some(fullyQualifiedPackageName))(defaultWskProps)
-      verifyPackageList(packageList, guestNamespace, samplePackage, sampleAction)
-    }
+          val fullyQualifiedPackageName = s"/$guestNamespace/$samplePackage"
+          retry {
+            val packageList = wsk.action.list(Some(fullyQualifiedPackageName))(defaultWskProps)
+            verifyPackageList(packageList, guestNamespace, samplePackage, sampleAction)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   def verifyPackageList(packageList: RunResult, namespace: String, packageName: String, actionName: String): Unit = {
@@ -312,67 +417,102 @@ abstract class WskEntitlementTests()
     result should include(s"/$namespace/$packageName/$actionName")
   }
 
-  behavior of "Wsk Package Binding"
+  behaviorname = "Wsk Package Binding"
+  behavior of s"$behaviorname"
 
-  it should "create a package binding" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-      pkg.create(samplePackage, shared = Some(true))(wp)
-    }
+  testname = "create a package binding"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage, shared = Some(true))(wp)
+          }
 
-    val name = "bindPackage"
-    val annotations = Map("a" -> "A".toJson, WhiskPackage.bindingFieldName -> "xxx".toJson)
-    val provider = s"/$guestNamespace/$samplePackage"
-    withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-        pkg.bind(provider, name, annotations = annotations)(wp)
-      }
+          val name = "bindPackage"
+          val annotations = Map("a" -> "A".toJson, WhiskPackage.bindingFieldName -> "xxx".toJson)
+          val provider = s"/$guestNamespace/$samplePackage"
+          withAssetCleaner(defaultWskProps) {
+            (wp, assetHelper) =>
+              assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+                pkg.bind(provider, name, annotations = annotations)(wp)
+              }
 
-      val stdout = wsk.pkg.get(name)(defaultWskProps).stdout
-      val annotationString = wsk.parseJsonString(stdout).fields("annotations").toString
-      annotationString should include(""""key":"a"""")
-      annotationString should include(""""value":"A"""")
-      annotationString should include(s""""key":"${WhiskPackage.bindingFieldName}"""")
-      annotationString should not include (""""key":"xxx"""")
-      annotationString should include(s""""name":"${samplePackage}"""")
-    }
+              val stdout = wsk.pkg.get(name)(defaultWskProps).stdout
+              val annotationString = wsk.parseJsonString(stdout).fields("annotations").toString
+              annotationString should include(""""key":"a"""")
+              annotationString should include(""""value":"A"""")
+              annotationString should include(s""""key":"${WhiskPackage.bindingFieldName}"""")
+              annotationString should not include (""""key":"xxx"""")
+              annotationString should include(s""""name":"${samplePackage}"""")
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not create a package binding for private package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-      pkg.create(samplePackage, shared = Some(false))(wp)
-    }
+  testname = "not create a package binding for private package"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage, shared = Some(false))(wp)
+          }
 
-    val name = "bindPackage"
-    val provider = s"/$guestNamespace/$samplePackage"
-    withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, name, confirmDelete = false) { (pkg, _) =>
-        pkg.bind(provider, name, expectedExitCode = forbiddenCode)(wp)
-      }
-    }
+          val name = "bindPackage"
+          val provider = s"/$guestNamespace/$samplePackage"
+          withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.pkg, name, confirmDelete = false) { (pkg, _) =>
+              pkg.bind(provider, name, expectedExitCode = forbiddenCode)(wp)
+            }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Package Action"
+  behaviorname = "Wsk Package Action"
+  behavior of s"$behaviorname"
 
-  it should "get and invoke an action from package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-      pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
-    }
+  testname = "get and invoke an action from package"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val sampleAction = "sampleAction"
+          val fullSampleActionName = s"$samplePackage/$sampleAction"
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
+          }
 
-    assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
-      (action, _) =>
-        action.create(fullSampleActionName, file)(wp)
-    }
+          assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+            (action, _) =>
+              action.create(fullSampleActionName, file)(wp)
+          }
 
-    val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-    val action = wsk.action.get(fullyQualifiedActionName)(defaultWskProps)
-    verifyAction(action)
+          val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+          val action = wsk.action.get(fullyQualifiedActionName)(defaultWskProps)
+          verifyAction(action)
 
-    val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
+          val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
 
-    withActivation(wsk.activation, run)({
-      _.response.success shouldBe true
-    })(defaultWskProps)
+          withActivation(wsk.activation, run)({
+            _.response.success shouldBe true
+          })(defaultWskProps)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   def verifyAction(action: RunResult) = {
@@ -384,108 +524,154 @@ abstract class WskEntitlementTests()
     stdout should include(""""value": "A"""")
   }
 
-  it should "invoke an action sequence from package" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-      pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
-    }
+  testname = "invoke an action sequence from package"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val sampleAction = "sampleAction"
+          val fullSampleActionName = s"$samplePackage/$sampleAction"
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage, parameters = Map("a" -> "A".toJson), shared = Some(true))(wp)
+          }
 
-    assetHelper.withCleaner(wsk.action, fullSampleActionName) {
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
-      (action, _) =>
-        action.create(fullSampleActionName, file)(wp)
-    }
+          assetHelper.withCleaner(wsk.action, fullSampleActionName) {
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+            (action, _) =>
+              action.create(fullSampleActionName, file)(wp)
+          }
 
-    withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, "sequence") { (action, name) =>
-        val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-        action.create(name, Some(fullyQualifiedActionName), kind = Some("sequence"), update = true)(wp)
-      }
+          withAssetCleaner(defaultWskProps) {
+            (wp, assetHelper) =>
+              assetHelper.withCleaner(wsk.action, "sequence") { (action, name) =>
+                val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+                action.create(name, Some(fullyQualifiedActionName), kind = Some("sequence"), update = true)(wp)
+              }
 
-      val run = wsk.action.invoke("sequence")(defaultWskProps)
-      withActivation(wsk.activation, run)({
-        _.response.success shouldBe true
-      })(defaultWskProps)
-    }
+              val run = wsk.action.invoke("sequence")(defaultWskProps)
+              withActivation(wsk.activation, run)({
+                _.response.success shouldBe true
+              })(defaultWskProps)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not allow invoke an action sequence with more than one component from package after entitlement change" in withAssetCleaner(
-    guestWskProps) { (guestwp, assetHelper) =>
-    val privateSamplePackage = samplePackage + "prv"
-    Seq(samplePackage, privateSamplePackage).foreach { n =>
-      assetHelper.withCleaner(wsk.pkg, n) { (pkg, _) =>
-        pkg.create(n, parameters = Map("a" -> "A".toJson), shared = Some(true))(guestwp)
-      }
-    }
+  testname = "not allow invoke an action sequence with more than one component from package after entitlement change"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (guestwp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val sampleAction = "sampleAction"
+          val fullSampleActionName = s"$samplePackage/$sampleAction"
+          val privateSamplePackage = samplePackage + "prv"
+          Seq(samplePackage, privateSamplePackage).foreach { n =>
+            assetHelper.withCleaner(wsk.pkg, n) { (pkg, _) =>
+              pkg.create(n, parameters = Map("a" -> "A".toJson), shared = Some(true))(guestwp)
+            }
+          }
 
-    Seq(fullSampleActionName, s"$privateSamplePackage/$sampleAction").foreach { a =>
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
-      assetHelper.withCleaner(wsk.action, a) { (action, _) =>
-        action.create(a, file)(guestwp)
-      }
-    }
+          Seq(fullSampleActionName, s"$privateSamplePackage/$sampleAction").foreach { a =>
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+            assetHelper.withCleaner(wsk.action, a) { (action, _) =>
+              action.create(a, file)(guestwp)
+            }
+          }
 
-    withAssetCleaner(defaultWskProps) { (dwp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, "sequence") { (action, name) =>
-        val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
-        val fullyQualifiedActionName2 = s"/$guestNamespace/$privateSamplePackage/$sampleAction"
-        action.create(name, Some(s"$fullyQualifiedActionName,$fullyQualifiedActionName2"), kind = Some("sequence"))(dwp)
-      }
+          withAssetCleaner(defaultWskProps) {
+            (dwp, assetHelper) =>
+              assetHelper.withCleaner(wsk.action, "sequence") { (action, name) =>
+                val fullyQualifiedActionName = s"/$guestNamespace/$fullSampleActionName"
+                val fullyQualifiedActionName2 = s"/$guestNamespace/$privateSamplePackage/$sampleAction"
+                action.create(
+                  name,
+                  Some(s"$fullyQualifiedActionName,$fullyQualifiedActionName2"),
+                  kind = Some("sequence"))(dwp)
+              }
 
-      // change package visibility
-      wsk.pkg.create(privateSamplePackage, update = true, shared = Some(false))(guestwp)
-      wsk.action.invoke("sequence", expectedExitCode = forbiddenCode)(defaultWskProps)
-    }
+              // change package visibility
+              wsk.pkg.create(privateSamplePackage, update = true, shared = Some(false))(guestwp)
+              wsk.action.invoke("sequence", expectedExitCode = forbiddenCode)(defaultWskProps)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke a packaged action not owned by the subject to get the subject's namespace" in withAssetCleaner(
-    guestWskProps) { (_, assetHelper) =>
-    val packageName = "namespacePackage"
-    val actionName = "namespaceAction"
-    val packagedActionName = s"$packageName/$actionName"
+  testname = "invoke a packaged action not owned by the subject to get the subject's namespace"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (_, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val packageName = "namespacePackage"
+          val actionName = "namespaceAction"
+          val packagedActionName = s"$packageName/$actionName"
 
-    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
-      pkg.create(packageName, shared = Some(true))(guestWskProps)
-    }
+          assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+            pkg.create(packageName, shared = Some(true))(guestWskProps)
+          }
 
-    assetHelper.withCleaner(wsk.action, packagedActionName) {
-      val file = Some(TestUtils.getTestActionFilename("helloContext.js"))
-      (action, _) =>
-        action.create(packagedActionName, file)(guestWskProps)
-    }
+          assetHelper.withCleaner(wsk.action, packagedActionName) {
+            val file = Some(TestUtils.getTestActionFilename("helloContext.js"))
+            (action, _) =>
+              action.create(packagedActionName, file)(guestWskProps)
+          }
 
-    val fullyQualifiedActionName = s"/$guestNamespace/$packagedActionName"
-    val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
+          val fullyQualifiedActionName = s"/$guestNamespace/$packagedActionName"
+          val run = wsk.action.invoke(fullyQualifiedActionName)(defaultWskProps)
 
-    withActivation(wsk.activation, run)({ activation =>
-      val namespace = wsk.namespace.whois()(defaultWskProps)
-      activation.response.success shouldBe true
-      activation.response.result.get.toString should include regex (s""""namespace":\\s*"$namespace"""")
-    })(defaultWskProps)
+          withActivation(wsk.activation, run)({ activation =>
+            val namespace = wsk.namespace.whois()(defaultWskProps)
+            activation.response.success shouldBe true
+            activation.response.result.get.toString should include regex (s""""namespace":\\s*"$namespace"""")
+          })(defaultWskProps)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Trigger Feed"
+  behaviorname = "Wsk Trigger Feed"
+  behavior of s"$behaviorname"
 
-  it should "not create a trigger with timeout error when feed fails to initialize" in withAssetCleaner(guestWskProps) {
-    (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
-        pkg.create(samplePackage, shared = Some(true))(wp)
-      }
+  testname = "not create a trigger with timeout error when feed fails to initialize"
+  it should s"$testname" in withAssetCleaner(guestWskProps) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
+            pkg.create(samplePackage, shared = Some(true))(wp)
+          }
 
-      val sampleFeed = s"$samplePackage/sampleFeed"
-      assetHelper.withCleaner(wsk.action, sampleFeed) {
-        val file = Some(TestUtils.getTestActionFilename("empty.js"))
-        (action, _) =>
-          action.create(sampleFeed, file, kind = Some("nodejs:default"))(wp)
-      }
+          val sampleFeed = s"$samplePackage/sampleFeed"
+          assetHelper.withCleaner(wsk.action, sampleFeed) {
+            val file = Some(TestUtils.getTestActionFilename("empty.js"))
+            (action, _) =>
+              action.create(sampleFeed, file, kind = Some("nodejs:default"))(wp)
+          }
 
-      val fullyQualifiedFeedName = s"/$guestNamespace/$sampleFeed"
-      withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
-        assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
-          trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = timeoutCode)(wp)
-        }
-        // with several active controllers race condition with cache invalidation might occur, thus retry
-        retry(wsk.trigger.get("badfeed", expectedExitCode = notFoundCode)(wp))
-      }
+          val fullyQualifiedFeedName = s"/$guestNamespace/$sampleFeed"
+          withAssetCleaner(defaultWskProps) { (wp, assetHelper) =>
+            assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
+              trigger.create(name, feed = Some(fullyQualifiedFeedName), expectedExitCode = timeoutCode)(wp)
+            }
+            // with several active controllers race condition with cache invalidation might occur, thus retry
+            retry(wsk.trigger.get("badfeed", expectedExitCode = notFoundCode)(wp))
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskEntitlementTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskEntitlementTests.scala
@@ -186,7 +186,7 @@ abstract class WskEntitlementTests()
   it should "reject deleting action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
     val behaviorname = "Wsk Package Entitlement"
     val testname = "reject deleting action in shared package not owned by authkey"
-    val samplePackage = "samplePackage-" + System.currentTimeMillis()
+    val samplePackage = "samplePackage-reject-deleting-action"
     val sampleAction = "sampleAction"
     val fullSampleActionName = s"$samplePackage/$sampleAction"
     (wp, assetHelper) =>
@@ -216,7 +216,7 @@ abstract class WskEntitlementTests()
   it should "reject create action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
     val behaviorname = "Wsk Package Entitlement"
     val testname = "reject create action in shared package not owned by authkey"
-    val samplePackage = "samplePackage-" + System.currentTimeMillis()
+    val samplePackage = "samplePackage-reject-create-action"
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
         .retry(
@@ -243,7 +243,7 @@ abstract class WskEntitlementTests()
   it should "reject update action in shared package not owned by authkey" in withAssetCleaner(guestWskProps) {
     val behaviorname = "Wsk Package Entitlement"
     val testname = "reject update action in shared package not owned by authkey"
-    val samplePackage = "samplePackage-" + System.currentTimeMillis()
+    val samplePackage = "samplePackage-reject-update-action"
     val sampleAction = "sampleAction"
     val fullSampleActionName = s"$samplePackage/$sampleAction"
     (wp, assetHelper) =>
@@ -279,7 +279,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-list-shared-packages"
           assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
             pkg.create(samplePackage, shared = Some(true))(wp)
           }
@@ -297,7 +297,7 @@ abstract class WskEntitlementTests()
   it should "list shared packages when package is turned into public" in withAssetCleaner(guestWskProps) {
     val behaviorname = "Wsk Package Listing"
     val testname = "list shared packages when package is turned into public"
-    val samplePackage = "samplePackage-" + System.currentTimeMillis()
+    val samplePackage = "samplePackage-list-shared-packages-when"
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
         .retry(
@@ -372,7 +372,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-not-list-private-packages"
           assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
             pkg.create(samplePackage)(wp)
           }
@@ -400,7 +400,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-list-shared-package-actions"
           val sampleAction = "sampleAction"
           val fullSampleActionName = s"$samplePackage/$sampleAction"
           assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
@@ -438,7 +438,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-create-package-binding"
           assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
             pkg.create(samplePackage, shared = Some(true))(wp)
           }
@@ -473,7 +473,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-not-create-package-binding"
           assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
             pkg.create(samplePackage, shared = Some(false))(wp)
           }
@@ -500,7 +500,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-get-and-invoke-action"
           val sampleAction = "sampleAction"
           val fullSampleActionName = s"$samplePackage/$sampleAction"
           assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
@@ -544,7 +544,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-invoke-action-sequence"
           val sampleAction = "sampleAction"
           val fullSampleActionName = s"$samplePackage/$sampleAction"
           assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
@@ -584,7 +584,7 @@ abstract class WskEntitlementTests()
       .retry(
         {
           assetHelper.deleteAssets()
-          val samplePackage = "samplePackage-" + System.currentTimeMillis()
+          val samplePackage = "samplePackage-not-allow-invoke-action-sequence"
           val sampleAction = "sampleAction"
           val fullSampleActionName = s"$samplePackage/$sampleAction"
           val privateSamplePackage = samplePackage + "prv"
@@ -668,7 +668,7 @@ abstract class WskEntitlementTests()
         .retry(
           {
             assetHelper.deleteAssets()
-            val samplePackage = "samplePackage-" + System.currentTimeMillis()
+            val samplePackage = "samplePackage-not-create-trigger"
             assetHelper.withCleaner(wsk.pkg, samplePackage) { (pkg, _) =>
               pkg.create(samplePackage, shared = Some(true))(wp)
             }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -60,54 +60,55 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
   private val retriesOnTestFailures = 5
   private val waitBeforeRetry = 1.second
 
-  var behaviorname = "Wsk API basic usage"
-  behavior of s"$behaviorname"
+  behavior of "Wsk API basic usage"
 
-  var testname = "allow a 3 part Fully Qualified Name (FQN) without a leading '/'"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val guestNamespace = wsk.namespace.whois()
-          val packageName = "packageName3ptFQN"
-          val actionName = "actionName3ptFQN"
-          val triggerName = "triggerName3ptFQN"
-          val ruleName = "ruleName3ptFQN"
-          val fullQualifiedName = s"${guestNamespace}/${packageName}/${actionName}"
-          // Used for action and rule creation below
-          assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
-            pkg.create(packageName)
-          }
-          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-            trigger.create(triggerName)
-          }
-          // Test action and rule creation where action name is 3 part FQN w/out leading slash
-          assetHelper.withCleaner(wsk.action, fullQualifiedName) { (action, _) =>
-            action.create(fullQualifiedName, defaultAction)
-          }
-          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, _) =>
-            rule.create(ruleName, trigger = triggerName, action = fullQualifiedName)
-          }
+  it should "allow a 3 part Fully Qualified Name (FQN) without a leading '/'" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk API basic usage"
+      val testname = "allow a 3 part Fully Qualified Name (FQN) without a leading '/'"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val guestNamespace = wsk.namespace.whois()
+            val packageName = "packageName3ptFQN"
+            val actionName = "actionName3ptFQN"
+            val triggerName = "triggerName3ptFQN"
+            val ruleName = "ruleName3ptFQN"
+            val fullQualifiedName = s"${guestNamespace}/${packageName}/${actionName}"
+            // Used for action and rule creation below
+            assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+              pkg.create(packageName)
+            }
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+              trigger.create(triggerName)
+            }
+            // Test action and rule creation where action name is 3 part FQN w/out leading slash
+            assetHelper.withCleaner(wsk.action, fullQualifiedName) { (action, _) =>
+              action.create(fullQualifiedName, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName) { (rule, _) =>
+              rule.create(ruleName, trigger = triggerName, action = fullQualifiedName)
+            }
 
-          val run = wsk.action.invoke(fullQualifiedName)
-          withActivation(wsk.activation, run) { activation =>
-            activation.response.status shouldBe "success"
-          }
-          val action = wsk.action.get(fullQualifiedName)
-          action.getField("name") shouldBe actionName
-          action.getField("namespace") shouldBe s"${guestNamespace}/${packageName}"
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            val run = wsk.action.invoke(fullQualifiedName)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.status shouldBe "success"
+            }
+            val action = wsk.action.get(fullQualifiedName)
+            action.getField("name") shouldBe actionName
+            action.getField("namespace") shouldBe s"${guestNamespace}/${packageName}"
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk actions"
-  behavior of s"$behaviorname"
+  behavior of "Wsk actions"
 
-  testname = "reject creating entities with invalid names"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "reject creating entities with invalid names" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val behaviorname = "Wsk actions"
+    val testname = "reject creating entities with invalid names"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -132,164 +133,178 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get an action to verify parameter and annotation parsing"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "actionAnnotations"
-          val file = Some(TestUtils.getTestActionFilename("hello.js"))
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, file, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-          }
+  it should "create, and get an action to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "create, and get an action to verify parameter and annotation parsing"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "actionAnnotations"
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, file, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+            }
 
-          val action = wsk.action.get(name)
-          action.getField("name") shouldBe name
+            val action = wsk.action.get(name)
+            action.getField("name") shouldBe name
 
-          val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+            val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get an action to verify file parameter and annotation parsing"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "actionAnnotAndParamParsing"
-          val file = Some(TestUtils.getTestActionFilename("hello.js"))
-          val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+  it should "create, and get an action to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "create, and get an action to verify file parameter and annotation parsing"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "actionAnnotAndParamParsing"
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+            val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
 
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, file, annotationFile = argInput, parameterFile = argInput)
-          }
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, file, annotationFile = argInput, parameterFile = argInput)
+            }
 
-          val action = wsk.action.get(name)
-          action.getField("name") shouldBe name
+            val action = wsk.action.get(name)
+            action.getField("name") shouldBe name
 
-          val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+            val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create an action with the proper parameter and annotation escapes"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "actionEscapes"
-          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+  it should "create an action with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "create an action with the proper parameter and annotation escapes"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "actionEscapes"
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
 
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, file, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
-          }
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action
+                .create(name, file, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+            }
 
-          val action = wsk.action.get(name)
-          action.getField("name") shouldBe name
+            val action = wsk.action.get(name)
+            action.getField("name") shouldBe name
 
-          val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+            val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action that exits during initialization and get appropriate error"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "abort init"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("initexit.js")))
-          }
+  it should "invoke an action that exits during initialization and get appropriate error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "invoke an action that exits during initialization and get appropriate error"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "abort init"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("initexit.js")))
+            }
 
-          withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-            val response = activation.response
-            response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
-            response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+              val response = activation.response
+              response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
+              response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action that hangs during initialization and get appropriate error"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "hang init"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("initforever.js")), timeout = Some(3 seconds))
-          }
+  it should "invoke an action that hangs during initialization and get appropriate error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "invoke an action that hangs during initialization and get appropriate error"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "hang init"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("initforever.js")), timeout = Some(3 seconds))
+            }
 
-          withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-            val response = activation.response
-            response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
-            response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+              val response = activation.response
+              response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
+              response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action that exits during run and get appropriate error"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "abort run"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("runexit.js")))
-          }
+  it should "invoke an action that exits during run and get appropriate error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "invoke an action that exits during run and get appropriate error"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "abort run"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("runexit.js")))
+            }
 
-          withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-            val response = activation.response
-            response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
-            response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+              val response = activation.response
+              response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
+              response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "ensure keys are not omitted from activation record"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "ensure keys are not omitted from activation record" in withAssetCleaner(wskprops) {
+    val behaviorname = "Wsk actions"
+    val testname = "ensure keys are not omitted from activation record"
     val name = "activationRecordTest"
 
     (wp, assetHelper) =>
@@ -317,51 +332,55 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "write the action-path and the limits to the annotations"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "annotations"
-          val memoryLimit = 512 MB
-          val logLimit = 1 MB
-          val timeLimit = 60 seconds
+  it should "write the action-path and the limits to the annotations" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "write the action-path and the limits to the annotations"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "annotations"
+            val memoryLimit = 512 MB
+            val logLimit = 1 MB
+            val timeLimit = 60 seconds
 
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(
-              name,
-              Some(TestUtils.getTestActionFilename("helloAsync.js")),
-              memory = Some(memoryLimit),
-              timeout = Some(timeLimit),
-              logsize = Some(logLimit))
-          }
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(
+                name,
+                Some(TestUtils.getTestActionFilename("helloAsync.js")),
+                memory = Some(memoryLimit),
+                timeout = Some(timeLimit),
+                logsize = Some(logLimit))
+            }
 
-          val run = wsk.action.invoke(name, Map("payload" -> "this is a test".toJson))
-          withActivation(wsk.activation, run) {
-            activation =>
-              activation.response.status shouldBe "success"
-              val annotations = activation.annotations.get
+            val run = wsk.action.invoke(name, Map("payload" -> "this is a test".toJson))
+            withActivation(wsk.activation, run) {
+              activation =>
+                activation.response.status shouldBe "success"
+                val annotations = activation.annotations.get
 
-              val limitsObj = JsObject(
-                "key" -> JsString("limits"),
-                "value" -> ActionLimits(TimeLimit(timeLimit), MemoryLimit(memoryLimit), LogLimit(logLimit)).toJson)
+                val limitsObj = JsObject(
+                  "key" -> JsString("limits"),
+                  "value" -> ActionLimits(TimeLimit(timeLimit), MemoryLimit(memoryLimit), LogLimit(logLimit)).toJson)
 
-              val path = annotations.find {
-                _.fields("key").convertTo[String] == "path"
-              }.get
+                val path = annotations.find {
+                  _.fields("key").convertTo[String] == "path"
+                }.get
 
-              path.fields("value").convertTo[String] should fullyMatch regex (s""".*/$name""")
-              annotations should contain(limitsObj)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+                path.fields("value").convertTo[String] should fullyMatch regex (s""".*/$name""")
+                annotations should contain(limitsObj)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create, and invoke an action that utilizes an invalid docker container with appropriate error"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create, and invoke an action that utilizes an invalid docker container with appropriate error" in withAssetCleaner(
+    wskprops) {
+    val behaviorname = "Wsk actions"
+    val testname = "create, and invoke an action that utilizes an invalid docker container with appropriate error"
     val name = "invalidDockerContainer"
     val containerName = s"bogus${Random.alphanumeric.take(16).mkString.toLowerCase}"
 
@@ -395,8 +414,9 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action using npm openwhisk"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke an action using npm openwhisk" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val behaviorname = "Wsk actions"
+    val testname = "invoke an action using npm openwhisk"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -423,8 +443,9 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action receiving context properties excluding api key"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "invoke an action receiving context properties excluding api key" in withAssetCleaner(wskprops) {
+    val behaviorname = "Wsk actions"
+    val testname = "invoke an action receiving context properties excluding api key"
     assume(requireAPIKeyAnnotation)
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
@@ -456,84 +477,92 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action receiving context properties including api key"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val namespace = wsk.namespace.whois()
-          val name = "context"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(
-              name,
-              Some(TestUtils.getTestActionFilename("helloContext.js")),
-              annotations = Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue))
-          }
+  it should "invoke an action receiving context properties including api key" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "invoke an action receiving context properties including api key"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val namespace = wsk.namespace.whois()
+            val name = "context"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(
+                name,
+                Some(TestUtils.getTestActionFilename("helloContext.js")),
+                annotations = Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue))
+            }
 
-          val start = Instant.now(Clock.systemUTC()).toEpochMilli
-          val run = wsk.action.invoke(name)
-          withActivation(wsk.activation, run) { activation =>
-            activation.response.status shouldBe "success"
-            val fields = activation.response.result.get.convertTo[Map[String, String]]
-            fields("api_host") shouldBe WhiskProperties.getApiHostForAction
-            fields("api_key") shouldBe wskprops.authKey
-            fields("namespace") shouldBe namespace
-            fields("action_name") shouldBe s"/$namespace/$name"
-            fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
-            fields("activation_id") shouldBe activation.activationId
-            fields("deadline").toLong should be >= start
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            val start = Instant.now(Clock.systemUTC()).toEpochMilli
+            val run = wsk.action.invoke(name)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.status shouldBe "success"
+              val fields = activation.response.result.get.convertTo[Map[String, String]]
+              fields("api_host") shouldBe WhiskProperties.getApiHostForAction
+              fields("api_key") shouldBe wskprops.authKey
+              fields("namespace") shouldBe namespace
+              fields("action_name") shouldBe s"/$namespace/$name"
+              fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
+              fields("activation_id") shouldBe activation.activationId
+              fields("deadline").toLong should be >= start
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action successfully with options --blocking and --result"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "invokeResult"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
-          }
-          val args = Map("hello" -> "Robert".toJson)
-          val run = wsk.action.invoke(name, args, blocking = true, result = true)
-          //--result takes precedence over --blocking
-          run.stdout.parseJson shouldBe args.toJson
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+  it should "invoke an action successfully with options --blocking and --result" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "invoke an action successfully with options --blocking and --result"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "invokeResult"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
+            }
+            val args = Map("hello" -> "Robert".toJson)
+            val run = wsk.action.invoke(name, args, blocking = true, result = true)
+            //--result takes precedence over --blocking
+            run.stdout.parseJson shouldBe args.toJson
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action that returns a result by the deadline"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "deadline"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
-          }
+  it should "invoke an action that returns a result by the deadline" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "invoke an action that returns a result by the deadline"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "deadline"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
+            }
 
-          val run = wsk.action.invoke(name)
-          withActivation(wsk.activation, run) { activation =>
-            activation.response.status shouldBe "success"
-            activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            val run = wsk.action.invoke(name)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.status shouldBe "success"
+              activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke an action twice, where the first times out but the second does not and should succeed"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "invoke an action twice, where the first times out but the second does not and should succeed" in withAssetCleaner(
+    wskprops) {
+    val behaviorname = "Wsk actions"
+    val testname = "invoke an action twice, where the first times out but the second does not and should succeed"
     // this test issues two activations: the first is forced to time out and not return a result by its deadline (ie it does not resolve
     // its promise). The invoker should reclaim its container so that a second activation of the same action (which must happen within a
     // short period of time (seconds, not minutes) is allocated a fresh container and hence runs as expected (vs. hitting in the container
@@ -571,8 +600,9 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "ensure --web flags set the proper annotations"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "ensure --web flags set the proper annotations" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val behaviorname = "Wsk actions"
+    val testname = "ensure --web flags set the proper annotations"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -624,59 +654,62 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "ensure action update creates an action with --web flag"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val runtime = "nodejs:default"
-          val name = "webaction"
-          val file = Some(TestUtils.getTestActionFilename("echo.js"))
+  it should "ensure action update creates an action with --web flag" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk actions"
+      val testname = "ensure action update creates an action with --web flag"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val runtime = "nodejs:default"
+            val name = "webaction"
+            val file = Some(TestUtils.getTestActionFilename("echo.js"))
 
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, file, web = Some("true"), update = true, kind = Some(runtime))
-          }
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, file, web = Some("true"), update = true, kind = Some(runtime))
+            }
 
-          val baseAnnotations =
-            Parameters("web-export", JsTrue) ++
-              Parameters("raw-http", JsFalse) ++
-              Parameters("final", JsTrue)
+            val baseAnnotations =
+              Parameters("web-export", JsTrue) ++
+                Parameters("raw-http", JsFalse) ++
+                Parameters("final", JsTrue)
 
-          val testAnnotations = if (requireAPIKeyAnnotation) {
-            baseAnnotations ++
-              Parameters(Annotations.ProvideApiKeyAnnotationName, JsFalse)
-          } else {
-            baseAnnotations
-          }
+            val testAnnotations = if (requireAPIKeyAnnotation) {
+              baseAnnotations ++
+                Parameters(Annotations.ProvideApiKeyAnnotationName, JsFalse)
+            } else {
+              baseAnnotations
+            }
 
-          val action = wsk.action.get(name)
+            val action = wsk.action.get(name)
 
-          // first check if we got 'nodejs:*' in the exec value
-          action
-            .getFieldJsValue("annotations")
-            .convertTo[Seq[JsObject]]
-            .find(_.fields("key").convertTo[String] == "exec")
-            .map(_.fields("value"))
-            .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
-            .getOrElse(fail())
+            // first check if we got 'nodejs:*' in the exec value
+            action
+              .getFieldJsValue("annotations")
+              .convertTo[Seq[JsObject]]
+              .find(_.fields("key").convertTo[String] == "exec")
+              .map(_.fields("value"))
+              .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
+              .getOrElse(fail())
 
-          // then we check the remaining annotations
-          // we ignore the exec field here, since we already compared it above
-          action
-            .getFieldJsValue("annotations")
-            .convertTo[Set[JsObject]]
-            .filter(annotation => annotation.fields("key").convertTo[String] != "exec") shouldBe testAnnotations.toJsArray
-            .convertTo[Set[JsObject]]
+            // then we check the remaining annotations
+            // we ignore the exec field here, since we already compared it above
+            action
+              .getFieldJsValue("annotations")
+              .convertTo[Set[JsObject]]
+              .filter(annotation => annotation.fields("key").convertTo[String] != "exec") shouldBe testAnnotations.toJsArray
+              .convertTo[Set[JsObject]]
 
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke action while not encoding &, <, > characters"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val behaviorname = "Wsk actions"
+    val testname = "invoke action while not encoding &, <, > characters"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -702,11 +735,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk packages"
-  behavior of s"$behaviorname"
+  behavior of "Wsk packages"
 
-  testname = "create, and delete a package"
-  it should s"$testname" in {
+  it should "create, and delete a package" in {
+    val behaviorname = "Wsk packages"
+    val testname = "create, and delete a package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -719,92 +752,99 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get a package to verify parameter and annotation parsing"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "packageAnnotAndParamParsing"
+  it should "create, and get a package to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk packages"
+      val testname = "create, and get a package to verify parameter and annotation parsing"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "packageAnnotAndParamParsing"
 
-          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-            pkg.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-          }
+            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+              pkg.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+            }
 
-          val pack = wsk.pkg.get(name)
+            val pack = wsk.pkg.get(name)
 
-          val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+            val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get a package to verify file parameter and annotation parsing"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "packageAnnotAndParamFileParsing"
-          val file = Some(TestUtils.getTestActionFilename("hello.js"))
-          val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+  it should "create, and get a package to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk packages"
+      val testname = "create, and get a package to verify file parameter and annotation parsing"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "packageAnnotAndParamFileParsing"
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+            val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
 
-          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-            pkg.create(name, annotationFile = argInput, parameterFile = argInput)
-          }
+            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+              pkg.create(name, annotationFile = argInput, parameterFile = argInput)
+            }
 
-          val stdout = wsk.pkg.get(name).stdout
-          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+            val stdout = wsk.pkg.get(name).stdout
+            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create a package with the proper parameter and annotation escapes"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "packageEscapses"
+  it should "create a package with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk packages"
+      val testname = "create a package with the proper parameter and annotation escapes"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "packageEscapses"
 
-          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-            pkg.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
-          }
+            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+              pkg.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+            }
 
-          val pack = wsk.pkg.get(name)
-          val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+            val pack = wsk.pkg.get(name)
+            val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report conformance error accessing action as package"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "report conformance error accessing action as package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val behaviorname = "Wsk packages"
+    val testname = "report conformance error accessing action as package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -829,97 +869,103 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk triggers"
-  behavior of s"$behaviorname"
+  behavior of "Wsk triggers"
 
-  testname = "create, and get a trigger to verify parameter and annotation parsing"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "triggerAnnotAndParamParsing"
+  it should "create, and get a trigger to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk triggers"
+      val testname = "create, and get a trigger to verify parameter and annotation parsing"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "triggerAnnotAndParamParsing"
 
-          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-            trigger.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-          }
+            assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+              trigger.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+            }
 
-          val stdout = wsk.trigger.get(name).stdout
+            val stdout = wsk.trigger.get(name).stdout
 
-          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get a trigger to verify file parameter and annotation parsing"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "triggerAnnotAndParamFileParsing"
-          val file = Some(TestUtils.getTestActionFilename("hello.js"))
-          val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+  it should "create, and get a trigger to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk triggers"
+      val testname = "create, and get a trigger to verify file parameter and annotation parsing"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "triggerAnnotAndParamFileParsing"
+            val file = Some(TestUtils.getTestActionFilename("hello.js"))
+            val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
 
-          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-            trigger.create(name, annotationFile = argInput, parameterFile = argInput)
-          }
+            assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+              trigger.create(name, annotationFile = argInput, parameterFile = argInput)
+            }
 
-          val stdout = wsk.trigger.get(name).stdout
+            val stdout = wsk.trigger.get(name).stdout
 
-          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create a trigger with the proper parameter and annotation escapes"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "triggerEscapes"
+  it should "create a trigger with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val behaviorname = "Wsk triggers"
+      val testname = "create a trigger with the proper parameter and annotation escapes"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "triggerEscapes"
 
-          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-            trigger.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
-          }
+            assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+              trigger.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+            }
 
-          val stdout = wsk.trigger.get(name).stdout
+            val stdout = wsk.trigger.get(name).stdout
 
-          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-          val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+            val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+            val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+            val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
 
-          for (expectedItem <- escapedJSONArr) {
-            receivedParams should contain(expectedItem)
-            receivedAnnots should contain(expectedItem)
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            for (expectedItem <- escapedJSONArr) {
+              receivedParams should contain(expectedItem)
+              receivedAnnots should contain(expectedItem)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not create a trigger when feed fails to initialize"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "not create a trigger when feed fails to initialize" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val behaviorname = "Wsk triggers"
+    val testname = "not create a trigger when feed fails to initialize"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -939,9 +985,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname =
-    "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val behaviorname = "Wsk triggers"
+    val testname =
+      "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger"
     org.apache.openwhisk.utils
       .retry(
         {

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -60,11 +60,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
   private val retriesOnTestFailures = 5
   private val waitBeforeRetry = 1.second
 
-  behavior of "Wsk API basic usage"
+  val behaviorwskapi = "Wsk API basic usage"
+  behavior of s"$behaviorwskapi"
 
   it should "allow a 3 part Fully Qualified Name (FQN) without a leading '/'" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk API basic usage"
       val testname = "allow a 3 part Fully Qualified Name (FQN) without a leading '/'"
       org.apache.openwhisk.utils
         .retry(
@@ -101,13 +101,13 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskapi should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk actions"
+  val behaviorwskactions = "Wsk actions"
+  behavior of s"$behaviorwskactions"
 
   it should "reject creating entities with invalid names" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val behaviorname = "Wsk actions"
     val testname = "reject creating entities with invalid names"
     org.apache.openwhisk.utils
       .retry(
@@ -130,12 +130,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "create, and get an action to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "create, and get an action to verify parameter and annotation parsing"
       org.apache.openwhisk.utils
         .retry(
@@ -161,12 +160,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "create, and get an action to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "create, and get an action to verify file parameter and annotation parsing"
       org.apache.openwhisk.utils
         .retry(
@@ -194,12 +192,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "create an action with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "create an action with the proper parameter and annotation escapes"
       org.apache.openwhisk.utils
         .retry(
@@ -227,12 +224,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action that exits during initialization and get appropriate error" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "invoke an action that exits during initialization and get appropriate error"
       org.apache.openwhisk.utils
         .retry(
@@ -251,12 +247,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action that hangs during initialization and get appropriate error" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "invoke an action that hangs during initialization and get appropriate error"
       org.apache.openwhisk.utils
         .retry(
@@ -275,12 +270,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action that exits during run and get appropriate error" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "invoke an action that exits during run and get appropriate error"
       org.apache.openwhisk.utils
         .retry(
@@ -299,11 +293,10 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "ensure keys are not omitted from activation record" in withAssetCleaner(wskprops) {
-    val behaviorname = "Wsk actions"
     val testname = "ensure keys are not omitted from activation record"
     val name = "activationRecordTest"
 
@@ -329,12 +322,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "write the action-path and the limits to the annotations" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "write the action-path and the limits to the annotations"
       org.apache.openwhisk.utils
         .retry(
@@ -374,12 +366,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "create, and invoke an action that utilizes an invalid docker container with appropriate error" in withAssetCleaner(
     wskprops) {
-    val behaviorname = "Wsk actions"
     val testname = "create, and invoke an action that utilizes an invalid docker container with appropriate error"
     val name = "invalidDockerContainer"
     val containerName = s"bogus${Random.alphanumeric.take(16).mkString.toLowerCase}"
@@ -411,11 +402,10 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action using npm openwhisk" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val behaviorname = "Wsk actions"
     val testname = "invoke an action using npm openwhisk"
     org.apache.openwhisk.utils
       .retry(
@@ -440,11 +430,10 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action receiving context properties excluding api key" in withAssetCleaner(wskprops) {
-    val behaviorname = "Wsk actions"
     val testname = "invoke an action receiving context properties excluding api key"
     assume(requireAPIKeyAnnotation)
     (wp, assetHelper) =>
@@ -474,12 +463,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action receiving context properties including api key" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "invoke an action receiving context properties including api key"
       org.apache.openwhisk.utils
         .retry(
@@ -510,12 +498,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action successfully with options --blocking and --result" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "invoke an action successfully with options --blocking and --result"
       org.apache.openwhisk.utils
         .retry(
@@ -532,12 +519,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action that returns a result by the deadline" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "invoke an action that returns a result by the deadline"
       org.apache.openwhisk.utils
         .retry(
@@ -556,12 +542,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke an action twice, where the first times out but the second does not and should succeed" in withAssetCleaner(
     wskprops) {
-    val behaviorname = "Wsk actions"
     val testname = "invoke an action twice, where the first times out but the second does not and should succeed"
     // this test issues two activations: the first is forced to time out and not return a result by its deadline (ie it does not resolve
     // its promise). The invoker should reclaim its container so that a second activation of the same action (which must happen within a
@@ -597,11 +582,10 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "ensure --web flags set the proper annotations" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val behaviorname = "Wsk actions"
     val testname = "ensure --web flags set the proper annotations"
     org.apache.openwhisk.utils
       .retry(
@@ -651,12 +635,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "ensure action update creates an action with --web flag" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk actions"
       val testname = "ensure action update creates an action with --web flag"
       org.apache.openwhisk.utils
         .retry(
@@ -704,11 +687,10 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
   it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val behaviorname = "Wsk actions"
     val testname = "invoke action while not encoding &, <, > characters"
     org.apache.openwhisk.utils
       .retry(
@@ -732,13 +714,13 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactions should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk packages"
+  val behaviorwskpkgs = "Wsk packages"
+  behavior of s"$behaviorwskpkgs"
 
   it should "create, and delete a package" in {
-    val behaviorname = "Wsk packages"
     val testname = "create, and delete a package"
     org.apache.openwhisk.utils
       .retry(
@@ -749,12 +731,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskpkgs should $testname not successful, retrying.."))
   }
 
   it should "create, and get a package to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk packages"
       val testname = "create, and get a package to verify parameter and annotation parsing"
       org.apache.openwhisk.utils
         .retry(
@@ -779,12 +760,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskpkgs should $testname not successful, retrying.."))
   }
 
   it should "create, and get a package to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk packages"
       val testname = "create, and get a package to verify file parameter and annotation parsing"
       org.apache.openwhisk.utils
         .retry(
@@ -810,12 +790,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskpkgs should $testname not successful, retrying.."))
   }
 
   it should "create a package with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk packages"
       val testname = "create a package with the proper parameter and annotation escapes"
       org.apache.openwhisk.utils
         .retry(
@@ -839,11 +818,10 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskpkgs should $testname not successful, retrying.."))
   }
 
   it should "report conformance error accessing action as package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val behaviorname = "Wsk packages"
     val testname = "report conformance error accessing action as package"
     org.apache.openwhisk.utils
       .retry(
@@ -866,14 +844,14 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskpkgs should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk triggers"
+  val behaviorwsktgs = "Wsk triggers"
+  behavior of s"$behaviorwsktgs"
 
   it should "create, and get a trigger to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk triggers"
       val testname = "create, and get a trigger to verify parameter and annotation parsing"
       org.apache.openwhisk.utils
         .retry(
@@ -898,12 +876,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwsktgs should $testname not successful, retrying.."))
   }
 
   it should "create, and get a trigger to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk triggers"
       val testname = "create, and get a trigger to verify file parameter and annotation parsing"
       org.apache.openwhisk.utils
         .retry(
@@ -930,12 +907,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwsktgs should $testname not successful, retrying.."))
   }
 
   it should "create a trigger with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
-      val behaviorname = "Wsk triggers"
       val testname = "create a trigger with the proper parameter and annotation escapes"
       org.apache.openwhisk.utils
         .retry(
@@ -960,11 +936,10 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwsktgs should $testname not successful, retrying.."))
   }
 
   it should "not create a trigger when feed fails to initialize" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val behaviorname = "Wsk triggers"
     val testname = "not create a trigger when feed fails to initialize"
     org.apache.openwhisk.utils
       .retry(
@@ -982,12 +957,11 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktgs should $testname not successful, retrying.."))
   }
 
   it should "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
-    val behaviorname = "Wsk triggers"
     val testname =
       "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger"
     org.apache.openwhisk.utils
@@ -1011,6 +985,6 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktgs should $testname not successful, retrying.."))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -57,652 +57,912 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
 
   val requireAPIKeyAnnotation = WhiskProperties.getBooleanProperty("whisk.feature.requireApiKeyAnnotation", true);
 
-  behavior of "Wsk API basic usage"
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
 
-  it should "allow a 3 part Fully Qualified Name (FQN) without a leading '/'" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val guestNamespace = wsk.namespace.whois()
-      val packageName = "packageName3ptFQN"
-      val actionName = "actionName3ptFQN"
-      val triggerName = "triggerName3ptFQN"
-      val ruleName = "ruleName3ptFQN"
-      val fullQualifiedName = s"${guestNamespace}/${packageName}/${actionName}"
-      // Used for action and rule creation below
-      assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
-        pkg.create(packageName)
-      }
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-        trigger.create(triggerName)
-      }
-      // Test action and rule creation where action name is 3 part FQN w/out leading slash
-      assetHelper.withCleaner(wsk.action, fullQualifiedName) { (action, _) =>
-        action.create(fullQualifiedName, defaultAction)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, _) =>
-        rule.create(ruleName, trigger = triggerName, action = fullQualifiedName)
-      }
+  var behaviorname = "Wsk API basic usage"
+  behavior of s"$behaviorname"
 
-      val run = wsk.action.invoke(fullQualifiedName)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.status shouldBe "success"
-      }
-      val action = wsk.action.get(fullQualifiedName)
-      action.getField("name") shouldBe actionName
-      action.getField("namespace") shouldBe s"${guestNamespace}/${packageName}"
+  var testname = "allow a 3 part Fully Qualified Name (FQN) without a leading '/'"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val guestNamespace = wsk.namespace.whois()
+          val packageName = "packageName3ptFQN"
+          val actionName = "actionName3ptFQN"
+          val triggerName = "triggerName3ptFQN"
+          val ruleName = "ruleName3ptFQN"
+          val fullQualifiedName = s"${guestNamespace}/${packageName}/${actionName}"
+          // Used for action and rule creation below
+          assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+            pkg.create(packageName)
+          }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+            trigger.create(triggerName)
+          }
+          // Test action and rule creation where action name is 3 part FQN w/out leading slash
+          assetHelper.withCleaner(wsk.action, fullQualifiedName) { (action, _) =>
+            action.create(fullQualifiedName, defaultAction)
+          }
+          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, _) =>
+            rule.create(ruleName, trigger = triggerName, action = fullQualifiedName)
+          }
+
+          val run = wsk.action.invoke(fullQualifiedName)
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+          }
+          val action = wsk.action.get(fullQualifiedName)
+          action.getField("name") shouldBe actionName
+          action.getField("namespace") shouldBe s"${guestNamespace}/${packageName}"
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk actions"
+  behaviorname = "Wsk actions"
+  behavior of s"$behaviorname"
 
-  it should "reject creating entities with invalid names" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val names = Seq(
-      ("", NotFound.intValue),
-      (" ", BadRequest.intValue),
-      ("hi+there", BadRequest.intValue),
-      ("$hola", BadRequest.intValue),
-      ("dora?", BadRequest.intValue),
-      ("|dora|dora?", BadRequest.intValue))
+  testname = "reject creating entities with invalid names"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val names = Seq(
+            ("", NotFound.intValue),
+            (" ", BadRequest.intValue),
+            ("hi+there", BadRequest.intValue),
+            ("$hola", BadRequest.intValue),
+            ("dora?", BadRequest.intValue),
+            ("|dora|dora?", BadRequest.intValue))
 
-    names foreach {
-      case (name, ec) =>
-        assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
-          action.create(name, defaultAction, expectedExitCode = ec)
-        }
-    }
+          names foreach {
+            case (name, ec) =>
+              assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+                action.create(name, defaultAction, expectedExitCode = ec)
+              }
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get an action to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "actionAnnotations"
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-      }
+  testname = "create, and get an action to verify parameter and annotation parsing"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "actionAnnotations"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, file, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+          }
 
-      val action = wsk.action.get(name)
-      action.getField("name") shouldBe name
+          val action = wsk.action.get(name)
+          action.getField("name") shouldBe name
 
-      val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+          val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get an action to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "actionAnnotAndParamParsing"
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
-      val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+  testname = "create, and get an action to verify file parameter and annotation parsing"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "actionAnnotAndParamParsing"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+          val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
 
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, annotationFile = argInput, parameterFile = argInput)
-      }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, file, annotationFile = argInput, parameterFile = argInput)
+          }
 
-      val action = wsk.action.get(name)
-      action.getField("name") shouldBe name
+          val action = wsk.action.get(name)
+          action.getField("name") shouldBe name
 
-      val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+          val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create an action with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "actionEscapes"
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
+  testname = "create an action with the proper parameter and annotation escapes"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "actionEscapes"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
 
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
-      }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, file, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+          }
 
-      val action = wsk.action.get(name)
-      action.getField("name") shouldBe name
+          val action = wsk.action.get(name)
+          action.getField("name") shouldBe name
 
-      val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+          val receivedParams = wsk.parseJsonString(action.stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(action.stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action that exits during initialization and get appropriate error" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "abort init"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("initexit.js")))
-      }
+  testname = "invoke an action that exits during initialization and get appropriate error"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "abort init"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("initexit.js")))
+          }
 
-      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-        val response = activation.response
-        response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
-        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-      }
+          withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+            val response = activation.response
+            response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
+            response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action that hangs during initialization and get appropriate error" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "hang init"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("initforever.js")), timeout = Some(3 seconds))
-      }
+  testname = "invoke an action that hangs during initialization and get appropriate error"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "hang init"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("initforever.js")), timeout = Some(3 seconds))
+          }
 
-      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-        val response = activation.response
-        response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
-        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-      }
+          withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+            val response = activation.response
+            response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
+            response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action that exits during run and get appropriate error" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "abort run"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("runexit.js")))
-      }
+  testname = "invoke an action that exits during run and get appropriate error"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "abort run"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("runexit.js")))
+          }
 
-      withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
-        val response = activation.response
-        response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
-        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-      }
+          withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
+            val response = activation.response
+            response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
+            response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "ensure keys are not omitted from activation record" in withAssetCleaner(wskprops) {
+  testname = "ensure keys are not omitted from activation record"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "activationRecordTest"
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("argCheck.js")))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("argCheck.js")))
+            }
 
-      val run = wsk.action.invoke(name)
-      withActivation(wsk.activation, run) { activation =>
-        activation.start should be > Instant.EPOCH
-        activation.end should be > Instant.EPOCH
-        activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.Success)
-        activation.response.success shouldBe true
-        activation.response.result shouldBe Some(JsObject.empty)
-        activation.logs shouldBe Some(List.empty)
-        activation.annotations shouldBe defined
-      }
+            val run = wsk.action.invoke(name)
+            withActivation(wsk.activation, run) { activation =>
+              activation.start should be > Instant.EPOCH
+              activation.end should be > Instant.EPOCH
+              activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.Success)
+              activation.response.success shouldBe true
+              activation.response.result shouldBe Some(JsObject.empty)
+              activation.logs shouldBe Some(List.empty)
+              activation.annotations shouldBe defined
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "write the action-path and the limits to the annotations" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "annotations"
-      val memoryLimit = 512 MB
-      val logLimit = 1 MB
-      val timeLimit = 60 seconds
+  testname = "write the action-path and the limits to the annotations"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "annotations"
+          val memoryLimit = 512 MB
+          val logLimit = 1 MB
+          val timeLimit = 60 seconds
 
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(
-          name,
-          Some(TestUtils.getTestActionFilename("helloAsync.js")),
-          memory = Some(memoryLimit),
-          timeout = Some(timeLimit),
-          logsize = Some(logLimit))
-      }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(
+              name,
+              Some(TestUtils.getTestActionFilename("helloAsync.js")),
+              memory = Some(memoryLimit),
+              timeout = Some(timeLimit),
+              logsize = Some(logLimit))
+          }
 
-      val run = wsk.action.invoke(name, Map("payload" -> "this is a test".toJson))
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.status shouldBe "success"
-        val annotations = activation.annotations.get
+          val run = wsk.action.invoke(name, Map("payload" -> "this is a test".toJson))
+          withActivation(wsk.activation, run) {
+            activation =>
+              activation.response.status shouldBe "success"
+              val annotations = activation.annotations.get
 
-        val limitsObj = JsObject(
-          "key" -> JsString("limits"),
-          "value" -> ActionLimits(TimeLimit(timeLimit), MemoryLimit(memoryLimit), LogLimit(logLimit)).toJson)
+              val limitsObj = JsObject(
+                "key" -> JsString("limits"),
+                "value" -> ActionLimits(TimeLimit(timeLimit), MemoryLimit(memoryLimit), LogLimit(logLimit)).toJson)
 
-        val path = annotations.find {
-          _.fields("key").convertTo[String] == "path"
-        }.get
+              val path = annotations.find {
+                _.fields("key").convertTo[String] == "path"
+              }.get
 
-        path.fields("value").convertTo[String] should fullyMatch regex (s""".*/$name""")
-        annotations should contain(limitsObj)
-      }
+              path.fields("value").convertTo[String] should fullyMatch regex (s""".*/$name""")
+              annotations should contain(limitsObj)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and invoke an action that utilizes an invalid docker container with appropriate error" in withAssetCleaner(
-    wskprops) {
+  testname = "create, and invoke an action that utilizes an invalid docker container with appropriate error"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "invalidDockerContainer"
     val containerName = s"bogus${Random.alphanumeric.take(16).mkString.toLowerCase}"
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) {
-        // docker name is a randomly generate string
-        (action, _) =>
-          action.create(name, None, docker = Some(containerName))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) {
+              // docker name is a randomly generate string
+              (action, _) =>
+                action.create(name, None, docker = Some(containerName))
+            }
 
-      val run = wsk.action.invoke(name)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-        activation.response.result.get
-          .fields("error") shouldBe s"Failed to pull container image '$containerName'.".toJson
-        activation.annotations shouldBe defined
-        val limits = activation.annotations.get.filter(_.fields("key").convertTo[String] == "limits")
-        withClue(limits) {
-          limits.length should be > 0
-          limits(0).fields("value") should not be JsNull
-        }
-      }
+            val run = wsk.action.invoke(name)
+            withActivation(wsk.activation, run) {
+              activation =>
+                activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+                activation.response.result.get
+                  .fields("error") shouldBe s"Failed to pull container image '$containerName'.".toJson
+                activation.annotations shouldBe defined
+                val limits = activation.annotations.get.filter(_.fields("key").convertTo[String] == "limits")
+                withClue(limits) {
+                  limits.length should be > 0
+                  limits(0).fields("value") should not be JsNull
+                }
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action using npm openwhisk" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "hello npm openwhisk"
-    assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
-      action.create(
-        name,
-        Some(TestUtils.getTestActionFilename("helloOpenwhiskPackage.js")),
-        annotations = Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue))
-    }
+  testname = "invoke an action using npm openwhisk"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "hello npm openwhisk"
+          assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+            action.create(
+              name,
+              Some(TestUtils.getTestActionFilename("helloOpenwhiskPackage.js")),
+              annotations = Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue))
+          }
 
-    val run = wsk.action.invoke(name, Map("ignore_certs" -> true.toJson, "name" -> name.toJson))
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.status shouldBe "success"
-      activation.response.result shouldBe Some(JsObject("delete" -> true.toJson))
-      activation.logs.get.mkString(" ") should include("action list has this many actions")
-    }
+          val run = wsk.action.invoke(name, Map("ignore_certs" -> true.toJson, "name" -> name.toJson))
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            activation.response.result shouldBe Some(JsObject("delete" -> true.toJson))
+            activation.logs.get.mkString(" ") should include("action list has this many actions")
+          }
 
-    wsk.action.delete(name, expectedExitCode = NotFound.intValue)
+          wsk.action.delete(name, expectedExitCode = NotFound.intValue)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action receiving context properties excluding api key" in withAssetCleaner(wskprops) {
+  testname = "invoke an action receiving context properties excluding api key"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     assume(requireAPIKeyAnnotation)
     (wp, assetHelper) =>
-      val namespace = wsk.namespace.whois()
-      val name = "context"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("helloContext.js")))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val namespace = wsk.namespace.whois()
+            val name = "context"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("helloContext.js")))
+            }
 
-      val start = Instant.now(Clock.systemUTC()).toEpochMilli
-      val run = wsk.action.invoke(name)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.status shouldBe "success"
-        val fields = activation.response.result.get.convertTo[Map[String, String]]
-        fields("api_host") shouldBe WhiskProperties.getApiHostForAction
-        fields.get("api_key") shouldBe empty
-        fields("namespace") shouldBe namespace
-        fields("action_name") shouldBe s"/$namespace/$name"
-        fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
-        fields("activation_id") shouldBe activation.activationId
-        fields("deadline").toLong should be >= start
-      }
+            val start = Instant.now(Clock.systemUTC()).toEpochMilli
+            val run = wsk.action.invoke(name)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.status shouldBe "success"
+              val fields = activation.response.result.get.convertTo[Map[String, String]]
+              fields("api_host") shouldBe WhiskProperties.getApiHostForAction
+              fields.get("api_key") shouldBe empty
+              fields("namespace") shouldBe namespace
+              fields("action_name") shouldBe s"/$namespace/$name"
+              fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
+              fields("activation_id") shouldBe activation.activationId
+              fields("deadline").toLong should be >= start
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action receiving context properties including api key" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val namespace = wsk.namespace.whois()
-      val name = "context"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(
-          name,
-          Some(TestUtils.getTestActionFilename("helloContext.js")),
-          annotations = Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue))
-      }
+  testname = "invoke an action receiving context properties including api key"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val namespace = wsk.namespace.whois()
+          val name = "context"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(
+              name,
+              Some(TestUtils.getTestActionFilename("helloContext.js")),
+              annotations = Map(Annotations.ProvideApiKeyAnnotationName -> JsTrue))
+          }
 
-      val start = Instant.now(Clock.systemUTC()).toEpochMilli
-      val run = wsk.action.invoke(name)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.status shouldBe "success"
-        val fields = activation.response.result.get.convertTo[Map[String, String]]
-        fields("api_host") shouldBe WhiskProperties.getApiHostForAction
-        fields("api_key") shouldBe wskprops.authKey
-        fields("namespace") shouldBe namespace
-        fields("action_name") shouldBe s"/$namespace/$name"
-        fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
-        fields("activation_id") shouldBe activation.activationId
-        fields("deadline").toLong should be >= start
-      }
+          val start = Instant.now(Clock.systemUTC()).toEpochMilli
+          val run = wsk.action.invoke(name)
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            val fields = activation.response.result.get.convertTo[Map[String, String]]
+            fields("api_host") shouldBe WhiskProperties.getApiHostForAction
+            fields("api_key") shouldBe wskprops.authKey
+            fields("namespace") shouldBe namespace
+            fields("action_name") shouldBe s"/$namespace/$name"
+            fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
+            fields("activation_id") shouldBe activation.activationId
+            fields("deadline").toLong should be >= start
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action successfully with options --blocking and --result" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "invokeResult"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
-      }
-      val args = Map("hello" -> "Robert".toJson)
-      val run = wsk.action.invoke(name, args, blocking = true, result = true)
-      //--result takes precedence over --blocking
-      run.stdout.parseJson shouldBe args.toJson
+  testname = "invoke an action successfully with options --blocking and --result"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "invokeResult"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
+          }
+          val args = Map("hello" -> "Robert".toJson)
+          val run = wsk.action.invoke(name, args, blocking = true, result = true)
+          //--result takes precedence over --blocking
+          run.stdout.parseJson shouldBe args.toJson
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action that returns a result by the deadline" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "deadline"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
-      }
+  testname = "invoke an action that returns a result by the deadline"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "deadline"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
+          }
 
-      val run = wsk.action.invoke(name)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.status shouldBe "success"
-        activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
-      }
+          val run = wsk.action.invoke(name)
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "success"
+            activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke an action twice, where the first times out but the second does not and should succeed" in withAssetCleaner(
-    wskprops) {
+  testname = "invoke an action twice, where the first times out but the second does not and should succeed"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     // this test issues two activations: the first is forced to time out and not return a result by its deadline (ie it does not resolve
     // its promise). The invoker should reclaim its container so that a second activation of the same action (which must happen within a
     // short period of time (seconds, not minutes) is allocated a fresh container and hence runs as expected (vs. hitting in the container
     // cache and reusing a bad container).
     (wp, assetHelper) =>
-      val name = "timeout"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "timeout"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("helloDeadline.js")), timeout = Some(3 seconds))
+            }
 
-      val start = Instant.now(Clock.systemUTC()).toEpochMilli
-      val hungRun = wsk.action.invoke(name, Map("forceHang" -> true.toJson))
-      withActivation(wsk.activation, hungRun) { activation =>
-        // the first action must fail with a timeout error
-        activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-        activation.response.result shouldBe Some(
-          JsObject("error" -> Messages.timedoutActivation(3 seconds, false).toJson))
-      }
+            val start = Instant.now(Clock.systemUTC()).toEpochMilli
+            val hungRun = wsk.action.invoke(name, Map("forceHang" -> true.toJson))
+            withActivation(wsk.activation, hungRun) { activation =>
+              // the first action must fail with a timeout error
+              activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+              activation.response.result shouldBe Some(
+                JsObject("error" -> Messages.timedoutActivation(3 seconds, false).toJson))
+            }
 
-      // run the action again, this time without forcing it to timeout
-      // it should succeed because it ran in a fresh container
-      val goodRun = wsk.action.invoke(name, Map("forceHang" -> false.toJson))
-      withActivation(wsk.activation, goodRun) { activation =>
-        // the first action must fail with a timeout error
-        activation.response.status shouldBe "success"
-        activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
-      }
+            // run the action again, this time without forcing it to timeout
+            // it should succeed because it ran in a fresh container
+            val goodRun = wsk.action.invoke(name, Map("forceHang" -> false.toJson))
+            withActivation(wsk.activation, goodRun) { activation =>
+              // the first action must fail with a timeout error
+              activation.response.status shouldBe "success"
+              activation.response.result shouldBe Some(JsObject("timedout" -> true.toJson))
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "ensure --web flags set the proper annotations" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    Seq("true", "faLse", "tRue", "nO", "yEs", "no", "raw", "NO", "Raw").foreach { flag =>
-      val webEnabled = flag.toLowerCase == "true" || flag.toLowerCase == "yes"
-      val rawEnabled = flag.toLowerCase == "raw"
+  testname = "ensure --web flags set the proper annotations"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          Seq("true", "faLse", "tRue", "nO", "yEs", "no", "raw", "NO", "Raw").foreach {
+            flag =>
+              val webEnabled = flag.toLowerCase == "true" || flag.toLowerCase == "yes"
+              val rawEnabled = flag.toLowerCase == "raw"
 
-      val runtime = "nodejs:default"
-      val name = "webaction-" + flag
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(
-          name,
-          Some(TestUtils.getTestActionFilename("echo.js")),
-          web = Some(flag.toLowerCase),
-          kind = Some(runtime))
-      }
+              val runtime = "nodejs:default"
+              val name = "webaction-" + flag
+              assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+                action.create(
+                  name,
+                  Some(TestUtils.getTestActionFilename("echo.js")),
+                  web = Some(flag.toLowerCase),
+                  kind = Some(runtime))
+              }
 
-      val action = wsk.action.get(name)
+              val action = wsk.action.get(name)
 
-      // first check if we got 'nodejs:*' in the exec value
-      action
-        .getFieldJsValue("annotations")
-        .convertTo[Seq[JsObject]]
-        .find(_.fields("key").convertTo[String] == "exec")
-        .map(_.fields("value"))
-        .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
-        .getOrElse(fail())
+              // first check if we got 'nodejs:*' in the exec value
+              action
+                .getFieldJsValue("annotations")
+                .convertTo[Seq[JsObject]]
+                .find(_.fields("key").convertTo[String] == "exec")
+                .map(_.fields("value"))
+                .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
+                .getOrElse(fail())
 
-      // then we check the remaining annotations
-      val baseAnnotations = Parameters("web-export", JsBoolean(webEnabled || rawEnabled)) ++
-        Parameters("raw-http", JsBoolean(rawEnabled)) ++
-        Parameters("final", JsBoolean(webEnabled || rawEnabled))
-      val testAnnotations = if (requireAPIKeyAnnotation) {
-        baseAnnotations ++ Parameters(Annotations.ProvideApiKeyAnnotationName, JsFalse)
-      } else baseAnnotations
+              // then we check the remaining annotations
+              val baseAnnotations = Parameters("web-export", JsBoolean(webEnabled || rawEnabled)) ++
+                Parameters("raw-http", JsBoolean(rawEnabled)) ++
+                Parameters("final", JsBoolean(webEnabled || rawEnabled))
+              val testAnnotations = if (requireAPIKeyAnnotation) {
+                baseAnnotations ++ Parameters(Annotations.ProvideApiKeyAnnotationName, JsFalse)
+              } else baseAnnotations
 
-      // we ignore the exec field here, since we already compared it above
-      action
-        .getFieldJsValue("annotations")
-        .convertTo[Set[JsObject]]
-        .filter(annotation => annotation.fields("key").convertTo[String] != "exec") shouldBe testAnnotations.toJsArray
-        .convertTo[Set[JsObject]]
-    }
+              // we ignore the exec field here, since we already compared it above
+              action
+                .getFieldJsValue("annotations")
+                .convertTo[Set[JsObject]]
+                .filter(annotation => annotation.fields("key").convertTo[String] != "exec") shouldBe testAnnotations.toJsArray
+                .convertTo[Set[JsObject]]
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "ensure action update creates an action with --web flag" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val runtime = "nodejs:default"
-      val name = "webaction"
-      val file = Some(TestUtils.getTestActionFilename("echo.js"))
+  testname = "ensure action update creates an action with --web flag"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val runtime = "nodejs:default"
+          val name = "webaction"
+          val file = Some(TestUtils.getTestActionFilename("echo.js"))
 
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, web = Some("true"), update = true, kind = Some(runtime))
-      }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, file, web = Some("true"), update = true, kind = Some(runtime))
+          }
 
-      val baseAnnotations =
-        Parameters("web-export", JsTrue) ++
-          Parameters("raw-http", JsFalse) ++
-          Parameters("final", JsTrue)
+          val baseAnnotations =
+            Parameters("web-export", JsTrue) ++
+              Parameters("raw-http", JsFalse) ++
+              Parameters("final", JsTrue)
 
-      val testAnnotations = if (requireAPIKeyAnnotation) {
-        baseAnnotations ++
-          Parameters(Annotations.ProvideApiKeyAnnotationName, JsFalse)
-      } else {
-        baseAnnotations
-      }
+          val testAnnotations = if (requireAPIKeyAnnotation) {
+            baseAnnotations ++
+              Parameters(Annotations.ProvideApiKeyAnnotationName, JsFalse)
+          } else {
+            baseAnnotations
+          }
 
-      val action = wsk.action.get(name)
+          val action = wsk.action.get(name)
 
-      // first check if we got 'nodejs:*' in the exec value
-      action
-        .getFieldJsValue("annotations")
-        .convertTo[Seq[JsObject]]
-        .find(_.fields("key").convertTo[String] == "exec")
-        .map(_.fields("value"))
-        .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
-        .getOrElse(fail())
+          // first check if we got 'nodejs:*' in the exec value
+          action
+            .getFieldJsValue("annotations")
+            .convertTo[Seq[JsObject]]
+            .find(_.fields("key").convertTo[String] == "exec")
+            .map(_.fields("value"))
+            .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
+            .getOrElse(fail())
 
-      // then we check the remaining annotations
-      // we ignore the exec field here, since we already compared it above
-      action
-        .getFieldJsValue("annotations")
-        .convertTo[Set[JsObject]]
-        .filter(annotation => annotation.fields("key").convertTo[String] != "exec") shouldBe testAnnotations.toJsArray
-        .convertTo[Set[JsObject]]
+          // then we check the remaining annotations
+          // we ignore the exec field here, since we already compared it above
+          action
+            .getFieldJsValue("annotations")
+            .convertTo[Set[JsObject]]
+            .filter(annotation => annotation.fields("key").convertTo[String] != "exec") shouldBe testAnnotations.toJsArray
+            .convertTo[Set[JsObject]]
 
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke action while not encoding &, <, > characters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "nonescape"
-    val file = Some(TestUtils.getTestActionFilename("hello.js"))
-    val nonescape = "&<>"
-    val input = Map("payload" -> nonescape.toJson)
-    val output = JsObject("payload" -> JsString(s"hello, $nonescape!"))
+  testname = "invoke action while not encoding &, <, > characters"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "nonescape"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+          val nonescape = "&<>"
+          val input = Map("payload" -> nonescape.toJson)
+          val output = JsObject("payload" -> JsString(s"hello, $nonescape!"))
 
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file)
-    }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, file)
+          }
 
-    withActivation(wsk.activation, wsk.action.invoke(name, parameters = input)) { activation =>
-      activation.response.success shouldBe true
-      activation.response.result shouldBe Some(output)
-      activation.logs.toList.flatten.filter(_.contains(nonescape)).length shouldBe 1
-    }
+          withActivation(wsk.activation, wsk.action.invoke(name, parameters = input)) { activation =>
+            activation.response.success shouldBe true
+            activation.response.result shouldBe Some(output)
+            activation.logs.toList.flatten.filter(_.contains(nonescape)).length shouldBe 1
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk packages"
+  behaviorname = "Wsk packages"
+  behavior of s"$behaviorname"
 
-  it should "create, and delete a package" in {
-    val name = "createDeletePackage"
-    wsk.pkg.create(name).statusCode shouldBe OK
-    wsk.pkg.delete(name).statusCode shouldBe OK
+  testname = "create, and delete a package"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "createDeletePackage"
+          wsk.pkg.create(name).statusCode shouldBe OK
+          wsk.pkg.delete(name).statusCode shouldBe OK
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get a package to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "packageAnnotAndParamParsing"
+  testname = "create, and get a package to verify parameter and annotation parsing"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "packageAnnotAndParamParsing"
 
-      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-        pkg.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-      }
+          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+            pkg.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+          }
 
-      val pack = wsk.pkg.get(name)
+          val pack = wsk.pkg.get(name)
 
-      val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+          val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get a package to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "packageAnnotAndParamFileParsing"
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
-      val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+  testname = "create, and get a package to verify file parameter and annotation parsing"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "packageAnnotAndParamFileParsing"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+          val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
 
-      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-        pkg.create(name, annotationFile = argInput, parameterFile = argInput)
-      }
+          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+            pkg.create(name, annotationFile = argInput, parameterFile = argInput)
+          }
 
-      val stdout = wsk.pkg.get(name).stdout
-      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+          val stdout = wsk.pkg.get(name).stdout
+          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create a package with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "packageEscapses"
+  testname = "create a package with the proper parameter and annotation escapes"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "packageEscapses"
 
-      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-        pkg.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
-      }
+          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+            pkg.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+          }
 
-      val pack = wsk.pkg.get(name)
-      val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+          val pack = wsk.pkg.get(name)
+          val receivedParams = wsk.parseJsonString(pack.stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(pack.stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "report conformance error accessing action as package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "aAsP"
-    val file = Some(TestUtils.getTestActionFilename("hello.js"))
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file)
-    }
+  testname = "report conformance error accessing action as package"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "aAsP"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, file)
+          }
 
-    wsk.pkg.get(name, expectedExitCode = Conflict.intValue).stderr should include(Messages.conformanceMessage)
+          wsk.pkg.get(name, expectedExitCode = Conflict.intValue).stderr should include(Messages.conformanceMessage)
 
-    wsk.pkg.bind(name, "bogus", expectedExitCode = Conflict.intValue).stderr should include(
-      Messages.requestedBindingIsNotValid)
+          wsk.pkg.bind(name, "bogus", expectedExitCode = Conflict.intValue).stderr should include(
+            Messages.requestedBindingIsNotValid)
 
-    wsk.pkg.bind("bogus", "alsobogus", expectedExitCode = BadRequest.intValue).stderr should include(
-      Messages.bindingDoesNotExist)
+          wsk.pkg.bind("bogus", "alsobogus", expectedExitCode = BadRequest.intValue).stderr should include(
+            Messages.bindingDoesNotExist)
 
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk triggers"
+  behaviorname = "Wsk triggers"
+  behavior of s"$behaviorname"
 
-  it should "create, and get a trigger to verify parameter and annotation parsing" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "triggerAnnotAndParamParsing"
+  testname = "create, and get a trigger to verify parameter and annotation parsing"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "triggerAnnotAndParamParsing"
 
-      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-        trigger.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
-      }
+          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+            trigger.create(name, annotations = getValidJSONTestArgInput, parameters = getValidJSONTestArgInput)
+          }
 
-      val stdout = wsk.trigger.get(name).stdout
+          val stdout = wsk.trigger.get(name).stdout
 
-      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
+          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getValidJSONTestArgOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get a trigger to verify file parameter and annotation parsing" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "triggerAnnotAndParamFileParsing"
-      val file = Some(TestUtils.getTestActionFilename("hello.js"))
-      val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
+  testname = "create, and get a trigger to verify file parameter and annotation parsing"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "triggerAnnotAndParamFileParsing"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+          val argInput = Some(TestUtils.getTestActionFilename("validInput1.json"))
 
-      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-        trigger.create(name, annotationFile = argInput, parameterFile = argInput)
-      }
+          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+            trigger.create(name, annotationFile = argInput, parameterFile = argInput)
+          }
 
-      val stdout = wsk.trigger.get(name).stdout
+          val stdout = wsk.trigger.get(name).stdout
 
-      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
+          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getJSONFileOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create a trigger with the proper parameter and annotation escapes" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "triggerEscapes"
+  testname = "create a trigger with the proper parameter and annotation escapes"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "triggerEscapes"
 
-      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-        trigger.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
-      }
+          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+            trigger.create(name, parameters = getEscapedJSONTestArgInput, annotations = getEscapedJSONTestArgInput)
+          }
 
-      val stdout = wsk.trigger.get(name).stdout
+          val stdout = wsk.trigger.get(name).stdout
 
-      val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
-      val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
-      val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
+          val receivedParams = wsk.parseJsonString(stdout).fields("parameters").convertTo[JsArray].elements
+          val receivedAnnots = wsk.parseJsonString(stdout).fields("annotations").convertTo[JsArray].elements
+          val escapedJSONArr = getEscapedJSONTestArgOutput.convertTo[JsArray].elements
 
-      for (expectedItem <- escapedJSONArr) {
-        receivedParams should contain(expectedItem)
-        receivedAnnots should contain(expectedItem)
-      }
+          for (expectedItem <- escapedJSONArr) {
+            receivedParams should contain(expectedItem)
+            receivedAnnots should contain(expectedItem)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "not create a trigger when feed fails to initialize" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
-      trigger.create(name, feed = Some(s"bogus"), expectedExitCode = ANY_ERROR_EXIT).exitCode should equal(NOT_FOUND)
-      trigger.get(name, expectedExitCode = NotFound.intValue)
+  testname = "not create a trigger when feed fails to initialize"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          assetHelper.withCleaner(wsk.trigger, "badfeed", confirmDelete = false) { (trigger, name) =>
+            trigger.create(name, feed = Some(s"bogus"), expectedExitCode = ANY_ERROR_EXIT).exitCode should equal(
+              NOT_FOUND)
+            trigger.get(name, expectedExitCode = NotFound.intValue)
 
-      trigger.create(name, feed = Some(s"bogus/feed"), expectedExitCode = ANY_ERROR_EXIT).exitCode should equal(
-        NOT_FOUND)
-      trigger.get(name, expectedExitCode = NotFound.intValue)
-    }
+            trigger.create(name, feed = Some(s"bogus/feed"), expectedExitCode = ANY_ERROR_EXIT).exitCode should equal(
+              NOT_FOUND)
+            trigger.get(name, expectedExitCode = NotFound.intValue)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
-    val actionName = "echo"
-    val triggerName = "feedTest"
+  testname =
+    "invoke a feed action with the correct lifecyle event when creating, retrieving and deleting a feed trigger"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val actionName = "echo"
+          val triggerName = "feedTest"
 
-    assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
-      action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
-    }
+          assetHelper.withCleaner(wsk.action, actionName) { (action, _) =>
+            action.create(actionName, Some(TestUtils.getTestActionFilename("echo.js")))
+          }
 
-    try {
-      wsk.trigger.create(triggerName, feed = Some(actionName)).statusCode shouldBe OK
+          try {
+            wsk.trigger.create(triggerName, feed = Some(actionName)).statusCode shouldBe OK
 
-      wsk.trigger.get(triggerName).statusCode shouldBe OK
-    } finally {
-      wsk.trigger.delete(triggerName).statusCode shouldBe OK
-    }
+            wsk.trigger.get(triggerName).statusCode shouldBe OK
+          } finally {
+            wsk.trigger.delete(triggerName).statusCode shouldBe OK
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivationsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActivationsApiTests.scala
@@ -78,6 +78,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           // create two sets of activation records, and check that only one set is served back
           val creds1 = WhiskAuthHelpers.newAuth()
@@ -154,20 +155,30 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
 
   //// GET /activations?docs=true
   it should "return empty list when no activations exist" in {
-    implicit val tid = transid()
     org.apache.openwhisk.utils
-      .retry { // retry because view will be stale from previous test and result in null doc fields
-        Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
-          status should be(OK)
-          responseAs[List[JsObject]] shouldBe 'empty
-        }
-      }
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          org.apache.openwhisk.utils
+            .retry { // retry because view will be stale from previous test and result in null doc fields
+              Get(s"$collectionPath?docs=true") ~> Route.seal(routes(creds)) ~> check {
+                status should be(OK)
+                responseAs[List[JsObject]] shouldBe 'empty
+              }
+            }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should return empty list when no activations exist not successful, retrying.."))
   }
 
   it should "get full activation by namespace" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           // create two sets of activation records, and check that only one set is served back
           val creds1 = WhiskAuthHelpers.newAuth()
@@ -221,6 +232,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           // create two sets of activation records, and check that only one set is served back
           val creds1 = WhiskAuthHelpers.newAuth()
@@ -345,6 +357,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
 
           Seq(("", OK), ("name=", OK), ("name=abc", OK), ("name=abc/xyz", OK), ("name=abc/xyz/123", BadRequest))
@@ -368,6 +381,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
 
           // create two sets of activation records, and check that only one set is served back
@@ -443,20 +457,30 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
   }
 
   it should "reject invalid query parameter combinations" in {
-    implicit val tid = transid()
     org.apache.openwhisk.utils
-      .retry { // retry because view will be stale from previous test and result in null doc fields
-        Get(s"$collectionPath?docs=true&count=true") ~> Route.seal(routes(creds)) ~> check {
-          status should be(BadRequest)
-          responseAs[ErrorResponse].error shouldBe Messages.docsNotAllowedWithCount
-        }
-      }
+      .retry(
+        {
+          afterEach()
+          implicit val tid = transid()
+          org.apache.openwhisk.utils
+            .retry { // retry because view will be stale from previous test and result in null doc fields
+              Get(s"$collectionPath?docs=true&count=true") ~> Route.seal(routes(creds)) ~> check {
+                status should be(BadRequest)
+                responseAs[ErrorResponse].error shouldBe Messages.docsNotAllowedWithCount
+              }
+            }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(
+          s"${this.getClass.getName} > Activations API should reject invalid query parameter combinations not successful, retrying.."))
   }
 
   it should "reject list when limit is greater than maximum allowed value" in {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val exceededMaxLimit = Collection.MAX_LIST_LIMIT + 1
           val response = Get(s"$collectionPath?limit=$exceededMaxLimit") ~> Route.seal(routes(creds)) ~> check {
@@ -476,6 +500,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val notAnInteger = "string"
           val response = Get(s"$collectionPath?limit=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
@@ -495,6 +520,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val negativeSkip = -1
           val response = Get(s"$collectionPath?skip=$negativeSkip") ~> Route.seal(routes(creds)) ~> check {
@@ -514,6 +540,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val notAnInteger = "string"
           val response = Get(s"$collectionPath?skip=$notAnInteger") ~> Route.seal(routes(creds)) ~> check {
@@ -533,6 +560,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           Get(s"$collectionPath?name=0%20") ~> Route.seal(routes(creds)) ~> check {
             status should be(BadRequest)
@@ -548,6 +576,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           Get(s"$collectionPath?since=xxx") ~> Route.seal(routes(creds)) ~> check {
             status should be(BadRequest)
@@ -566,6 +595,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val activations: Seq[WhiskActivation] = (1 to 3).map { i =>
             //make sure the time is different for each activation
@@ -598,6 +628,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val activations = (1 to 3).map { i =>
             //make sure the time is different for each activation
@@ -633,6 +664,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val activation =
             WhiskActivation(
@@ -679,6 +711,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val activation =
             WhiskActivation(
@@ -711,6 +744,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val activation =
             WhiskActivation(
@@ -742,6 +776,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val activation =
             WhiskActivation(
@@ -771,6 +806,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           val activationId = ActivationId.generate().toString
           val tooshort = activationId.substring(0, 31)
@@ -803,6 +839,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           Put(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
             status should be(MethodNotAllowed)
@@ -817,6 +854,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           Post(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
             status should be(MethodNotAllowed)
@@ -831,6 +869,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
           Delete(s"$collectionPath/${ActivationId.generate()}") ~> Route.seal(routes(creds)) ~> check {
             status should be(MethodNotAllowed)
@@ -846,6 +885,7 @@ class ActivationsApiTests extends ControllerTestCommon with WhiskActivationsApi 
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid = transid()
 
           //A bad activation type which breaks the deserialization by removing the subject entry

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -50,7 +50,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   private val waitBeforeRetry = 1.second
 
   /** Packages API tests */
-  var behaviorname = "Packages API"
+  val behaviorname = "Packages API"
   behavior of s"$behaviorname"
 
   val creds = WhiskAuthHelpers.newIdentity()
@@ -76,8 +76,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   //// GET /packages
-  var testname = "list all packages/references"
-  it should s"$testname" in {
+  it should "list all packages/references" in {
+    val testname = "list all packages/references"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -120,8 +120,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "list all public packages in explicit namespace excluding bindings"
-  it should s"$testname" in {
+  it should "list all public packages in explicit namespace excluding bindings" in {
+    val testname = "list all public packages in explicit namespace excluding bindings"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -174,8 +174,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when limit is greater than maximum allowed value"
-  it should s"$testname" in {
+  it should "reject list when limit is greater than maximum allowed value" in {
+    val testname = "reject list when limit is greater than maximum allowed value"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -194,8 +194,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when limit is not an integer"
-  it should s"$testname" in {
+  it should "reject list when limit is not an integer" in {
+    val testname = "reject list when limit is not an integer"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -213,8 +213,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when skip is negative"
-  it should s"$testname" in {
+  it should "reject list when skip is negative" in {
+    val testname = "reject list when skip is negative"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -233,8 +233,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when skip is not an integer"
-  it should s"$testname" in {
+  it should "reject list when skip is not an integer" in {
+    val testname = "reject list when skip is not an integer"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -253,8 +253,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "list all public packages excluding bindings"
-  ignore should s"$testname" in {
+  ignore should "list all public packages excluding bindings" in {
+    val testname = "list all public packages excluding bindings"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -291,8 +291,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   // ?public disabled
-  testname = "list all public packages including ones with same name but in different namespaces"
-  ignore should s"$testname" in {
+  ignore should "list all public packages including ones with same name but in different namespaces" in {
+    val testname = "list all public packages including ones with same name but in different namespaces"
     implicit val tid = transid()
     // create packages and package bindings, set some public and confirm API lists only public packages
     val namespaces = Seq(namespace, EntityPath(aname().toString), EntityPath(aname().toString))
@@ -317,8 +317,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   // confirm ?public disabled
-  testname = "ignore ?public on list all packages"
-  it should s"$testname" in {
+  it should "ignore ?public on list all packages" in {
+    val testname = "ignore ?public on list all packages"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -363,8 +363,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   //// GET /packages/name
-  testname = "get package"
-  it should s"$testname" in {
+  it should "get package" in {
+    val testname = "get package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -383,8 +383,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "get package with updated field"
-  it should s"$testname" in {
+  it should "get package with updated field" in {
+    val testname = "get package with updated field"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -407,8 +407,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "get package reference for private package in same namespace"
-  it should s"$testname" in {
+  it should "get package reference for private package in same namespace" in {
+    val testname = "get package reference for private package in same namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -431,8 +431,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not get package reference for a private package in other namespace"
-  it should s"$testname" in {
+  it should "not get package reference for a private package in other namespace" in {
+    val testname = "not get package reference for a private package in other namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -454,8 +454,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "get package with its actions and feeds"
-  it should s"$testname" in {
+  it should "get package with its actions and feeds" in {
+    val testname = "get package with its actions and feeds"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -489,8 +489,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "get package reference with its actions and feeds"
-  it should s"$testname" in {
+  it should "get package reference with its actions and feeds" in {
+    val testname = "get package reference with its actions and feeds"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -529,8 +529,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not get package reference with its actions and feeds from private package"
-  it should s"$testname" in {
+  it should "not get package reference with its actions and feeds from private package" in {
+    val testname = "not get package reference with its actions and feeds from private package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -567,8 +567,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   //// PUT /packages/name
-  testname = "create package"
-  it should s"$testname" in {
+  it should "create package" in {
+    val testname = "create package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -590,8 +590,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create/update package when package name is reserved"
-  it should s"$testname" in {
+  it should "reject create/update package when package name is reserved" in {
+    val testname = "reject create/update package when package name is reserved"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -614,8 +614,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not allow package update of pre-existing package with a reserved"
-  it should s"$testname" in {
+  it should "not allow package update of pre-existing package with a reserved" in {
+    val testname = "not allow package update of pre-existing package with a reserved"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -636,8 +636,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "allow package get/delete for pre-existing package with a reserved name"
-  it should s"$testname" in {
+  it should "allow package get/delete for pre-existing package with a reserved name" in {
+    val testname = "allow package get/delete for pre-existing package with a reserved name"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -662,8 +662,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create package reference with explicit namespace"
-  it should s"$testname" in {
+  it should "create package reference with explicit namespace" in {
+    val testname = "create package reference with explicit namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -699,8 +699,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not create package reference from private package in another namespace"
-  it should s"$testname" in {
+  it should "not create package reference from private package in another namespace" in {
+    val testname = "not create package reference from private package in another namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -724,8 +724,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "create package reference with implicit namespace"
-  it should s"$testname" in {
+  it should "create package reference with implicit namespace" in {
+    val testname = "create package reference with implicit namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -753,8 +753,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create package reference when referencing non-existent package in same namespace"
-  it should s"$testname" in {
+  it should "reject create package reference when referencing non-existent package in same namespace" in {
+    val testname = "reject create package reference when referencing non-existent package in same namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -772,8 +772,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create package reference when referencing non-existent package in another namespace"
-  it should s"$testname" in {
+  it should "reject create package reference when referencing non-existent package in another namespace" in {
+    val testname = "reject create package reference when referencing non-existent package in another namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -793,8 +793,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create package reference when referencing a non-package"
-  it should s"$testname" in {
+  it should "reject create package reference when referencing a non-package" in {
+    val testname = "reject create package reference when referencing a non-package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -815,8 +815,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create package reference when annotations are too big"
-  it should s"$testname" in {
+  it should "reject create package reference when annotations are too big" in {
+    val testname = "reject create package reference when annotations are too big"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -840,8 +840,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create package reference when parameters are too big"
-  it should s"$testname" in {
+  it should "reject create package reference when parameters are too big" in {
+    val testname = "reject create package reference when parameters are too big"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -865,8 +865,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update package reference when parameters are too big"
-  it should s"$testname" in {
+  it should "reject update package reference when parameters are too big" in {
+    val testname = "reject update package reference when parameters are too big"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -892,8 +892,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "update package"
-  it should s"$testname" in {
+  it should "update package" in {
+    val testname = "update package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -923,8 +923,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "update package reference"
-  it should s"$testname" in {
+  it should "update package reference" in {
+    val testname = "update package reference"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -966,8 +966,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update package with binding"
-  it should s"$testname" in {
+  it should "reject update package with binding" in {
+    val testname = "reject update package with binding"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -986,8 +986,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update package reference when new binding refers to non-existent package in same namespace"
-  it should s"$testname" in {
+  it should "reject update package reference when new binding refers to non-existent package in same namespace" in {
+    val testname = "reject update package reference when new binding refers to non-existent package in same namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1007,8 +1007,9 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update package reference when new binding refers to non-existent package in another namespace"
-  it should s"$testname" in {
+  it should "reject update package reference when new binding refers to non-existent package in another namespace" in {
+    val testname =
+      "reject update package reference when new binding refers to non-existent package in another namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1030,8 +1031,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update package reference when new binding refers to itself"
-  it should s"$testname" in {
+  it should "reject update package reference when new binding refers to itself" in {
+    val testname = "reject update package reference when new binding refers to itself"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1061,8 +1062,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update package reference when new binding refers to private package in another namespace"
-  it should s"$testname" in {
+  it should "reject update package reference when new binding refers to private package in another namespace" in {
+    val testname = "reject update package reference when new binding refers to private package in another namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1086,8 +1087,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   //// DEL /packages/name
-  testname = "delete package"
-  it should s"$testname" in {
+  it should "delete package" in {
+    val testname = "delete package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1113,8 +1114,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "delete package reference regardless of package existence"
-  it should s"$testname" in {
+  it should "delete package reference regardless of package existence" in {
+    val testname = "delete package reference regardless of package existence"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1141,8 +1142,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject delete non-empty package"
-  it should s"$testname" in {
+  it should "reject delete non-empty package" in {
+    val testname = "reject delete non-empty package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1173,8 +1174,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   }
 
   //// invalid resource
-  testname = "reject invalid resource"
-  it should s"$testname" in {
+  it should "reject invalid resource" in {
+    val testname = "reject invalid resource"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1191,8 +1192,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "return empty list for invalid namespace"
-  it should s"$testname" in {
+  it should "return empty list for invalid namespace" in {
+    val testname = "return empty list for invalid namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1209,8 +1210,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject bind to non-package"
-  it should s"$testname" in {
+  it should "reject bind to non-package" in {
+    val testname = "reject bind to non-package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1232,8 +1233,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report proper error when record is corrupted on delete"
-  it should s"$testname" in {
+  it should "report proper error when record is corrupted on delete" in {
+    val testname = "report proper error when record is corrupted on delete"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1252,8 +1253,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report proper error when record is corrupted on get"
-  it should s"$testname" in {
+  it should "report proper error when record is corrupted on get" in {
+    val testname = "report proper error when record is corrupted on get"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1271,8 +1272,8 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report proper error when record is corrupted on put"
-  it should s"$testname" in {
+  it should "report proper error when record is corrupted on put" in {
+    val testname = "report proper error when record is corrupted on put"
     org.apache.openwhisk.utils
       .retry(
         {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
@@ -74,8 +74,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   private val waitBeforeRetry = 1.second
 
   //// GET /triggers
-  var testname = "list triggers by default/explicit namespace"
-  it should s"$testname" in {
+  it should "list triggers by default/explicit namespace" in {
+    val testname = "list triggers by default/explicit namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -112,8 +112,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when limit is greater than maximum allowed value"
-  it should s"$testname" in {
+  it should "reject list when limit is greater than maximum allowed value" in {
+    val testname = "reject list when limit is greater than maximum allowed value"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -132,8 +132,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when limit is not an integer"
-  it should s"$testname" in {
+  it should "reject list when limit is not an integer" in {
+    val testname = "reject list when limit is not an integer"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -152,8 +152,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when skip is negative"
-  it should s"$testname" in {
+  it should "reject list when skip is negative" in {
+    val testname = "reject list when skip is negative"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -172,8 +172,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject list when skip is not an integer"
-  it should s"$testname" in {
+  it should "reject list when skip is not an integer" in {
+    val testname = "reject list when skip is not an integer"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -193,8 +193,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   }
 
   // ?docs disabled
-  testname = "list triggers by default namespace with full docs"
-  ignore should s"$testname" in {
+  ignore should "list triggers by default namespace with full docs" in {
+    val testname = "list triggers by default namespace with full docs"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -218,8 +218,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   }
 
   //// GET /triggers/name
-  testname = "get trigger by name in default/explicit namespace"
-  it should s"$testname" in {
+  it should "get trigger by name in default/explicit namespace" in {
+    val testname = "get trigger by name in default/explicit namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -251,8 +251,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "get trigger with updated field"
-  it should s"$testname" in {
+  it should "get trigger with updated field" in {
+    val testname = "get trigger with updated field"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -275,8 +275,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report Conflict if the name was of a different type"
-  it should s"$testname" in {
+  it should "report Conflict if the name was of a different type" in {
+    val testname = "report Conflict if the name was of a different type"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -298,8 +298,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   }
 
   //// DEL /triggers/name
-  testname = "delete trigger by name"
-  it should s"$testname" in {
+  it should "delete trigger by name" in {
+    val testname = "delete trigger by name"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -319,8 +319,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   }
 
   //// PUT /triggers/name
-  testname = "put should accept request with missing optional properties"
-  it should s"$testname" in {
+  it should "put should accept request with missing optional properties" in {
+    val testname = "put should accept request with missing optional properties"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -340,8 +340,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "put should accept request with valid feed parameter"
-  it should s"$testname" in {
+  it should "put should accept request with valid feed parameter" in {
+    val testname = "put should accept request with valid feed parameter"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -361,8 +361,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "put should reject request with undefined feed parameter"
-  it should s"$testname" in {
+  it should "put should reject request with undefined feed parameter" in {
+    val testname = "put should reject request with undefined feed parameter"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -379,8 +379,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "put should reject request with bad feed parameters"
-  it should s"$testname" in {
+  it should "put should reject request with bad feed parameters" in {
+    val testname = "put should reject request with bad feed parameters"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -397,8 +397,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject activation with entity which is too big"
-  it should s"$testname" in {
+  it should "reject activation with entity which is too big" in {
+    val testname = "reject activation with entity which is too big"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -419,8 +419,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create with parameters which are too big"
-  it should s"$testname" in {
+  it should "reject create with parameters which are too big" in {
+    val testname = "reject create with parameters which are too big"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -444,8 +444,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject create with annotations which are too big"
-  it should s"$testname" in {
+  it should "reject create with annotations which are too big" in {
+    val testname = "reject create with annotations which are too big"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -469,8 +469,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "reject update with parameters which are too big"
-  it should s"$testname" in {
+  it should "reject update with parameters which are too big" in {
+    val testname = "reject update with parameters which are too big"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -496,8 +496,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "put should accept update request with missing optional properties"
-  it should s"$testname" in {
+  it should "put should accept update request with missing optional properties" in {
+    val testname = "put should accept update request with missing optional properties"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -525,8 +525,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "put should reject update request for trigger with existing feed"
-  it should s"$testname" in {
+  it should "put should reject update request for trigger with existing feed" in {
+    val testname = "put should reject update request for trigger with existing feed"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -545,8 +545,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "put should reject update request for trigger with new feed"
-  it should s"$testname" in {
+  it should "put should reject update request for trigger with new feed" in {
+    val testname = "put should reject update request for trigger with new feed"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -566,8 +566,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   }
 
   //// POST /triggers/name
-  testname = "fire a trigger"
-  it should s"$testname" in {
+  it should "fire a trigger" in {
+    val testname = "fire a trigger"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -605,8 +605,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "fire a trigger without args"
-  it should s"$testname" in {
+  it should "fire a trigger without args" in {
+    val testname = "fire a trigger without args"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -637,8 +637,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "not fire a trigger without a rule"
-  it should s"$testname" in {
+  it should "not fire a trigger without a rule" in {
+    val testname = "not fire a trigger without a rule"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -656,8 +656,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   }
 
   //// invalid resource
-  testname = "reject invalid resource"
-  it should s"$testname" in {
+  it should "reject invalid resource" in {
+    val testname = "reject invalid resource"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -675,8 +675,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   }
 
   // migration path
-  testname = "be able to handle a trigger as of the old schema"
-  it should s"$testname" in {
+  it should "be able to handle a trigger as of the old schema" in {
+    val testname = "be able to handle a trigger as of the old schema"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -695,8 +695,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report proper error when record is corrupted on delete"
-  it should s"$testname" in {
+  it should "report proper error when record is corrupted on delete" in {
+    val testname = "report proper error when record is corrupted on delete"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -715,8 +715,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report proper error when record is corrupted on get"
-  it should s"$testname" in {
+  it should "report proper error when record is corrupted on get" in {
+    val testname = "report proper error when record is corrupted on get"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -735,8 +735,8 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "report proper error when record is corrupted on put"
-  it should s"$testname" in {
+  it should "report proper error when record is corrupted on put" in {
+    val testname = "report proper error when record is corrupted on put"
     org.apache.openwhisk.utils
       .retry(
         {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
@@ -62,8 +62,8 @@ class SequenceActionApiMigrationTests
 
   private def seqParameters(seq: Vector[String]) = Parameters("_actions", seq.toJson)
 
-  var testname = "list old-style sequence action with explicit namespace"
-  it should s"$testname" in {
+  it should "list old-style sequence action with explicit namespace" in {
+    val testname = "list old-style sequence action with explicit namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -87,8 +87,8 @@ class SequenceActionApiMigrationTests
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "get old-style sequence action by name in default namespace"
-  it should s"$testname" in {
+  it should "get old-style sequence action by name in default namespace" in {
+    val testname = "get old-style sequence action by name in default namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -109,8 +109,8 @@ class SequenceActionApiMigrationTests
   }
 
   // this test is a repeat from ActionsApiTest BUT with old style sequence
-  testname = "preserve new parameters when changing old-style sequence action to non sequence"
-  it should s"$testname" in {
+  it should "preserve new parameters when changing old-style sequence action to non sequence" in {
+    val testname = "preserve new parameters when changing old-style sequence action to non sequence"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -137,8 +137,8 @@ class SequenceActionApiMigrationTests
   }
 
   // this test is a repeat from ActionsApiTest BUT with old style sequence
-  testname = "reset parameters when changing old-style sequence action to non sequence"
-  it should s"$testname" in {
+  it should "reset parameters when changing old-style sequence action to non sequence" in {
+    val testname = "reset parameters when changing old-style sequence action to non sequence"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -164,8 +164,8 @@ class SequenceActionApiMigrationTests
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "update old-style sequence action with new annotations"
-  it should s"$testname" in {
+  it should "update old-style sequence action with new annotations" in {
+    val testname = "update old-style sequence action with new annotations"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -196,8 +196,8 @@ class SequenceActionApiMigrationTests
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "update an old-style sequence with new sequence"
-  it should s"$testname" in {
+  it should "update an old-style sequence with new sequence" in {
+    val testname = "update an old-style sequence with new sequence"
     org.apache.openwhisk.utils
       .retry(
         {

--- a/tests/src/test/scala/system/basic/WskConductorTests.scala
+++ b/tests/src/test/scala/system/basic/WskConductorTests.scala
@@ -47,13 +47,15 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
   private val retriesOnTestFailures = 5
   private val waitBeforeRetry = 1.second
 
-  behavior of "Whisk conductor actions"
+  val behaviorname = "Whisk conductor actions"
+  behavior of s"$behaviorname"
 
   var testname: String = "invoke a conductor action with no continuation"
   it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val echo = "echo" // echo conductor action
           assetHelper.withCleaner(wsk.action, echo) { (action, _) =>
             action.create(
@@ -96,7 +98,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Whisk conductor actions should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   testname = "invoke a conductor action with an invalid continuation"
@@ -104,6 +106,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val echo = "echo" // echo conductor action
           assetHelper.withCleaner(wsk.action, echo) { (action, _) =>
             action.create(
@@ -135,7 +138,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Whisk conductor actions should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   testname = "invoke a conductor action with a continuation"
@@ -143,6 +146,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val conductor = "conductor" // conductor action
           assetHelper.withCleaner(wsk.action, conductor) { (action, _) =>
             action.create(
@@ -210,7 +214,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Whisk conductor actions should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   testname = "invoke nested conductor actions"
@@ -218,6 +222,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val conductor = "conductor" // conductor action
           assetHelper.withCleaner(wsk.action, conductor) { (action, _) =>
             action.create(
@@ -305,7 +310,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Whisk conductor actions should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   testname = "invoke a conductor action in a package binding"
@@ -313,6 +318,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val ns = wsk.namespace.whois()
           val actionName = "echo" // echo conductor action
           val packageName = "package1"
@@ -384,7 +390,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > Whisk conductor actions should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   /**

--- a/tests/src/test/scala/system/basic/WskConductorTests.scala
+++ b/tests/src/test/scala/system/basic/WskConductorTests.scala
@@ -50,8 +50,8 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
   val behaviorname = "Whisk conductor actions"
   behavior of s"$behaviorname"
 
-  var testname: String = "invoke a conductor action with no continuation"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke a conductor action with no continuation" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname: String = "invoke a conductor action with no continuation"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -101,48 +101,49 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke a conductor action with an invalid continuation"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val echo = "echo" // echo conductor action
-          assetHelper.withCleaner(wsk.action, echo) { (action, _) =>
-            action.create(
-              echo,
-              Some(TestUtils.getTestActionFilename("echo.js")),
-              annotations = Map("conductor" -> true.toJson))
-          }
+  it should "invoke a conductor action with an invalid continuation" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "invoke a conductor action with an invalid continuation"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val echo = "echo" // echo conductor action
+            assetHelper.withCleaner(wsk.action, echo) { (action, _) =>
+              action.create(
+                echo,
+                Some(TestUtils.getTestActionFilename("echo.js")),
+                annotations = Map("conductor" -> true.toJson))
+            }
 
-          // an invalid action name
-          val invalidrun =
-            wsk.action.invoke(echo, Map("payload" -> testString.toJson, "action" -> invalid.toJson))
-          withActivation(wsk.activation, invalidrun) { activation =>
-            activation.response.status shouldBe "application error"
-            activation.response.result.get.fields.get("error") shouldBe Some(
-              JsString(compositionComponentInvalid(JsString(invalid))))
-            checkConductorLogsAndAnnotations(activation, 2) // echo
-          }
+            // an invalid action name
+            val invalidrun =
+              wsk.action.invoke(echo, Map("payload" -> testString.toJson, "action" -> invalid.toJson))
+            withActivation(wsk.activation, invalidrun) { activation =>
+              activation.response.status shouldBe "application error"
+              activation.response.result.get.fields.get("error") shouldBe Some(
+                JsString(compositionComponentInvalid(JsString(invalid))))
+              checkConductorLogsAndAnnotations(activation, 2) // echo
+            }
 
-          // an undefined action
-          val undefinedrun = wsk.action.invoke(echo, Map("payload" -> testString.toJson, "action" -> missing.toJson))
-          val namespace = wsk.namespace.whois()
+            // an undefined action
+            val undefinedrun = wsk.action.invoke(echo, Map("payload" -> testString.toJson, "action" -> missing.toJson))
+            val namespace = wsk.namespace.whois()
 
-          withActivation(wsk.activation, undefinedrun) { activation =>
-            activation.response.status shouldBe "application error"
-            activation.response.result.get.fields.get("error") shouldBe Some(
-              JsString(compositionComponentNotFound(s"$namespace/$missing")))
-            checkConductorLogsAndAnnotations(activation, 2) // echo
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            withActivation(wsk.activation, undefinedrun) { activation =>
+              activation.response.status shouldBe "application error"
+              activation.response.result.get.fields.get("error") shouldBe Some(
+                JsString(compositionComponentNotFound(s"$namespace/$missing")))
+              checkConductorLogsAndAnnotations(activation, 2) // echo
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke a conductor action with a continuation"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke a conductor action with a continuation" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "invoke a conductor action with a continuation"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -217,8 +218,8 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke nested conductor actions"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke nested conductor actions" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "invoke nested conductor actions"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -313,8 +314,8 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  testname = "invoke a conductor action in a package binding"
   it should "invoke a conductor action in a package binding" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "invoke a conductor action in a package binding"
     org.apache.openwhisk.utils
       .retry(
         {

--- a/tests/src/test/scala/system/basic/WskRestBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicTests.scala
@@ -54,11 +54,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
   private val retriesOnTestFailures = 5
   private val waitBeforeRetry = 1.second
 
-  var behaviorname = "Wsk REST"
-  behavior of s"$behaviorname"
+  val behaviorwsk = "Wsk REST"
+  behavior of s"$behaviorwsk"
 
-  var testname = "reject creating duplicate entity"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "reject creating duplicate entity" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "reject creating duplicate entity"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -73,11 +73,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsk should $testname not successful, retrying.."))
   }
 
-  testname = "reject deleting entity in wrong collection"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "reject deleting entity in wrong collection" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "reject deleting entity in wrong collection"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -90,11 +90,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsk should $testname not successful, retrying.."))
   }
 
-  testname = "reject unauthenticated access"
-  it should s"$testname" in {
+  it should "reject unauthenticated access" in {
+    val testname = "reject unauthenticated access"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -104,14 +104,14 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsk should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Package REST"
-  behavior of s"$behaviorname"
+  val behaviorwskpkg = "Wsk Package REST"
+  behavior of s"$behaviorwskpkg"
 
-  testname = "create, update, get and list a package"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, update, get and list a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create, update, get and list a package"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -138,11 +138,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskpkg should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get a package summary"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, and get a package summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create, and get a package summary"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -240,11 +240,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskpkg should $testname not successful, retrying.."))
   }
 
-  testname = "create a package with a name that contains spaces"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create a package with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create a package with a name that contains spaces"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -260,11 +260,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskpkg should $testname not successful, retrying.."))
   }
 
-  testname = "create a package, and get its individual fields"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create a package, and get its individual fields" in withAssetCleaner(wskprops) {
+    val testname = "create a package, and get its individual fields"
     val name = "packageFields"
     val paramInput = Map("payload" -> "test".toJson)
 
@@ -290,11 +290,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskpkg should $testname not successful, retrying.."))
   }
 
-  testname = "reject creation of duplication packages"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "reject creation of duplication packages" in withAssetCleaner(wskprops) {
+    val testname = "reject creation of duplication packages"
     val name = "dupePackage"
 
     (wp, assetHelper) =>
@@ -311,11 +311,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskpkg should $testname not successful, retrying.."))
   }
 
-  testname = "reject delete of package that does not exist"
-  it should s"$testname" in {
+  it should "reject delete of package that does not exist" in {
+    val testname = "reject delete of package that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -325,11 +325,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskpkg should $testname not successful, retrying.."))
   }
 
-  testname = "reject get of package that does not exist"
-  it should s"$testname" in {
+  it should "reject get of package that does not exist" in {
+    val testname = "reject get of package that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -340,14 +340,14 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskpkg should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Action REST"
-  behavior of s"$behaviorname"
+  val behaviorwskaction = "Wsk Action REST"
+  behavior of s"$behaviorwskaction"
 
-  testname = "create the same action twice with different cases"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create the same action twice with different cases" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create the same action twice with different cases"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -361,11 +361,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create, update, get and list an action"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, update, get and list an action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create, update, get and list an action"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -393,11 +393,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "reject create of an action that already exists"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "reject create of an action that already exists" in withAssetCleaner(wskprops) {
+    val testname = "reject create of an action that already exists"
     val name = "dupeAction"
     val file = Some(TestUtils.getTestActionFilename("echo.js"))
 
@@ -415,11 +415,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "reject delete of action that does not exist"
-  it should s"$testname" in {
+  it should "reject delete of action that does not exist" in {
+    val testname = "reject delete of action that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -429,11 +429,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "reject invocation of action that does not exist"
-  it should s"$testname" in {
+  it should "reject invocation of action that does not exist" in {
+    val testname = "reject invocation of action that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -443,11 +443,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "reject get of an action that does not exist"
-  it should s"$testname" in {
+  it should "reject get of an action that does not exist" in {
+    val testname = "reject get of an action that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -457,11 +457,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create, and invoke an action that utilizes a docker container"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create, and invoke an action that utilizes a docker container" in withAssetCleaner(wskprops) {
+    val testname = "create, and invoke an action that utilizes a docker container"
     val name = "dockerContainer"
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
@@ -483,11 +483,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create, and invoke an action that utilizes dockerskeleton with native zip"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create, and invoke an action that utilizes dockerskeleton with native zip" in withAssetCleaner(wskprops) {
+    val testname = "create, and invoke an action that utilizes dockerskeleton with native zip"
     val name = "dockerContainerWithZip"
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
@@ -511,11 +511,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create, and invoke an action using a parameter file"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create, and invoke an action using a parameter file" in withAssetCleaner(wskprops) {
+    val testname = "create, and invoke an action using a parameter file"
     val name = "paramFileAction"
     val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
     val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
@@ -537,11 +537,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create an action, and get its individual fields"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create an action, and get its individual fields" in withAssetCleaner(wskprops) {
+    val testname = "create an action, and get its individual fields"
     val runtime = "nodejs:default"
     val name = "actionFields"
     val paramInput = Map("payload" -> "test".toJson)
@@ -599,7 +599,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
   /**
@@ -608,31 +608,33 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
    * surely when it runs there should be some indication in the logs. Don't
    * think this is true currently.
    */
-  testname = "create and invoke action with malformed js resulting in activation error"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "MALFORMED"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("malformed.js")))
-          }
+  it should "create and invoke action with malformed js resulting in activation error" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "create and invoke action with malformed js resulting in activation error"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "MALFORMED"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("malformed.js")))
+            }
 
-          val run = wsk.action.invoke(name, Map("payload" -> "whatever".toJson))
-          withActivation(wsk.activation, run) { activation =>
-            activation.response.status shouldBe "action developer error"
-            // representing nodejs giving an error when given malformed.js
-            activation.response.result.get.toString should include("ReferenceError")
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            val run = wsk.action.invoke(name, Map("payload" -> "whatever".toJson))
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.status shouldBe "action developer error"
+              // representing nodejs giving an error when given malformed.js
+              activation.response.result.get.toString should include("ReferenceError")
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create and invoke a blocking action resulting in an application error response"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create and invoke a blocking action resulting in an application error response" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val testname = "create and invoke a blocking action resulting in an application error response"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -665,32 +667,33 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create and invoke a blocking action resulting in an failed promise"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "errorResponseObject"
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
-          }
+  it should "create and invoke a blocking action resulting in an failed promise" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "create and invoke a blocking action resulting in an failed promise"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "errorResponseObject"
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
+            }
 
-          val result = wsk.action.invoke(name, blocking = true, expectedExitCode = BadGateway.intValue)
-          val response = result.getFieldJsObject("response")
-          val res = RestResult.getFieldJsObject(response, "result")
-          res shouldBe JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            val result = wsk.action.invoke(name, blocking = true, expectedExitCode = BadGateway.intValue)
+            val response = result.getFieldJsObject("response")
+            val res = RestResult.getFieldJsObject(response, "result")
+            res shouldBe JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "invoke a blocking action and get only the result"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke a blocking action and get only the result" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "invoke a blocking action and get only the result"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -706,11 +709,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get an action summary"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, and get an action summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create, and get an action summary"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -785,11 +788,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create an action with a name that contains spaces"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create an action with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create an action with a name that contains spaces"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -804,31 +807,33 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create an action, and invoke an action that returns an empty JSON object"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val name = "emptyJSONAction"
+  it should "create an action, and invoke an action that returns an empty JSON object" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "create an action, and invoke an action that returns an empty JSON object"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val name = "emptyJSONAction"
 
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
-          }
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
+            }
 
-          val result = wsk.action.invoke(name, blocking = true, result = true)
-          result.stdout.parseJson.asJsObject shouldBe JsObject.empty
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            val result = wsk.action.invoke(name, blocking = true, result = true)
+            result.stdout.parseJson.asJsObject shouldBe JsObject.empty
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create, and invoke an action that times out to ensure the proper response is received"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, and invoke an action that times out to ensure the proper response is received" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val testname = "create, and invoke an action that times out to ensure the proper response is received"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -848,11 +853,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get docker action get ensure exec code is omitted"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create, and get docker action get ensure exec code is omitted" in withAssetCleaner(wskprops) {
+    val testname = "create, and get docker action get ensure exec code is omitted"
     val name = "dockerContainer"
     (wp, assetHelper) =>
       org.apache.openwhisk.utils
@@ -867,14 +872,14 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskaction should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Trigger REST"
-  behavior of s"$behaviorname"
+  val behaviorwsktrg = "Wsk Trigger REST"
+  behavior of s"$behaviorwsktrg"
 
-  testname = "create, update, get, fire and list trigger"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, update, get, fire and list trigger" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create, update, get, fire and list trigger"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -950,11 +955,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "create, and get a trigger summary"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, and get a trigger summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create, and get a trigger summary"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -986,11 +991,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "create a trigger with a name that contains spaces"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create a trigger with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create a trigger with a name that contains spaces"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1006,11 +1011,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "create, and fire a trigger using a parameter file"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create, and fire a trigger using a parameter file" in withAssetCleaner(wskprops) {
+    val testname = "create, and fire a trigger using a parameter file"
     val ruleName = withTimestamp("r1toa1")
     val triggerName = withTimestamp("paramFileTrigger")
     val actionName = withTimestamp("a1")
@@ -1041,11 +1046,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "create a trigger, and get its individual fields"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create a trigger, and get its individual fields" in withAssetCleaner(wskprops) {
+    val testname = "create a trigger, and get its individual fields"
     val name = "triggerFields"
     val paramInput = Map("payload" -> "test".toJson)
 
@@ -1075,11 +1080,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "create, and fire a trigger to ensure result is empty"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create, and fire a trigger to ensure result is empty" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create, and fire a trigger to ensure result is empty"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1107,11 +1112,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "reject creation of duplicate triggers"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "reject creation of duplicate triggers" in withAssetCleaner(wskprops) {
+    val testname = "reject creation of duplicate triggers"
     val name = "dupeTrigger"
 
     (wp, assetHelper) =>
@@ -1128,11 +1133,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "reject delete of trigger that does not exist"
-  it should s"$testname" in {
+  it should "reject delete of trigger that does not exist" in {
+    val testname = "reject delete of trigger that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1142,11 +1147,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "reject get of trigger that does not exist"
-  it should s"$testname" in {
+  it should "reject get of trigger that does not exist" in {
+    val testname = "reject get of trigger that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1156,11 +1161,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "reject firing of a trigger that does not exist"
-  it should s"$testname" in {
+  it should "reject firing of a trigger that does not exist" in {
+    val testname = "reject firing of a trigger that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1170,152 +1175,154 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "create and fire a trigger with a rule whose action has been deleted"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val ruleName1 = withTimestamp("r1toa1")
-          val ruleName2 = withTimestamp("r2toa2")
-          val triggerName = withTimestamp("t1tor1r2")
-          val actionName1 = withTimestamp("a1")
-          val actionName2 = withTimestamp("a2")
-          val ns = wsk.namespace.whois()
+  it should "create and fire a trigger with a rule whose action has been deleted" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "create and fire a trigger with a rule whose action has been deleted"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val ruleName1 = withTimestamp("r1toa1")
+            val ruleName2 = withTimestamp("r2toa2")
+            val triggerName = withTimestamp("t1tor1r2")
+            val actionName1 = withTimestamp("a1")
+            val actionName2 = withTimestamp("a2")
+            val ns = wsk.namespace.whois()
 
-          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-            trigger.create(triggerName)
-            trigger.create(triggerName, update = true)
-          }
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+              trigger.create(triggerName)
+              trigger.create(triggerName, update = true)
+            }
 
-          assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
-            action.create(name, defaultAction)
-          }
-          wsk.action.create(actionName2, defaultAction) // Delete this after the rule is created
+            assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
+              action.create(name, defaultAction)
+            }
+            wsk.action.create(actionName2, defaultAction) // Delete this after the rule is created
 
-          assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
-            rule.create(name, trigger = triggerName, action = actionName1)
-          }
-          assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
-            rule.create(name, trigger = triggerName, action = actionName2)
-          }
-          wsk.action.delete(actionName2)
+            assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName1)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName2)
+            }
+            wsk.action.delete(actionName2)
 
-          val run = wsk.trigger.fire(triggerName)
-          withActivation(wsk.activation, run) {
-            activation =>
-              activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-              activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-              activation.logs shouldBe defined
-              activation.logs.get.size shouldBe 2
+            val run = wsk.trigger.fire(triggerName)
+            withActivation(wsk.activation, run) {
+              activation =>
+                activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+                activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
+                activation.logs shouldBe defined
+                activation.logs.get.size shouldBe 2
 
-              val logEntry1 = activation.logs.get(0).parseJson.asJsObject
-              val logEntry2 = activation.logs.get(1).parseJson.asJsObject
-              val logs = JsArray(logEntry1, logEntry2)
-              val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
-                logEntry1.getFields("activationId")(0).convertTo[String]
-              } else {
-                logEntry2.getFields("activationId")(0).convertTo[String]
-              }
-              val expectedLogs = JsArray(
-                JsObject(
-                  "statusCode" -> JsNumber(0),
-                  "activationId" -> JsString(ruleActivationId),
-                  "success" -> JsTrue,
-                  "rule" -> JsString(ns + "/" + ruleName1),
-                  "action" -> JsString(ns + "/" + actionName1)),
-                JsObject(
-                  "statusCode" -> JsNumber(1),
-                  "success" -> JsFalse,
-                  "error" -> JsString("The requested resource does not exist."),
-                  "rule" -> JsString(ns + "/" + ruleName2),
-                  "action" -> JsString(ns + "/" + actionName2)))
-              logs shouldBe expectedLogs
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+                val logEntry1 = activation.logs.get(0).parseJson.asJsObject
+                val logEntry2 = activation.logs.get(1).parseJson.asJsObject
+                val logs = JsArray(logEntry1, logEntry2)
+                val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
+                  logEntry1.getFields("activationId")(0).convertTo[String]
+                } else {
+                  logEntry2.getFields("activationId")(0).convertTo[String]
+                }
+                val expectedLogs = JsArray(
+                  JsObject(
+                    "statusCode" -> JsNumber(0),
+                    "activationId" -> JsString(ruleActivationId),
+                    "success" -> JsTrue,
+                    "rule" -> JsString(ns + "/" + ruleName1),
+                    "action" -> JsString(ns + "/" + actionName1)),
+                  JsObject(
+                    "statusCode" -> JsNumber(1),
+                    "success" -> JsFalse,
+                    "error" -> JsString("The requested resource does not exist."),
+                    "rule" -> JsString(ns + "/" + ruleName2),
+                    "action" -> JsString(ns + "/" + actionName2)))
+                logs shouldBe expectedLogs
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  testname = "create and fire a trigger having an active rule and an inactive rule"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val ruleName1 = withTimestamp("r1toa1")
-          val ruleName2 = withTimestamp("r2toa2")
-          val triggerName = withTimestamp("t1tor1r2")
-          val actionName1 = withTimestamp("a1")
-          val actionName2 = withTimestamp("a2")
-          val ns = wsk.namespace.whois()
+  it should "create and fire a trigger having an active rule and an inactive rule" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "create and fire a trigger having an active rule and an inactive rule"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val ruleName1 = withTimestamp("r1toa1")
+            val ruleName2 = withTimestamp("r2toa2")
+            val triggerName = withTimestamp("t1tor1r2")
+            val actionName1 = withTimestamp("a1")
+            val actionName2 = withTimestamp("a2")
+            val ns = wsk.namespace.whois()
 
-          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-            trigger.create(triggerName)
-            trigger.create(triggerName, update = true)
-          }
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+              trigger.create(triggerName)
+              trigger.create(triggerName, update = true)
+            }
 
-          assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
-            action.create(name, defaultAction)
-          }
-          assetHelper.withCleaner(wsk.action, actionName2) { (action, name) =>
-            action.create(name, defaultAction)
-          }
+            assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
+              action.create(name, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.action, actionName2) { (action, name) =>
+              action.create(name, defaultAction)
+            }
 
-          assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
-            rule.create(name, trigger = triggerName, action = actionName1)
-          }
-          assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
-            rule.create(name, trigger = triggerName, action = actionName2)
-            rule.disable(ruleName2)
-          }
+            assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName1)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName2)
+              rule.disable(ruleName2)
+            }
 
-          val run = wsk.trigger.fire(triggerName)
-          withActivation(wsk.activation, run) {
-            activation =>
-              activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-              activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-              activation.logs shouldBe defined
-              activation.logs.get.size shouldBe 2
+            val run = wsk.trigger.fire(triggerName)
+            withActivation(wsk.activation, run) {
+              activation =>
+                activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+                activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
+                activation.logs shouldBe defined
+                activation.logs.get.size shouldBe 2
 
-              val logEntry1 = activation.logs.get(0).parseJson.asJsObject
-              val logEntry2 = activation.logs.get(1).parseJson.asJsObject
-              val logs = JsArray(logEntry1, logEntry2)
-              val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
-                logEntry1.getFields("activationId")(0).convertTo[String]
-              } else {
-                logEntry2.getFields("activationId")(0).convertTo[String]
-              }
-              val expectedLogs = JsArray(
-                JsObject(
-                  "statusCode" -> JsNumber(0),
-                  "activationId" -> JsString(ruleActivationId),
-                  "success" -> JsTrue,
-                  "rule" -> JsString(ns + "/" + ruleName1),
-                  "action" -> JsString(ns + "/" + actionName1)),
-                JsObject(
-                  "statusCode" -> JsNumber(1),
-                  "success" -> JsFalse,
-                  "error" -> JsString(Messages.triggerWithInactiveRule(s"$ns/$ruleName2", s"$ns/$actionName2")),
-                  "rule" -> JsString(ns + "/" + ruleName2),
-                  "action" -> JsString(ns + "/" + actionName2)))
-              logs shouldBe expectedLogs
-          }
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+                val logEntry1 = activation.logs.get(0).parseJson.asJsObject
+                val logEntry2 = activation.logs.get(1).parseJson.asJsObject
+                val logs = JsArray(logEntry1, logEntry2)
+                val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
+                  logEntry1.getFields("activationId")(0).convertTo[String]
+                } else {
+                  logEntry2.getFields("activationId")(0).convertTo[String]
+                }
+                val expectedLogs = JsArray(
+                  JsObject(
+                    "statusCode" -> JsNumber(0),
+                    "activationId" -> JsString(ruleActivationId),
+                    "success" -> JsTrue,
+                    "rule" -> JsString(ns + "/" + ruleName1),
+                    "action" -> JsString(ns + "/" + actionName1)),
+                  JsObject(
+                    "statusCode" -> JsNumber(1),
+                    "success" -> JsFalse,
+                    "error" -> JsString(Messages.triggerWithInactiveRule(s"$ns/$ruleName2", s"$ns/$actionName2")),
+                    "rule" -> JsString(ns + "/" + ruleName2),
+                    "action" -> JsString(ns + "/" + actionName2)))
+                logs shouldBe expectedLogs
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorwsktrg should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Rule REST"
-  behavior of s"$behaviorname"
+  val behaviorwskrule = "Wsk Rule REST"
+  behavior of s"$behaviorwskrule"
 
-  testname = "create rule, get rule, update rule and list rule"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create rule, get rule, update rule and list rule" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val testname = "create rule, get rule, update rule and list rule"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1353,71 +1360,73 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "create rule, get rule, ensure rule is enabled by default"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val ruleName = "enabledRule"
-          val triggerName = "enabledRuleTrigger"
-          val actionName = "enabledRuleAction"
+  it should "create rule, get rule, ensure rule is enabled by default" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "create rule, get rule, ensure rule is enabled by default"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val ruleName = "enabledRule"
+            val triggerName = "enabledRuleTrigger"
+            val actionName = "enabledRuleAction"
 
-          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-            trigger.create(name)
-          }
-          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-            action.create(name, defaultAction)
-          }
-          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-            rule.create(name, trigger = triggerName, action = actionName)
-          }
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+              trigger.create(name)
+            }
+            assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+              action.create(name, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName)
+            }
 
-          val rule = wsk.rule.get(ruleName)
-          rule.getField("status") shouldBe "active"
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            val rule = wsk.rule.get(ruleName)
+            rule.getField("status") shouldBe "active"
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "display a rule summary when --summary flag is used with 'wsk rule get"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    org.apache.openwhisk.utils
-      .retry(
-        {
-          assetHelper.deleteAssets()
-          val ruleName = "mySummaryRule"
-          val triggerName = "summaryRuleTrigger"
-          val actionName = "summaryRuleAction"
+  it should "display a rule summary when --summary flag is used with 'wsk rule get" in withAssetCleaner(wskprops) {
+    (wp, assetHelper) =>
+      val testname = "display a rule summary when --summary flag is used with 'wsk rule get"
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            val ruleName = "mySummaryRule"
+            val triggerName = "summaryRuleTrigger"
+            val actionName = "summaryRuleAction"
 
-          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-            trigger.create(name)
-          }
-          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-            action.create(name, defaultAction)
-          }
-          assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
-            rule.create(name, trigger = triggerName, action = actionName)
-          }
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+              trigger.create(name)
+            }
+            assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+              action.create(name, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName)
+            }
 
-          // Summary namespace should match one of the allowable namespaces (typically 'guest')
-          val ns = wsk.namespace.whois()
-          val result = wsk.rule.get(ruleName)
-          result.getField("name") shouldBe ruleName
-          result.getField("namespace") shouldBe ns
-          result.getField("status") shouldBe "active"
-        },
-        retriesOnTestFailures,
-        Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+            // Summary namespace should match one of the allowable namespaces (typically 'guest')
+            val ns = wsk.namespace.whois()
+            val result = wsk.rule.get(ruleName)
+            result.getField("name") shouldBe ruleName
+            result.getField("namespace") shouldBe ns
+            result.getField("status") shouldBe "active"
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "create a rule, and get its individual fields"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "create a rule, and get its individual fields" in withAssetCleaner(wskprops) {
+    val testname = "create a rule, and get its individual fields"
     val ruleName = "ruleFields"
     val triggerName = "ruleTriggerFields"
     val actionName = "ruleActionFields"
@@ -1454,11 +1463,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "reject creation of duplicate rules"
-  it should s"$testname" in withAssetCleaner(wskprops) {
+  it should "reject creation of duplicate rules" in withAssetCleaner(wskprops) {
+    val testname = "reject creation of duplicate rules"
     val ruleName = "dupeRule"
     val triggerName = "triggerName"
     val actionName = "actionName"
@@ -1486,11 +1495,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
-          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+          Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "reject delete of rule that does not exist"
-  it should s"$testname" in {
+  it should "reject delete of rule that does not exist" in {
+    val testname = "reject delete of rule that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1500,11 +1509,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "reject enable of rule that does not exist"
-  it should s"$testname" in {
+  it should "reject enable of rule that does not exist" in {
+    val testname = "reject enable of rule that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1514,11 +1523,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "reject disable of rule that does not exist"
-  it should s"$testname" in {
+  it should "reject disable of rule that does not exist" in {
+    val testname = "reject disable of rule that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1528,11 +1537,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "reject status of rule that does not exist"
-  it should s"$testname" in {
+  it should "reject status of rule that does not exist" in {
+    val testname = "reject status of rule that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1542,11 +1551,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  testname = "reject get of rule that does not exist"
-  it should s"$testname" in {
+  it should "reject get of rule that does not exist" in {
+    val testname = "reject get of rule that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1556,14 +1565,14 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskrule should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Namespace REST"
-  behavior of s"$behaviorname"
+  val behaviorwskns = "Wsk Namespace REST"
+  behavior of s"$behaviorwskns"
 
-  testname = "return a list of exactly one namespace"
-  it should s"$testname" in {
+  it should "return a list of exactly one namespace" in {
+    val testname = "return a list of exactly one namespace"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1572,14 +1581,15 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskns should $testname not successful, retrying.."))
   }
 
-  behaviorname = "Wsk Activation REST"
-  behavior of s"$behaviorname"
+  val behaviorwskactivation = "Wsk Activation REST"
+  behavior of s"$behaviorwskactivation"
 
-  testname = "create a trigger, and fire a trigger to get its individual fields from an activation"
-  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "create a trigger, and fire a trigger to get its individual fields from an activation" in withAssetCleaner(
+    wskprops) { (wp, assetHelper) =>
+    val testname = "create a trigger, and fire a trigger to get its individual fields from an activation"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1618,11 +1628,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactivation should $testname not successful, retrying.."))
   }
 
-  testname = "reject get of activation that does not exist"
-  it should s"$testname" in {
+  it should "reject get of activation that does not exist" in {
+    val testname = "reject get of activation that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1632,11 +1642,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactivation should $testname not successful, retrying.."))
   }
 
-  testname = "reject logs of activation that does not exist"
-  it should s"$testname" in {
+  it should "reject logs of activation that does not exist" in {
+    val testname = "reject logs of activation that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1646,11 +1656,11 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactivation should $testname not successful, retrying.."))
   }
 
-  testname = "reject result of activation that does not exist"
-  it should s"$testname" in {
+  it should "reject result of activation that does not exist" in {
+    val testname = "reject result of activation that does not exist"
     org.apache.openwhisk.utils
       .retry(
         {
@@ -1660,6 +1670,6 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         },
         retriesOnTestFailures,
         Some(waitBeforeRetry),
-        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
+        Some(s"${this.getClass.getName} > $behaviorwskactivation should $testname not successful, retrying.."))
   }
 }

--- a/tests/src/test/scala/system/basic/WskRestBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicTests.scala
@@ -51,370 +51,555 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
    */
   def cacheRetry[T](fn: => T) = org.apache.openwhisk.utils.retry(fn, 5, Some(1.second))
 
-  behavior of "Wsk REST"
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
 
-  it should "reject creating duplicate entity" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "testDuplicateCreate"
-    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-      trigger.create(name)
-    }
-    assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
-      action.create(name, defaultAction, expectedExitCode = Conflict.intValue)
-    }
+  var behaviorname = "Wsk REST"
+  behavior of s"$behaviorname"
+
+  var testname = "reject creating duplicate entity"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "testDuplicateCreate"
+          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+            trigger.create(name)
+          }
+          assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
+            action.create(name, defaultAction, expectedExitCode = Conflict.intValue)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject deleting entity in wrong collection" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "testCrossDelete"
-    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-      trigger.create(name)
-    }
-    wsk.action.delete(name, expectedExitCode = Conflict.intValue)
+  testname = "reject deleting entity in wrong collection"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "testCrossDelete"
+          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+            trigger.create(name)
+          }
+          wsk.action.delete(name, expectedExitCode = Conflict.intValue)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject unauthenticated access" in {
-    implicit val wskprops = WskProps("xxx") // shadow properties
-    val errormsg = "The supplied authentication is invalid"
-    wsk.namespace.list(expectedExitCode = Unauthorized.intValue).stderr should include(errormsg)
+  testname = "reject unauthenticated access"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val wskprops = WskProps("xxx") // shadow properties
+          val errormsg = "The supplied authentication is invalid"
+          wsk.namespace.list(expectedExitCode = Unauthorized.intValue).stderr should include(errormsg)
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Package REST"
+  behaviorname = "Wsk Package REST"
+  behavior of s"$behaviorname"
 
-  it should "create, update, get and list a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "testPackage"
-    val params = Map("a" -> "A".toJson)
-    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-      pkg.create(name, parameters = params, shared = Some(true))
-      pkg.create(name, update = true)
-    }
+  testname = "create, update, get and list a package"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "testPackage"
+          val params = Map("a" -> "A".toJson)
+          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+            pkg.create(name, parameters = params, shared = Some(true))
+            pkg.create(name, update = true)
+          }
 
-    // Add retry to ensure cache with "0.0.1" is replaced
-    val pack = cacheRetry({
-      val p = wsk.pkg.get(name)
-      p.getField("version") shouldBe "0.0.2"
-      p
-    })
-    pack.getFieldJsValue("publish") shouldBe JsTrue
-    pack.getFieldJsValue("parameters") shouldBe JsArray(JsObject("key" -> JsString("a"), "value" -> JsString("A")))
-    val packageList = wsk.pkg.list()
-    val packages = packageList.getBodyListJsObject
-    packages.exists(pack => RestResult.getField(pack, "name") == name) shouldBe true
+          // Add retry to ensure cache with "0.0.1" is replaced
+          val pack = cacheRetry({
+            val p = wsk.pkg.get(name)
+            p.getField("version") shouldBe "0.0.2"
+            p
+          })
+          pack.getFieldJsValue("publish") shouldBe JsTrue
+          pack.getFieldJsValue("parameters") shouldBe JsArray(
+            JsObject("key" -> JsString("a"), "value" -> JsString("A")))
+          val packageList = wsk.pkg.list()
+          val packages = packageList.getBodyListJsObject
+          packages.exists(pack => RestResult.getField(pack, "name") == name) shouldBe true
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get a package summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val runtime = "nodejs:default"
-    val packageName = "packageName"
-    val actionName = "actionName"
-    val packageAnnots = Map(
-      "description" -> JsString("Package description"),
-      "parameters" -> JsArray(
-        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
-    val actionAnnots = Map(
-      "description" -> JsString("Action description"),
-      "parameters" -> JsArray(
-        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+  testname = "create, and get a package summary"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val runtime = "nodejs:default"
+          val packageName = "packageName"
+          val actionName = "actionName"
+          val packageAnnots = Map(
+            "description" -> JsString("Package description"),
+            "parameters" -> JsArray(
+              JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+              JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+          val actionAnnots = Map(
+            "description" -> JsString("Action description"),
+            "parameters" -> JsArray(
+              JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+              JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
 
-    assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
-      pkg.create(packageName, annotations = packageAnnots)
-    }
+          assetHelper.withCleaner(wsk.pkg, packageName) { (pkg, _) =>
+            pkg.create(packageName, annotations = packageAnnots)
+          }
 
-    wsk.action.create(packageName + "/" + actionName, defaultAction, annotations = actionAnnots, kind = Some(runtime))
-    val result = cacheRetry({
-      val p = wsk.pkg.get(packageName)
-      p.getFieldListJsObject("actions") should have size 1
-      p
-    })
-    val ns = wsk.namespace.whois()
-    wsk.action.delete(packageName + "/" + actionName)
+          wsk.action
+            .create(packageName + "/" + actionName, defaultAction, annotations = actionAnnots, kind = Some(runtime))
+          val result = cacheRetry({
+            val p = wsk.pkg.get(packageName)
+            p.getFieldListJsObject("actions") should have size 1
+            p
+          })
+          val ns = wsk.namespace.whois()
+          wsk.action.delete(packageName + "/" + actionName)
 
-    result.getField("name") shouldBe packageName
-    result.getField("namespace") shouldBe ns
-    val annos = result.getFieldJsValue("annotations")
-    annos shouldBe JsArray(
-      JsObject("key" -> JsString("description"), "value" -> JsString("Package description")),
-      JsObject(
-        "key" -> JsString("parameters"),
-        "value" -> JsArray(
-          JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-          JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2")))))
-    val action = result.getFieldListJsObject("actions")(0)
-    RestResult.getField(action, "name") shouldBe actionName
+          result.getField("name") shouldBe packageName
+          result.getField("namespace") shouldBe ns
+          val annos = result.getFieldJsValue("annotations")
+          annos shouldBe JsArray(
+            JsObject("key" -> JsString("description"), "value" -> JsString("Package description")),
+            JsObject(
+              "key" -> JsString("parameters"),
+              "value" -> JsArray(
+                JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+                JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2")))))
+          val action = result.getFieldListJsObject("actions")(0)
+          RestResult.getField(action, "name") shouldBe actionName
 
-    val annoAction = RestResult.getFieldJsValue(action, "annotations")
+          val annoAction = RestResult.getFieldJsValue(action, "annotations")
 
-    // first we check the returned execution runtime for 'nodejs:*'
-    annoAction
-      .convertTo[Seq[JsObject]]
-      .find(_.fields("key").convertTo[String] == "exec")
-      .map(_.fields("value"))
-      .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
-      .getOrElse(fail())
+          // first we check the returned execution runtime for 'nodejs:*'
+          annoAction
+            .convertTo[Seq[JsObject]]
+            .find(_.fields("key").convertTo[String] == "exec")
+            .map(_.fields("value"))
+            .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
+            .getOrElse(fail())
 
-    // since we checked it, we can remove the exec field from the annotations to make the following checks easier
-    val annoActionWithoutExec =
-      annoAction
-        .convertTo[Seq[JsObject]]
-        .filter(annotation => annotation.fields("key").convertTo[String] != "exec")
-        .toJson
+          // since we checked it, we can remove the exec field from the annotations to make the following checks easier
+          val annoActionWithoutExec =
+            annoAction
+              .convertTo[Seq[JsObject]]
+              .filter(annotation => annotation.fields("key").convertTo[String] != "exec")
+              .toJson
 
-    annoActionWithoutExec shouldBe (if (requireAPIKeyAnnotation) {
-                                      JsArray(
-                                        JsObject(
-                                          "key" -> JsString("description"),
-                                          "value" -> JsString("Action description")),
-                                        JsObject(
-                                          "key" -> JsString("parameters"),
-                                          "value" -> JsArray(
-                                            JsObject(
-                                              "name" -> JsString("paramName1"),
-                                              "description" -> JsString("Parameter description 1")),
-                                            JsObject(
-                                              "name" -> JsString("paramName2"),
-                                              "description" -> JsString("Parameter description 2")))),
-                                        JsObject(
-                                          "key" -> Annotations.ProvideApiKeyAnnotationName.toJson,
-                                          "value" -> JsFalse))
-                                    } else {
-                                      JsArray(
-                                        JsObject(
-                                          "key" -> JsString("description"),
-                                          "value" -> JsString("Action description")),
-                                        JsObject(
-                                          "key" -> JsString("parameters"),
-                                          "value" -> JsArray(
-                                            JsObject(
-                                              "name" -> JsString("paramName1"),
-                                              "description" -> JsString("Parameter description 1")),
-                                            JsObject(
-                                              "name" -> JsString("paramName2"),
-                                              "description" -> JsString("Parameter description 2")))))
-                                    })
+          annoActionWithoutExec shouldBe (if (requireAPIKeyAnnotation) {
+                                            JsArray(
+                                              JsObject(
+                                                "key" -> JsString("description"),
+                                                "value" -> JsString("Action description")),
+                                              JsObject(
+                                                "key" -> JsString("parameters"),
+                                                "value" -> JsArray(
+                                                  JsObject(
+                                                    "name" -> JsString("paramName1"),
+                                                    "description" -> JsString("Parameter description 1")),
+                                                  JsObject(
+                                                    "name" -> JsString("paramName2"),
+                                                    "description" -> JsString("Parameter description 2")))),
+                                              JsObject(
+                                                "key" -> Annotations.ProvideApiKeyAnnotationName.toJson,
+                                                "value" -> JsFalse))
+                                          } else {
+                                            JsArray(
+                                              JsObject(
+                                                "key" -> JsString("description"),
+                                                "value" -> JsString("Action description")),
+                                              JsObject(
+                                                "key" -> JsString("parameters"),
+                                                "value" -> JsArray(
+                                                  JsObject(
+                                                    "name" -> JsString("paramName1"),
+                                                    "description" -> JsString("Parameter description 1")),
+                                                  JsObject(
+                                                    "name" -> JsString("paramName2"),
+                                                    "description" -> JsString("Parameter description 2")))))
+                                          })
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create a package with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "package with spaces"
+  testname = "create a package with a name that contains spaces"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "package with spaces"
 
-    assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-      pkg.create(name)
-    }
+          assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+            pkg.create(name)
+          }
 
-    val pack = wsk.pkg.get(name)
-    pack.getField("name") shouldBe name
+          val pack = wsk.pkg.get(name)
+          pack.getField("name") shouldBe name
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create a package, and get its individual fields" in withAssetCleaner(wskprops) {
+  testname = "create a package, and get its individual fields"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "packageFields"
     val paramInput = Map("payload" -> "test".toJson)
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-        pkg.create(name, parameters = paramInput)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+              pkg.create(name, parameters = paramInput)
+            }
 
-      val expectedParam = JsObject("payload" -> JsString("test"))
-      val ns = wsk.namespace.whois()
+            val expectedParam = JsObject("payload" -> JsString("test"))
+            val ns = wsk.namespace.whois()
 
-      var result = wsk.pkg.get(name)
-      result.getField("namespace") shouldBe ns
-      result.getField("name") shouldBe name
-      result.getField("version") shouldBe "0.0.1"
-      result.getFieldJsValue("publish") shouldBe JsFalse
-      result.getFieldJsValue("binding") shouldBe JsObject.empty
-      result.getField("invalid") shouldBe ""
+            var result = wsk.pkg.get(name)
+            result.getField("namespace") shouldBe ns
+            result.getField("name") shouldBe name
+            result.getField("version") shouldBe "0.0.1"
+            result.getFieldJsValue("publish") shouldBe JsFalse
+            result.getFieldJsValue("binding") shouldBe JsObject.empty
+            result.getField("invalid") shouldBe ""
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject creation of duplication packages" in withAssetCleaner(wskprops) {
+  testname = "reject creation of duplication packages"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "dupePackage"
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
-        pkg.create(name)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
+              pkg.create(name)
+            }
 
-      val stderr = wsk.pkg.create(name, expectedExitCode = Conflict.intValue).stderr
-      stderr should include("resource already exists")
+            val stderr = wsk.pkg.create(name, expectedExitCode = Conflict.intValue).stderr
+            stderr should include("resource already exists")
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject delete of package that does not exist" in {
-    val name = "nonexistentPackage"
-    val stderr = wsk.pkg.delete(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject delete of package that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentPackage"
+          val stderr = wsk.pkg.delete(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject get of package that does not exist" in {
-    val name = "nonexistentPackage"
-    val ns = wsk.namespace.whois()
-    val stderr = wsk.pkg.get(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include(s"The requested resource '$ns/$name' does not exist")
+  testname = "reject get of package that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentPackage"
+          val ns = wsk.namespace.whois()
+          val stderr = wsk.pkg.get(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include(s"The requested resource '$ns/$name' does not exist")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Action REST"
+  behaviorname = "Wsk Action REST"
+  behavior of s"$behaviorname"
 
-  it should "create the same action twice with different cases" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    assetHelper.withCleaner(wsk.action, "TWICE") { (action, name) =>
-      action.create(name, defaultAction)
-    }
-    assetHelper.withCleaner(wsk.action, "twice") { (action, name) =>
-      action.create(name, defaultAction)
-    }
+  testname = "create the same action twice with different cases"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          assetHelper.withCleaner(wsk.action, "TWICE") { (action, name) =>
+            action.create(name, defaultAction)
+          }
+          assetHelper.withCleaner(wsk.action, "twice") { (action, name) =>
+            action.create(name, defaultAction)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, update, get and list an action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "createAndUpdate"
-    val file = Some(TestUtils.getTestActionFilename("hello.js"))
-    val params = Map("a" -> "A".toJson)
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, file, parameters = params)
-      action.create(name, None, parameters = Map("b" -> "B".toJson), update = true)
-    }
+  testname = "create, update, get and list an action"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "createAndUpdate"
+          val file = Some(TestUtils.getTestActionFilename("hello.js"))
+          val params = Map("a" -> "A".toJson)
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, file, parameters = params)
+            action.create(name, None, parameters = Map("b" -> "B".toJson), update = true)
+          }
 
-    // Add retry to ensure cache with "0.0.1" is replaced
-    val action = cacheRetry({
-      val a = wsk.action.get(name)
-      a.getField("version") shouldBe "0.0.2"
-      a
-    })
-    action.getFieldJsValue("parameters") shouldBe JsArray(JsObject("key" -> JsString("b"), "value" -> JsString("B")))
-    action.getFieldJsValue("publish") shouldBe JsFalse
-    val actionList = wsk.action.list()
-    val actions = actionList.getBodyListJsObject
-    actions.exists(action => RestResult.getField(action, "name") == name) shouldBe true
+          // Add retry to ensure cache with "0.0.1" is replaced
+          val action = cacheRetry({
+            val a = wsk.action.get(name)
+            a.getField("version") shouldBe "0.0.2"
+            a
+          })
+          action.getFieldJsValue("parameters") shouldBe JsArray(
+            JsObject("key" -> JsString("b"), "value" -> JsString("B")))
+          action.getFieldJsValue("publish") shouldBe JsFalse
+          val actionList = wsk.action.list()
+          val actions = actionList.getBodyListJsObject
+          actions.exists(action => RestResult.getField(action, "name") == name) shouldBe true
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject create of an action that already exists" in withAssetCleaner(wskprops) {
+  testname = "reject create of an action that already exists"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "dupeAction"
     val file = Some(TestUtils.getTestActionFilename("echo.js"))
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, file)
+            }
 
-      val stderr = wsk.action.create(name, file, expectedExitCode = Conflict.intValue).stderr
-      stderr should include("resource already exists")
+            val stderr = wsk.action.create(name, file, expectedExitCode = Conflict.intValue).stderr
+            stderr should include("resource already exists")
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject delete of action that does not exist" in {
-    val name = "nonexistentAction"
-    val stderr = wsk.action.delete(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject delete of action that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentAction"
+          val stderr = wsk.action.delete(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject invocation of action that does not exist" in {
-    val name = "nonexistentAction"
-    val stderr = wsk.action.invoke(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject invocation of action that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentAction"
+          val stderr = wsk.action.invoke(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject get of an action that does not exist" in {
-    val name = "nonexistentAction"
-    val stderr = wsk.action.get(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject get of an action that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentAction"
+          val stderr = wsk.action.get(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and invoke an action that utilizes a docker container" in withAssetCleaner(wskprops) {
+  testname = "create, and invoke an action that utilizes a docker container"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "dockerContainer"
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) {
-        // this docker image will be need to be pulled from dockerhub and hence has to be published there first
-        (action, _) =>
-          action.create(name, None, docker = Some("openwhisk/example"))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) {
+              // this docker image will be need to be pulled from dockerhub and hence has to be published there first
+              (action, _) =>
+                action.create(name, None, docker = Some("openwhisk/example"))
+            }
 
-      val args = Map("payload" -> "test".toJson)
-      val run = wsk.action.invoke(name, args)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.result shouldBe Some(
-          JsObject("args" -> args.toJson, "msg" -> "Hello from arbitrary C program!".toJson))
-      }
+            val args = Map("payload" -> "test".toJson)
+            val run = wsk.action.invoke(name, args)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.result shouldBe Some(
+                JsObject("args" -> args.toJson, "msg" -> "Hello from arbitrary C program!".toJson))
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and invoke an action that utilizes dockerskeleton with native zip" in withAssetCleaner(wskprops) {
+  testname = "create, and invoke an action that utilizes dockerskeleton with native zip"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "dockerContainerWithZip"
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) {
-        // this docker image will be need to be pulled from dockerhub and hence has to be published there first
-        (action, _) =>
-          action.create(name, Some(TestUtils.getTestActionFilename("blackbox.zip")), kind = Some("native"))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) {
+              // this docker image will be need to be pulled from dockerhub and hence has to be published there first
+              (action, _) =>
+                action.create(name, Some(TestUtils.getTestActionFilename("blackbox.zip")), kind = Some("native"))
+            }
 
-      val run = wsk.action.invoke(name, Map.empty)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.result shouldBe Some(JsObject("msg" -> "hello zip".toJson))
-        activation.logs shouldBe defined
-        val logs = activation.logs.get.toString
-        logs should include("This is an example zip used with the docker skeleton action.")
-        logs should not include Container.ACTIVATION_LOG_SENTINEL
-      }
+            val run = wsk.action.invoke(name, Map.empty)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.result shouldBe Some(JsObject("msg" -> "hello zip".toJson))
+              activation.logs shouldBe defined
+              val logs = activation.logs.get.toString
+              logs should include("This is an example zip used with the docker skeleton action.")
+              logs should not include Container.ACTIVATION_LOG_SENTINEL
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and invoke an action using a parameter file" in withAssetCleaner(wskprops) {
+  testname = "create, and invoke an action using a parameter file"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "paramFileAction"
     val file = Some(TestUtils.getTestActionFilename("argCheck.js"))
     val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, file)
+            }
 
-      val expectedOutput = JsObject("payload" -> JsString("test"))
-      val run = wsk.action.invoke(name, parameterFile = argInput)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.result shouldBe Some(expectedOutput)
-      }
+            val expectedOutput = JsObject("payload" -> JsString("test"))
+            val run = wsk.action.invoke(name, parameterFile = argInput)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.result shouldBe Some(expectedOutput)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create an action, and get its individual fields" in withAssetCleaner(wskprops) {
+  testname = "create an action, and get its individual fields"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val runtime = "nodejs:default"
     val name = "actionFields"
     val paramInput = Map("payload" -> "test".toJson)
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, defaultAction, parameters = paramInput, kind = Some(runtime))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, defaultAction, parameters = paramInput, kind = Some(runtime))
+            }
 
-      val expectedParam = JsObject("payload" -> JsString("test"))
-      val ns = wsk.namespace.whois()
-      val result = wsk.action.get(name)
-      result.getField("name") shouldBe name
-      result.getField("namespace") shouldBe ns
-      result.getFieldJsValue("publish") shouldBe JsFalse
-      result.getField("version") shouldBe "0.0.1"
-      val exec = result.getFieldJsObject("exec")
-      RestResult.getField(exec, "kind") should startWith("nodejs:")
-      RestResult.getField(exec, "code") should not be ""
-      result.getFieldJsValue("parameters") shouldBe JsArray(
-        JsObject("key" -> JsString("payload"), "value" -> JsString("test")))
+            val expectedParam = JsObject("payload" -> JsString("test"))
+            val ns = wsk.namespace.whois()
+            val result = wsk.action.get(name)
+            result.getField("name") shouldBe name
+            result.getField("namespace") shouldBe ns
+            result.getFieldJsValue("publish") shouldBe JsFalse
+            result.getField("version") shouldBe "0.0.1"
+            val exec = result.getFieldJsObject("exec")
+            RestResult.getField(exec, "kind") should startWith("nodejs:")
+            RestResult.getField(exec, "code") should not be ""
+            result.getFieldJsValue("parameters") shouldBe JsArray(
+              JsObject("key" -> JsString("payload"), "value" -> JsString("test")))
 
-      // first we check the returned execution runtime for 'nodejs:*'
-      result
-        .getFieldJsValue("annotations")
-        .convertTo[Seq[JsObject]]
-        .find(_.fields("key").convertTo[String] == "exec")
-        .map(_.fields("value"))
-        .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
-        .getOrElse(fail())
+            // first we check the returned execution runtime for 'nodejs:*'
+            result
+              .getFieldJsValue("annotations")
+              .convertTo[Seq[JsObject]]
+              .find(_.fields("key").convertTo[String] == "exec")
+              .map(_.fields("value"))
+              .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
+              .getOrElse(fail())
 
-      // since we checked it, we can remove the exec field from the annotations to make the following checks easier
-      result
-        .getFieldJsValue("annotations")
-        .convertTo[Seq[JsObject]]
-        .filter(annotation => annotation.fields("key").convertTo[String] != "exec")
-        .toJson shouldBe (if (requireAPIKeyAnnotation) {
-                            JsArray(
-                              JsObject("key" -> Annotations.ProvideApiKeyAnnotationName.toJson, "value" -> JsFalse))
-                          } else {
-                            JsArray()
-                          })
-      result.getFieldJsValue("limits") shouldBe JsObject(
-        "timeout" -> JsNumber(60000),
-        "memory" -> JsNumber(256),
-        "logs" -> JsNumber(10),
-        "concurrency" -> JsNumber(1))
-      result.getField("invalid") shouldBe ""
+            // since we checked it, we can remove the exec field from the annotations to make the following checks easier
+            result
+              .getFieldJsValue("annotations")
+              .convertTo[Seq[JsObject]]
+              .filter(annotation => annotation.fields("key").convertTo[String] != "exec")
+              .toJson shouldBe (if (requireAPIKeyAnnotation) {
+                                  JsArray(
+                                    JsObject(
+                                      "key" -> Annotations.ProvideApiKeyAnnotationName.toJson,
+                                      "value" -> JsFalse))
+                                } else {
+                                  JsArray()
+                                })
+            result.getFieldJsValue("limits") shouldBe JsObject(
+              "timeout" -> JsNumber(60000),
+              "memory" -> JsNumber(256),
+              "logs" -> JsNumber(10),
+              "concurrency" -> JsNumber(1))
+            result.getField("invalid") shouldBe ""
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
   /**
@@ -423,742 +608,1058 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
    * surely when it runs there should be some indication in the logs. Don't
    * think this is true currently.
    */
-  it should "create and invoke action with malformed js resulting in activation error" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "MALFORMED"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("malformed.js")))
-      }
+  testname = "create and invoke action with malformed js resulting in activation error"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "MALFORMED"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("malformed.js")))
+          }
 
-      val run = wsk.action.invoke(name, Map("payload" -> "whatever".toJson))
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.status shouldBe "action developer error"
-        // representing nodejs giving an error when given malformed.js
-        activation.response.result.get.toString should include("ReferenceError")
-      }
+          val run = wsk.action.invoke(name, Map("payload" -> "whatever".toJson))
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.status shouldBe "action developer error"
+            // representing nodejs giving an error when given malformed.js
+            activation.response.result.get.toString should include("ReferenceError")
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create and invoke a blocking action resulting in an application error response" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
-    val name = "applicationError"
-    val strErrInput = Map("error" -> "Error message".toJson)
-    val numErrInput = Map("error" -> 502.toJson)
-    val boolErrInput = Map("error" -> true.toJson)
+  testname = "create and invoke a blocking action resulting in an application error response"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "applicationError"
+          val strErrInput = Map("error" -> "Error message".toJson)
+          val numErrInput = Map("error" -> 502.toJson)
+          val boolErrInput = Map("error" -> true.toJson)
 
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
-    }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("echo.js")))
+          }
 
-    Seq(strErrInput, numErrInput, boolErrInput) foreach { input =>
-      val result = wsk.action.invoke(name, parameters = input, blocking = true, expectedExitCode = BadGateway.intValue)
-      val response = result.getFieldJsObject("response")
-      val res = RestResult.getFieldJsObject(response, "result")
-      res shouldBe input.toJson.asJsObject
-      val resultTrue =
-        wsk.action.invoke(
-          name,
-          parameters = input,
-          blocking = true,
-          result = true,
-          expectedExitCode = BadGateway.intValue)
-      resultTrue.respData shouldBe input.toJson.asJsObject.toString()
-    }
+          Seq(strErrInput, numErrInput, boolErrInput) foreach {
+            input =>
+              val result =
+                wsk.action.invoke(name, parameters = input, blocking = true, expectedExitCode = BadGateway.intValue)
+              val response = result.getFieldJsObject("response")
+              val res = RestResult.getFieldJsObject(response, "result")
+              res shouldBe input.toJson.asJsObject
+              val resultTrue =
+                wsk.action.invoke(
+                  name,
+                  parameters = input,
+                  blocking = true,
+                  result = true,
+                  expectedExitCode = BadGateway.intValue)
+              resultTrue.respData shouldBe input.toJson.asJsObject.toString()
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create and invoke a blocking action resulting in an failed promise" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "errorResponseObject"
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
-      }
+  testname = "create and invoke a blocking action resulting in an failed promise"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "errorResponseObject"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
+          }
 
-      val result = wsk.action.invoke(name, blocking = true, expectedExitCode = BadGateway.intValue)
-      val response = result.getFieldJsObject("response")
-      val res = RestResult.getFieldJsObject(response, "result")
-      res shouldBe JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
+          val result = wsk.action.invoke(name, blocking = true, expectedExitCode = BadGateway.intValue)
+          val response = result.getFieldJsObject("response")
+          val res = RestResult.getFieldJsObject(response, "result")
+          res shouldBe JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "invoke a blocking action and get only the result" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "basicInvoke"
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
-    }
+  testname = "invoke a blocking action and get only the result"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "basicInvoke"
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
+          }
 
-    val result = wsk.action
-      .invoke(name, Map("payload" -> "one two three".toJson), blocking = true, result = true)
-    result.stdout.parseJson.asJsObject shouldBe JsObject("count" -> JsNumber(3))
+          val result = wsk.action
+            .invoke(name, Map("payload" -> "one two three".toJson), blocking = true, result = true)
+          result.stdout.parseJson.asJsObject shouldBe JsObject("count" -> JsNumber(3))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get an action summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val runtime = "nodejs:default"
-    val name = "actionName"
-    val annots = Map(
-      "description" -> JsString("Action description"),
-      "parameters" -> JsArray(
-        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+  testname = "create, and get an action summary"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val runtime = "nodejs:default"
+          val name = "actionName"
+          val annots = Map(
+            "description" -> JsString("Action description"),
+            "parameters" -> JsArray(
+              JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+              JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
 
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, defaultAction, annotations = annots, kind = Some(runtime))
-    }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, defaultAction, annotations = annots, kind = Some(runtime))
+          }
 
-    val result = wsk.action.get(name, summary = true)
-    val ns = wsk.namespace.whois()
+          val result = wsk.action.get(name, summary = true)
+          val ns = wsk.namespace.whois()
 
-    result.getField("name") shouldBe name
-    result.getField("namespace") shouldBe ns
+          result.getField("name") shouldBe name
+          result.getField("namespace") shouldBe ns
 
-    val annos = result.getFieldJsValue("annotations")
+          val annos = result.getFieldJsValue("annotations")
 
-    // first we check the returned execution runtime for 'nodejs:*'
-    annos
-      .convertTo[Seq[JsObject]]
-      .find(_.fields("key").convertTo[String] == "exec")
-      .map(_.fields("value"))
-      .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
-      .getOrElse(fail())
+          // first we check the returned execution runtime for 'nodejs:*'
+          annos
+            .convertTo[Seq[JsObject]]
+            .find(_.fields("key").convertTo[String] == "exec")
+            .map(_.fields("value"))
+            .map(exec => { exec.convertTo[String] should startWith("nodejs:") })
+            .getOrElse(fail())
 
-    // since we checked it, we can remove the exec field from the annotations to make the following checks easier
-    val annosWithoutExec =
-      annos.convertTo[Seq[JsObject]].filter(annotation => annotation.fields("key").convertTo[String] != "exec").toJson
+          // since we checked it, we can remove the exec field from the annotations to make the following checks easier
+          val annosWithoutExec =
+            annos
+              .convertTo[Seq[JsObject]]
+              .filter(annotation => annotation.fields("key").convertTo[String] != "exec")
+              .toJson
 
-    annosWithoutExec shouldBe (if (requireAPIKeyAnnotation) {
-                                 JsArray(
-                                   JsObject(
-                                     "key" -> JsString("description"),
-                                     "value" -> JsString("Action description")),
-                                   JsObject(
-                                     "key" -> JsString("parameters"),
-                                     "value" -> JsArray(
-                                       JsObject(
-                                         "name" -> JsString("paramName1"),
-                                         "description" -> JsString("Parameter description 1")),
-                                       JsObject(
-                                         "name" -> JsString("paramName2"),
-                                         "description" -> JsString("Parameter description 2")))),
-                                   JsObject(
-                                     "key" -> Annotations.ProvideApiKeyAnnotationName.toJson,
-                                     "value" -> JsFalse))
-                               } else {
-                                 JsArray(
-                                   JsObject(
-                                     "key" -> JsString("description"),
-                                     "value" -> JsString("Action description")),
-                                   JsObject(
-                                     "key" -> JsString("parameters"),
-                                     "value" -> JsArray(
-                                       JsObject(
-                                         "name" -> JsString("paramName1"),
-                                         "description" -> JsString("Parameter description 1")),
-                                       JsObject(
-                                         "name" -> JsString("paramName2"),
-                                         "description" -> JsString("Parameter description 2")))))
-                               })
+          annosWithoutExec shouldBe (if (requireAPIKeyAnnotation) {
+                                       JsArray(
+                                         JsObject(
+                                           "key" -> JsString("description"),
+                                           "value" -> JsString("Action description")),
+                                         JsObject(
+                                           "key" -> JsString("parameters"),
+                                           "value" -> JsArray(
+                                             JsObject(
+                                               "name" -> JsString("paramName1"),
+                                               "description" -> JsString("Parameter description 1")),
+                                             JsObject(
+                                               "name" -> JsString("paramName2"),
+                                               "description" -> JsString("Parameter description 2")))),
+                                         JsObject(
+                                           "key" -> Annotations.ProvideApiKeyAnnotationName.toJson,
+                                           "value" -> JsFalse))
+                                     } else {
+                                       JsArray(
+                                         JsObject(
+                                           "key" -> JsString("description"),
+                                           "value" -> JsString("Action description")),
+                                         JsObject(
+                                           "key" -> JsString("parameters"),
+                                           "value" -> JsArray(
+                                             JsObject(
+                                               "name" -> JsString("paramName1"),
+                                               "description" -> JsString("Parameter description 1")),
+                                             JsObject(
+                                               "name" -> JsString("paramName2"),
+                                               "description" -> JsString("Parameter description 2")))))
+                                     })
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create an action with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "action with spaces"
+  testname = "create an action with a name that contains spaces"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "action with spaces"
 
-    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, defaultAction)
-    }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, defaultAction)
+          }
 
-    wsk.action.get(name).getField("name") shouldBe name
+          wsk.action.get(name).getField("name") shouldBe name
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create an action, and invoke an action that returns an empty JSON object" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val name = "emptyJSONAction"
+  testname = "create an action, and invoke an action that returns an empty JSON object"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "emptyJSONAction"
 
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
-      }
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action.create(name, Some(TestUtils.getTestActionFilename("emptyJSONResult.js")))
+          }
 
-      val result = wsk.action.invoke(name, blocking = true, result = true)
-      result.stdout.parseJson.asJsObject shouldBe JsObject.empty
+          val result = wsk.action.invoke(name, blocking = true, result = true)
+          result.stdout.parseJson.asJsObject shouldBe JsObject.empty
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and invoke an action that times out to ensure the proper response is received" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
-    val name = "sleepAction-" + System.currentTimeMillis()
-    // Must be larger than 60 seconds to see the expected exit code
-    val allowedActionDuration = 120.seconds
-    // Sleep time must be larger than 60 seconds to see the expected exit code
-    // Set sleep time to a value smaller than allowedActionDuration to not raise a timeout
-    val sleepTime = allowedActionDuration - 20.seconds
-    val params = Map("sleepTimeInMs" -> sleepTime.toMillis.toJson)
-    val res = assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-      action.create(name, Some(TestUtils.getTestActionFilename("sleep.js")), timeout = Some(allowedActionDuration))
-      action.invoke(name, parameters = params, result = true, expectedExitCode = Accepted.intValue)
-    }
+  testname = "create, and invoke an action that times out to ensure the proper response is received"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "sleepAction-" + System.currentTimeMillis()
+          // Must be larger than 60 seconds to see the expected exit code
+          val allowedActionDuration = 120.seconds
+          // Sleep time must be larger than 60 seconds to see the expected exit code
+          // Set sleep time to a value smaller than allowedActionDuration to not raise a timeout
+          val sleepTime = allowedActionDuration - 20.seconds
+          val params = Map("sleepTimeInMs" -> sleepTime.toMillis.toJson)
+          val res = assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            action
+              .create(name, Some(TestUtils.getTestActionFilename("sleep.js")), timeout = Some(allowedActionDuration))
+            action.invoke(name, parameters = params, result = true, expectedExitCode = Accepted.intValue)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get docker action get ensure exec code is omitted" in withAssetCleaner(wskprops) {
+  testname = "create, and get docker action get ensure exec code is omitted"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "dockerContainer"
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, None, docker = Some("fake-container"))
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+              action.create(name, None, docker = Some("fake-container"))
+            }
 
-      wsk.action.get(name).stdout should not include """"code""""
+            wsk.action.get(name).stdout should not include """"code""""
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Trigger REST"
+  behaviorname = "Wsk Trigger REST"
+  behavior of s"$behaviorname"
 
-  it should "create, update, get, fire and list trigger" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val ruleName = withTimestamp("r1toa1")
-    val triggerName = withTimestamp("t1tor1")
-    val actionName = withTimestamp("a1")
-    val params = Map("a" -> "A".toJson)
-    val ns = wsk.namespace.whois()
+  testname = "create, update, get, fire and list trigger"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName = withTimestamp("r1toa1")
+          val triggerName = withTimestamp("t1tor1")
+          val actionName = withTimestamp("a1")
+          val params = Map("a" -> "A".toJson)
+          val ns = wsk.namespace.whois()
 
-    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-      trigger.create(triggerName, parameters = params)
-      trigger.create(triggerName, update = true)
-    }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+            trigger.create(triggerName, parameters = params)
+            trigger.create(triggerName, update = true)
+          }
 
-    assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-      action.create(name, defaultAction)
-    }
+          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+            action.create(name, defaultAction)
+          }
 
-    assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-      rule.create(name, trigger = triggerName, action = actionName)
-    }
+          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName)
+          }
 
-    // Add retry to ensure cache with "0.0.1" is replaced
-    val trigger = cacheRetry({
-      val t = wsk.trigger.get(triggerName)
-      t.getField("version") shouldBe "0.0.2"
-      t
-    })
-    trigger.getFieldJsValue("parameters") shouldBe JsArray(JsObject("key" -> JsString("a"), "value" -> JsString("A")))
-    trigger.getFieldJsValue("publish") shouldBe JsFalse
+          // Add retry to ensure cache with "0.0.1" is replaced
+          val trigger = cacheRetry({
+            val t = wsk.trigger.get(triggerName)
+            t.getField("version") shouldBe "0.0.2"
+            t
+          })
+          trigger.getFieldJsValue("parameters") shouldBe JsArray(
+            JsObject("key" -> JsString("a"), "value" -> JsString("A")))
+          trigger.getFieldJsValue("publish") shouldBe JsFalse
 
-    val expectedRules = JsObject(
-      ns + "/" + ruleName -> JsObject(
-        "action" -> JsObject("name" -> JsString(actionName), "path" -> JsString(ns)),
-        "status" -> JsString("active")))
-    trigger.getFieldJsValue("rules") shouldBe expectedRules
+          val expectedRules = JsObject(
+            ns + "/" + ruleName -> JsObject(
+              "action" -> JsObject("name" -> JsString(actionName), "path" -> JsString(ns)),
+              "status" -> JsString("active")))
+          trigger.getFieldJsValue("rules") shouldBe expectedRules
 
-    val dynamicParams = Map("t" -> "T".toJson)
-    val run = wsk.trigger.fire(triggerName, dynamicParams)
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.result shouldBe Some(dynamicParams.toJson)
-      activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-      activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-      activation.logs shouldBe defined
-      activation.logs.get.size shouldBe 1
+          val dynamicParams = Map("t" -> "T".toJson)
+          val run = wsk.trigger.fire(triggerName, dynamicParams)
+          withActivation(wsk.activation, run) {
+            activation =>
+              activation.response.result shouldBe Some(dynamicParams.toJson)
+              activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+              activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
+              activation.logs shouldBe defined
+              activation.logs.get.size shouldBe 1
 
-      val logEntry = activation.logs.get(0).parseJson.asJsObject
-      val logs = JsArray(logEntry)
-      val ruleActivationId: String = logEntry.getFields("activationId")(0).convertTo[String]
-      val expectedLogs = JsArray(
-        JsObject(
-          "statusCode" -> JsNumber(0),
-          "activationId" -> JsString(ruleActivationId),
-          "success" -> JsTrue,
-          "rule" -> JsString(ns + "/" + ruleName),
-          "action" -> JsString(ns + "/" + actionName)))
-      logs shouldBe expectedLogs
-    }
+              val logEntry = activation.logs.get(0).parseJson.asJsObject
+              val logs = JsArray(logEntry)
+              val ruleActivationId: String = logEntry.getFields("activationId")(0).convertTo[String]
+              val expectedLogs = JsArray(
+                JsObject(
+                  "statusCode" -> JsNumber(0),
+                  "activationId" -> JsString(ruleActivationId),
+                  "success" -> JsTrue,
+                  "rule" -> JsString(ns + "/" + ruleName),
+                  "action" -> JsString(ns + "/" + actionName)))
+              logs shouldBe expectedLogs
+          }
 
-    val runWithNoParams = wsk.trigger.fire(triggerName, Map.empty)
-    withActivation(wsk.activation, runWithNoParams) { activation =>
-      activation.response.result shouldBe Some(JsObject.empty)
-      activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-      activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-    }
+          val runWithNoParams = wsk.trigger.fire(triggerName, Map.empty)
+          withActivation(wsk.activation, runWithNoParams) { activation =>
+            activation.response.result shouldBe Some(JsObject.empty)
+            activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+            activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
+          }
 
-    val triggerList = wsk.trigger.list()
-    val triggers = triggerList.getBodyListJsObject
-    triggers.exists(trigger => RestResult.getField(trigger, "name") == triggerName) shouldBe true
+          val triggerList = wsk.trigger.list()
+          val triggers = triggerList.getBodyListJsObject
+          triggers.exists(trigger => RestResult.getField(trigger, "name") == triggerName) shouldBe true
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and get a trigger summary" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "triggerName"
-    val annots = Map(
-      "description" -> JsString("Trigger description"),
-      "parameters" -> JsArray(
-        JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-        JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
+  testname = "create, and get a trigger summary"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "triggerName"
+          val annots = Map(
+            "description" -> JsString("Trigger description"),
+            "parameters" -> JsArray(
+              JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+              JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2"))))
 
-    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-      trigger.create(name, annotations = annots)
-    }
+          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+            trigger.create(name, annotations = annots)
+          }
 
-    val result = wsk.trigger.get(name)
-    val ns = wsk.namespace.whois()
+          val result = wsk.trigger.get(name)
+          val ns = wsk.namespace.whois()
 
-    result.getField("name") shouldBe name
-    result.getField("namespace") shouldBe ns
-    val annos = result.getFieldJsValue("annotations")
-    annos shouldBe JsArray(
-      JsObject("key" -> JsString("description"), "value" -> JsString("Trigger description")),
-      JsObject(
-        "key" -> JsString("parameters"),
-        "value" -> JsArray(
-          JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
-          JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2")))))
+          result.getField("name") shouldBe name
+          result.getField("namespace") shouldBe ns
+          val annos = result.getFieldJsValue("annotations")
+          annos shouldBe JsArray(
+            JsObject("key" -> JsString("description"), "value" -> JsString("Trigger description")),
+            JsObject(
+              "key" -> JsString("parameters"),
+              "value" -> JsArray(
+                JsObject("name" -> JsString("paramName1"), "description" -> JsString("Parameter description 1")),
+                JsObject("name" -> JsString("paramName2"), "description" -> JsString("Parameter description 2")))))
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create a trigger with a name that contains spaces" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val name = "trigger with spaces"
+  testname = "create a trigger with a name that contains spaces"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val name = "trigger with spaces"
 
-    assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-      trigger.create(name)
-    }
+          assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+            trigger.create(name)
+          }
 
-    val res = wsk.trigger.get(name)
-    res.getField("name") shouldBe name
+          val res = wsk.trigger.get(name)
+          res.getField("name") shouldBe name
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and fire a trigger using a parameter file" in withAssetCleaner(wskprops) {
+  testname = "create, and fire a trigger using a parameter file"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val ruleName = withTimestamp("r1toa1")
     val triggerName = withTimestamp("paramFileTrigger")
     val actionName = withTimestamp("a1")
     val argInput = Some(TestUtils.getTestActionFilename("validInput2.json"))
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-        trigger.create(triggerName)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+              trigger.create(triggerName)
+            }
 
-      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-        action.create(name, defaultAction)
-      }
+            assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+              action.create(name, defaultAction)
+            }
 
-      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName)
-      }
+            assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName)
+            }
 
-      val expectedOutput = JsObject("payload" -> JsString("test"))
-      val run = wsk.trigger.fire(triggerName, parameterFile = argInput)
-      withActivation(wsk.activation, run) { activation =>
-        activation.response.result shouldBe Some(expectedOutput)
-      }
+            val expectedOutput = JsObject("payload" -> JsString("test"))
+            val run = wsk.trigger.fire(triggerName, parameterFile = argInput)
+            withActivation(wsk.activation, run) { activation =>
+              activation.response.result shouldBe Some(expectedOutput)
+            }
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create a trigger, and get its individual fields" in withAssetCleaner(wskprops) {
+  testname = "create a trigger, and get its individual fields"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "triggerFields"
     val paramInput = Map("payload" -> "test".toJson)
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-        trigger.create(name, parameters = paramInput)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+              trigger.create(name, parameters = paramInput)
+            }
 
-      val expectedParam = JsObject("payload" -> JsString("test"))
-      val ns = wsk.namespace.whois()
+            val expectedParam = JsObject("payload" -> JsString("test"))
+            val ns = wsk.namespace.whois()
 
-      val result = wsk.trigger
-        .get(name, fieldFilter = Some("namespace"))
-      result.getField("namespace") shouldBe ns
-      result.getField("name") shouldBe name
-      result.getField("version") shouldBe "0.0.1"
-      result.getFieldJsValue("publish") shouldBe JsFalse
-      result.getFieldJsValue("annotations").toString shouldBe "[]"
-      result.getFieldJsValue("parameters") shouldBe JsArray(
-        JsObject("key" -> JsString("payload"), "value" -> JsString("test")))
-      result.getFieldJsValue("limits") shouldBe JsObject.empty
-      result.getField("invalid") shouldBe ""
+            val result = wsk.trigger
+              .get(name, fieldFilter = Some("namespace"))
+            result.getField("namespace") shouldBe ns
+            result.getField("name") shouldBe name
+            result.getField("version") shouldBe "0.0.1"
+            result.getFieldJsValue("publish") shouldBe JsFalse
+            result.getFieldJsValue("annotations").toString shouldBe "[]"
+            result.getFieldJsValue("parameters") shouldBe JsArray(
+              JsObject("key" -> JsString("payload"), "value" -> JsString("test")))
+            result.getFieldJsValue("limits") shouldBe JsObject.empty
+            result.getField("invalid") shouldBe ""
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create, and fire a trigger to ensure result is empty" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val ruleName = withTimestamp("r1toa1")
-    val triggerName = withTimestamp("emptyResultTrigger")
-    val actionName = withTimestamp("a1")
+  testname = "create, and fire a trigger to ensure result is empty"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName = withTimestamp("r1toa1")
+          val triggerName = withTimestamp("emptyResultTrigger")
+          val actionName = withTimestamp("a1")
 
-    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-      trigger.create(triggerName)
-    }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+            trigger.create(triggerName)
+          }
 
-    assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-      action.create(name, defaultAction)
-    }
+          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+            action.create(name, defaultAction)
+          }
 
-    assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-      rule.create(name, trigger = triggerName, action = actionName)
-    }
+          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName)
+          }
 
-    val run = wsk.trigger.fire(triggerName)
-    withActivation(wsk.activation, run) { activation =>
-      activation.response.result shouldBe Some(JsObject.empty)
-    }
+          val run = wsk.trigger.fire(triggerName)
+          withActivation(wsk.activation, run) { activation =>
+            activation.response.result shouldBe Some(JsObject.empty)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject creation of duplicate triggers" in withAssetCleaner(wskprops) {
+  testname = "reject creation of duplicate triggers"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val name = "dupeTrigger"
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
-        trigger.create(name)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.trigger, name) { (trigger, _) =>
+              trigger.create(name)
+            }
 
-      val stderr = wsk.trigger.create(name, expectedExitCode = Conflict.intValue).stderr
-      stderr should include("resource already exists")
+            val stderr = wsk.trigger.create(name, expectedExitCode = Conflict.intValue).stderr
+            stderr should include("resource already exists")
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject delete of trigger that does not exist" in {
-    val name = "nonexistentTrigger"
-    val stderr = wsk.trigger.delete(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject delete of trigger that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentTrigger"
+          val stderr = wsk.trigger.delete(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject get of trigger that does not exist" in {
-    val name = "nonexistentTrigger"
-    val stderr = wsk.trigger.get(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject get of trigger that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentTrigger"
+          val stderr = wsk.trigger.get(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject firing of a trigger that does not exist" in {
-    val name = "nonexistentTrigger"
-    val stderr = wsk.trigger.fire(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject firing of a trigger that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentTrigger"
+          val stderr = wsk.trigger.fire(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create and fire a trigger with a rule whose action has been deleted" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val ruleName1 = withTimestamp("r1toa1")
-      val ruleName2 = withTimestamp("r2toa2")
-      val triggerName = withTimestamp("t1tor1r2")
-      val actionName1 = withTimestamp("a1")
-      val actionName2 = withTimestamp("a2")
-      val ns = wsk.namespace.whois()
+  testname = "create and fire a trigger with a rule whose action has been deleted"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName1 = withTimestamp("r1toa1")
+          val ruleName2 = withTimestamp("r2toa2")
+          val triggerName = withTimestamp("t1tor1r2")
+          val actionName1 = withTimestamp("a1")
+          val actionName2 = withTimestamp("a2")
+          val ns = wsk.namespace.whois()
 
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-        trigger.create(triggerName)
-        trigger.create(triggerName, update = true)
-      }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+            trigger.create(triggerName)
+            trigger.create(triggerName, update = true)
+          }
 
-      assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
-        action.create(name, defaultAction)
-      }
-      wsk.action.create(actionName2, defaultAction) // Delete this after the rule is created
+          assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
+            action.create(name, defaultAction)
+          }
+          wsk.action.create(actionName2, defaultAction) // Delete this after the rule is created
 
-      assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName1)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName2)
-      }
-      wsk.action.delete(actionName2)
+          assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName1)
+          }
+          assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName2)
+          }
+          wsk.action.delete(actionName2)
 
-      val run = wsk.trigger.fire(triggerName)
-      withActivation(wsk.activation, run) { activation =>
-        activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-        activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-        activation.logs shouldBe defined
-        activation.logs.get.size shouldBe 2
+          val run = wsk.trigger.fire(triggerName)
+          withActivation(wsk.activation, run) {
+            activation =>
+              activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+              activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
+              activation.logs shouldBe defined
+              activation.logs.get.size shouldBe 2
 
-        val logEntry1 = activation.logs.get(0).parseJson.asJsObject
-        val logEntry2 = activation.logs.get(1).parseJson.asJsObject
-        val logs = JsArray(logEntry1, logEntry2)
-        val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
-          logEntry1.getFields("activationId")(0).convertTo[String]
-        } else {
-          logEntry2.getFields("activationId")(0).convertTo[String]
-        }
-        val expectedLogs = JsArray(
-          JsObject(
-            "statusCode" -> JsNumber(0),
-            "activationId" -> JsString(ruleActivationId),
-            "success" -> JsTrue,
-            "rule" -> JsString(ns + "/" + ruleName1),
-            "action" -> JsString(ns + "/" + actionName1)),
-          JsObject(
-            "statusCode" -> JsNumber(1),
-            "success" -> JsFalse,
-            "error" -> JsString("The requested resource does not exist."),
-            "rule" -> JsString(ns + "/" + ruleName2),
-            "action" -> JsString(ns + "/" + actionName2)))
-        logs shouldBe expectedLogs
-      }
+              val logEntry1 = activation.logs.get(0).parseJson.asJsObject
+              val logEntry2 = activation.logs.get(1).parseJson.asJsObject
+              val logs = JsArray(logEntry1, logEntry2)
+              val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
+                logEntry1.getFields("activationId")(0).convertTo[String]
+              } else {
+                logEntry2.getFields("activationId")(0).convertTo[String]
+              }
+              val expectedLogs = JsArray(
+                JsObject(
+                  "statusCode" -> JsNumber(0),
+                  "activationId" -> JsString(ruleActivationId),
+                  "success" -> JsTrue,
+                  "rule" -> JsString(ns + "/" + ruleName1),
+                  "action" -> JsString(ns + "/" + actionName1)),
+                JsObject(
+                  "statusCode" -> JsNumber(1),
+                  "success" -> JsFalse,
+                  "error" -> JsString("The requested resource does not exist."),
+                  "rule" -> JsString(ns + "/" + ruleName2),
+                  "action" -> JsString(ns + "/" + actionName2)))
+              logs shouldBe expectedLogs
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create and fire a trigger having an active rule and an inactive rule" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val ruleName1 = withTimestamp("r1toa1")
-      val ruleName2 = withTimestamp("r2toa2")
-      val triggerName = withTimestamp("t1tor1r2")
-      val actionName1 = withTimestamp("a1")
-      val actionName2 = withTimestamp("a2")
-      val ns = wsk.namespace.whois()
+  testname = "create and fire a trigger having an active rule and an inactive rule"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName1 = withTimestamp("r1toa1")
+          val ruleName2 = withTimestamp("r2toa2")
+          val triggerName = withTimestamp("t1tor1r2")
+          val actionName1 = withTimestamp("a1")
+          val actionName2 = withTimestamp("a2")
+          val ns = wsk.namespace.whois()
 
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-        trigger.create(triggerName)
-        trigger.create(triggerName, update = true)
-      }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+            trigger.create(triggerName)
+            trigger.create(triggerName, update = true)
+          }
 
-      assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
-        action.create(name, defaultAction)
-      }
-      assetHelper.withCleaner(wsk.action, actionName2) { (action, name) =>
-        action.create(name, defaultAction)
-      }
+          assetHelper.withCleaner(wsk.action, actionName1) { (action, name) =>
+            action.create(name, defaultAction)
+          }
+          assetHelper.withCleaner(wsk.action, actionName2) { (action, name) =>
+            action.create(name, defaultAction)
+          }
 
-      assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName1)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName2)
-        rule.disable(ruleName2)
-      }
+          assetHelper.withCleaner(wsk.rule, ruleName1) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName1)
+          }
+          assetHelper.withCleaner(wsk.rule, ruleName2) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName2)
+            rule.disable(ruleName2)
+          }
 
-      val run = wsk.trigger.fire(triggerName)
-      withActivation(wsk.activation, run) { activation =>
-        activation.duration shouldBe 0L // shouldn't exist but CLI generates it
-        activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
-        activation.logs shouldBe defined
-        activation.logs.get.size shouldBe 2
+          val run = wsk.trigger.fire(triggerName)
+          withActivation(wsk.activation, run) {
+            activation =>
+              activation.duration shouldBe 0L // shouldn't exist but CLI generates it
+              activation.end shouldBe Instant.EPOCH // shouldn't exist but CLI generates it
+              activation.logs shouldBe defined
+              activation.logs.get.size shouldBe 2
 
-        val logEntry1 = activation.logs.get(0).parseJson.asJsObject
-        val logEntry2 = activation.logs.get(1).parseJson.asJsObject
-        val logs = JsArray(logEntry1, logEntry2)
-        val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
-          logEntry1.getFields("activationId")(0).convertTo[String]
-        } else {
-          logEntry2.getFields("activationId")(0).convertTo[String]
-        }
-        val expectedLogs = JsArray(
-          JsObject(
-            "statusCode" -> JsNumber(0),
-            "activationId" -> JsString(ruleActivationId),
-            "success" -> JsTrue,
-            "rule" -> JsString(ns + "/" + ruleName1),
-            "action" -> JsString(ns + "/" + actionName1)),
-          JsObject(
-            "statusCode" -> JsNumber(1),
-            "success" -> JsFalse,
-            "error" -> JsString(Messages.triggerWithInactiveRule(s"$ns/$ruleName2", s"$ns/$actionName2")),
-            "rule" -> JsString(ns + "/" + ruleName2),
-            "action" -> JsString(ns + "/" + actionName2)))
-        logs shouldBe expectedLogs
-      }
+              val logEntry1 = activation.logs.get(0).parseJson.asJsObject
+              val logEntry2 = activation.logs.get(1).parseJson.asJsObject
+              val logs = JsArray(logEntry1, logEntry2)
+              val ruleActivationId: String = if (logEntry1.getFields("activationId").size == 1) {
+                logEntry1.getFields("activationId")(0).convertTo[String]
+              } else {
+                logEntry2.getFields("activationId")(0).convertTo[String]
+              }
+              val expectedLogs = JsArray(
+                JsObject(
+                  "statusCode" -> JsNumber(0),
+                  "activationId" -> JsString(ruleActivationId),
+                  "success" -> JsTrue,
+                  "rule" -> JsString(ns + "/" + ruleName1),
+                  "action" -> JsString(ns + "/" + actionName1)),
+                JsObject(
+                  "statusCode" -> JsNumber(1),
+                  "success" -> JsFalse,
+                  "error" -> JsString(Messages.triggerWithInactiveRule(s"$ns/$ruleName2", s"$ns/$actionName2")),
+                  "rule" -> JsString(ns + "/" + ruleName2),
+                  "action" -> JsString(ns + "/" + actionName2)))
+              logs shouldBe expectedLogs
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Rule REST"
+  behaviorname = "Wsk Rule REST"
+  behavior of s"$behaviorname"
 
-  it should "create rule, get rule, update rule and list rule" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
-    val ruleName = "listRules"
-    val triggerName = "listRulesTrigger"
-    val actionName = "listRulesAction"
+  testname = "create rule, get rule, update rule and list rule"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName = "listRules"
+          val triggerName = "listRulesTrigger"
+          val actionName = "listRulesAction"
 
-    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-      trigger.create(name)
-    }
-    assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-      action.create(name, defaultAction)
-    }
-    assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-      rule.create(name, trigger = triggerName, action = actionName)
-    }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+            trigger.create(name)
+          }
+          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+            action.create(name, defaultAction)
+          }
+          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName)
+          }
 
-    // finally, we perform the update, and expect success this time
-    wsk.rule.create(ruleName, trigger = triggerName, action = actionName, update = true)
+          // finally, we perform the update, and expect success this time
+          wsk.rule.create(ruleName, trigger = triggerName, action = actionName, update = true)
 
-    // Add retry to ensure cache with "0.0.1" is replaced
-    val rule = cacheRetry({
-      val r = wsk.rule.get(ruleName)
-      r.getField("version") shouldBe "0.0.2"
-      r
-    })
-    rule.getField("name") shouldBe ruleName
-    RestResult.getField(rule.getFieldJsObject("trigger"), "name") shouldBe triggerName
-    RestResult.getField(rule.getFieldJsObject("action"), "name") shouldBe actionName
-    val rules = wsk.rule.list().getBodyListJsObject
-    rules.exists { rule =>
-      RestResult.getField(rule, "name") == ruleName
-    } shouldBe true
+          // Add retry to ensure cache with "0.0.1" is replaced
+          val rule = cacheRetry({
+            val r = wsk.rule.get(ruleName)
+            r.getField("version") shouldBe "0.0.2"
+            r
+          })
+          rule.getField("name") shouldBe ruleName
+          RestResult.getField(rule.getFieldJsObject("trigger"), "name") shouldBe triggerName
+          RestResult.getField(rule.getFieldJsObject("action"), "name") shouldBe actionName
+          val rules = wsk.rule.list().getBodyListJsObject
+          rules.exists { rule =>
+            RestResult.getField(rule, "name") == ruleName
+          } shouldBe true
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create rule, get rule, ensure rule is enabled by default" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val ruleName = "enabledRule"
-      val triggerName = "enabledRuleTrigger"
-      val actionName = "enabledRuleAction"
+  testname = "create rule, get rule, ensure rule is enabled by default"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName = "enabledRule"
+          val triggerName = "enabledRuleTrigger"
+          val actionName = "enabledRuleAction"
 
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-        trigger.create(name)
-      }
-      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-        action.create(name, defaultAction)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName)
-      }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+            trigger.create(name)
+          }
+          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+            action.create(name, defaultAction)
+          }
+          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName)
+          }
 
-      val rule = wsk.rule.get(ruleName)
-      rule.getField("status") shouldBe "active"
+          val rule = wsk.rule.get(ruleName)
+          rule.getField("status") shouldBe "active"
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "display a rule summary when --summary flag is used with 'wsk rule get'" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val ruleName = "mySummaryRule"
-      val triggerName = "summaryRuleTrigger"
-      val actionName = "summaryRuleAction"
+  testname = "display a rule summary when --summary flag is used with 'wsk rule get"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName = "mySummaryRule"
+          val triggerName = "summaryRuleTrigger"
+          val actionName = "summaryRuleAction"
 
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-        trigger.create(name)
-      }
-      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-        action.create(name, defaultAction)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName)
-      }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+            trigger.create(name)
+          }
+          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+            action.create(name, defaultAction)
+          }
+          assetHelper.withCleaner(wsk.rule, ruleName, confirmDelete = false) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName)
+          }
 
-      // Summary namespace should match one of the allowable namespaces (typically 'guest')
-      val ns = wsk.namespace.whois()
-      val result = wsk.rule.get(ruleName)
-      result.getField("name") shouldBe ruleName
-      result.getField("namespace") shouldBe ns
-      result.getField("status") shouldBe "active"
+          // Summary namespace should match one of the allowable namespaces (typically 'guest')
+          val ns = wsk.namespace.whois()
+          val result = wsk.rule.get(ruleName)
+          result.getField("name") shouldBe ruleName
+          result.getField("namespace") shouldBe ns
+          result.getField("status") shouldBe "active"
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "create a rule, and get its individual fields" in withAssetCleaner(wskprops) {
+  testname = "create a rule, and get its individual fields"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val ruleName = "ruleFields"
     val triggerName = "ruleTriggerFields"
     val actionName = "ruleActionFields"
     val paramInput = Map("payload" -> "test".toJson)
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-        trigger.create(name)
-      }
-      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-        action.create(name, defaultAction)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+              trigger.create(name)
+            }
+            assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+              action.create(name, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName)
+            }
 
-      val ns = wsk.namespace.whois()
-      val rule = wsk.rule.get(ruleName)
-      rule.getField("namespace") shouldBe ns
-      rule.getField("name") shouldBe ruleName
-      rule.getField("version") shouldBe "0.0.1"
-      rule.getField("status") shouldBe "active"
-      val result = wsk.rule.get(ruleName)
-      val trigger = result.getFieldJsValue("trigger").toString
-      trigger should include(triggerName)
-      trigger should not include actionName
-      val action = result.getFieldJsValue("action").toString
-      action should not include triggerName
-      action should include(actionName)
+            val ns = wsk.namespace.whois()
+            val rule = wsk.rule.get(ruleName)
+            rule.getField("namespace") shouldBe ns
+            rule.getField("name") shouldBe ruleName
+            rule.getField("version") shouldBe "0.0.1"
+            rule.getField("status") shouldBe "active"
+            val result = wsk.rule.get(ruleName)
+            val trigger = result.getFieldJsValue("trigger").toString
+            trigger should include(triggerName)
+            trigger should not include actionName
+            val action = result.getFieldJsValue("action").toString
+            action should not include triggerName
+            action should include(actionName)
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject creation of duplicate rules" in withAssetCleaner(wskprops) {
+  testname = "reject creation of duplicate rules"
+  it should s"$testname" in withAssetCleaner(wskprops) {
     val ruleName = "dupeRule"
     val triggerName = "triggerName"
     val actionName = "actionName"
 
     (wp, assetHelper) =>
-      assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
-        trigger.create(name)
-      }
-      assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-        action.create(name, defaultAction)
-      }
-      assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-        rule.create(name, trigger = triggerName, action = actionName)
-      }
+      org.apache.openwhisk.utils
+        .retry(
+          {
+            assetHelper.deleteAssets()
+            assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, name) =>
+              trigger.create(name)
+            }
+            assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+              action.create(name, defaultAction)
+            }
+            assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+              rule.create(name, trigger = triggerName, action = actionName)
+            }
 
-      val stderr =
-        wsk.rule
-          .create(ruleName, trigger = triggerName, action = actionName, expectedExitCode = Conflict.intValue)
-          .stderr
-      stderr should include("resource already exists")
+            val stderr =
+              wsk.rule
+                .create(ruleName, trigger = triggerName, action = actionName, expectedExitCode = Conflict.intValue)
+                .stderr
+            stderr should include("resource already exists")
+          },
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
+          Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject delete of rule that does not exist" in {
-    val name = "nonexistentRule"
-    val stderr = wsk.rule.delete(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject delete of rule that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentRule"
+          val stderr = wsk.rule.delete(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject enable of rule that does not exist" in {
-    val name = "nonexistentRule"
-    val stderr = wsk.rule.enable(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject enable of rule that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentRule"
+          val stderr = wsk.rule.enable(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject disable of rule that does not exist" in {
-    val name = "nonexistentRule"
-    val stderr = wsk.rule.disable(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject disable of rule that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentRule"
+          val stderr = wsk.rule.disable(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject status of rule that does not exist" in {
-    val name = "nonexistentRule"
-    val stderr = wsk.rule.state(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject status of rule that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentRule"
+          val stderr = wsk.rule.state(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject get of rule that does not exist" in {
-    val name = "nonexistentRule"
-    val stderr = wsk.rule.get(name, expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject get of rule that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "nonexistentRule"
+          val stderr = wsk.rule.get(name, expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Namespace REST"
+  behaviorname = "Wsk Namespace REST"
+  behavior of s"$behaviorname"
 
-  it should "return a list of exactly one namespace" in {
-    val lines = wsk.namespace.list()
-    lines.getBodyListString.size shouldBe 1
+  testname = "return a list of exactly one namespace"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val lines = wsk.namespace.list()
+          lines.getBodyListString.size shouldBe 1
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  behavior of "Wsk Activation REST"
+  behaviorname = "Wsk Activation REST"
+  behavior of s"$behaviorname"
 
-  it should "create a trigger, and fire a trigger to get its individual fields from an activation" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
-    val ruleName = withTimestamp("r1toa1")
-    val triggerName = withTimestamp("activationFields")
-    val actionName = withTimestamp("a1")
+  testname = "create a trigger, and fire a trigger to get its individual fields from an activation"
+  it should s"$testname" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          assetHelper.deleteAssets()
+          val ruleName = withTimestamp("r1toa1")
+          val triggerName = withTimestamp("activationFields")
+          val actionName = withTimestamp("a1")
 
-    assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
-      trigger.create(triggerName)
-    }
+          assetHelper.withCleaner(wsk.trigger, triggerName) { (trigger, _) =>
+            trigger.create(triggerName)
+          }
 
-    assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
-      action.create(name, defaultAction)
-    }
+          assetHelper.withCleaner(wsk.action, actionName) { (action, name) =>
+            action.create(name, defaultAction)
+          }
 
-    assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
-      rule.create(name, trigger = triggerName, action = actionName)
-    }
+          assetHelper.withCleaner(wsk.rule, ruleName) { (rule, name) =>
+            rule.create(name, trigger = triggerName, action = actionName)
+          }
 
-    val ns = wsk.namespace.whois()
-    val run = wsk.trigger.fire(triggerName)
-    withActivation(wsk.activation, run) { activation =>
-      var result = wsk.activation.get(Some(activation.activationId))
-      result.getField("namespace") shouldBe ns
-      result.getField("name") shouldBe triggerName
-      result.getField("version") shouldBe "0.0.1"
-      result.getFieldJsValue("publish") shouldBe JsFalse
-      result.getField("subject") shouldBe ns
-      result.getField("activationId") shouldBe activation.activationId
-      result.getFieldJsValue("start").toString should not be JsObject.empty.toString
-      result.getFieldJsValue("end").toString shouldBe JsObject.empty.toString
-      result.getFieldJsValue("duration").toString shouldBe JsObject.empty.toString
-      result.getFieldListJsObject("annotations").length shouldBe 0
-    }
+          val ns = wsk.namespace.whois()
+          val run = wsk.trigger.fire(triggerName)
+          withActivation(wsk.activation, run) { activation =>
+            var result = wsk.activation.get(Some(activation.activationId))
+            result.getField("namespace") shouldBe ns
+            result.getField("name") shouldBe triggerName
+            result.getField("version") shouldBe "0.0.1"
+            result.getFieldJsValue("publish") shouldBe JsFalse
+            result.getField("subject") shouldBe ns
+            result.getField("activationId") shouldBe activation.activationId
+            result.getFieldJsValue("start").toString should not be JsObject.empty.toString
+            result.getFieldJsValue("end").toString shouldBe JsObject.empty.toString
+            result.getFieldJsValue("duration").toString shouldBe JsObject.empty.toString
+            result.getFieldListJsObject("annotations").length shouldBe 0
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject get of activation that does not exist" in {
-    val name = "0" * 32
-    val stderr = wsk.activation.get(Some(name), expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject get of activation that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "0" * 32
+          val stderr = wsk.activation.get(Some(name), expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject logs of activation that does not exist" in {
-    val name = "0" * 32
-    val stderr = wsk.activation.logs(Some(name), expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject logs of activation that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "0" * 32
+          val stderr = wsk.activation.logs(Some(name), expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 
-  it should "reject result of activation that does not exist" in {
-    val name = "0" * 32
-    val stderr = wsk.activation.result(Some(name), expectedExitCode = NotFound.intValue).stderr
-    stderr should include("The requested resource does not exist.")
+  testname = "reject result of activation that does not exist"
+  it should s"$testname" in {
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val name = "0" * 32
+          val stderr = wsk.activation.result(Some(name), expectedExitCode = NotFound.intValue).stderr
+          stderr should include("The requested resource does not exist.")
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorname should $testname not successful, retrying.."))
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds as well as the health tests performed as part of the production deployments.

```
07:18:57      Starting test Wsk Action REST should create, update, get and list an action at 2021-03-22 02:18:56.850
07:18:58  
07:18:58  system.basic.WskRestBasicTests > Wsk Action REST should create, update, get and list an action STANDARD_OUT
07:18:58      Exception occurred during test execution: org.scalatest.exceptions.TestFailedException: false was not equal to true
07:18:58  
07:18:58  system.basic.WskRestBasicTests > Wsk Action REST should create, update, get and list an action STANDARD_ERROR
07:18:58      org.scalatest.exceptions.TestFailedException: false was not equal to true
07:18:58      	at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
07:18:58      	at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6919)
07:18:58      	at system.basic.WskRestBasicTests.$anonfun$new$39(WskRestBasicTests.scala:282)
07:18:58      	at common.WskTestHelpers.withAssetCleaner(WskTestHelpers.scala:198)
07:18:58      	at common.WskTestHelpers.withAssetCleaner$(WskTestHelpers.scala:193)
07:18:58      	at system.basic.WskRestBasicTests.withAssetCleaner(WskRestBasicTests.scala:40)
07:18:58      	at system.basic.WskRestBasicTests.$anonfun$new$38(WskRestBasicTests.scala:263)
07:18:58      	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

