### PR TITLE
Retries on testcase failures (cont.)

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ActivationStoreQueryBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ActivationStoreQueryBehaviors.scala
@@ -101,6 +101,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -124,6 +125,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -160,6 +162,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -179,6 +182,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -198,6 +202,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -217,6 +222,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
 
           a[IllegalArgumentException] should be thrownBy activationStore
@@ -237,6 +243,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -260,6 +267,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -299,6 +307,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -318,6 +327,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -342,6 +352,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -361,6 +372,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
 
           a[IllegalArgumentException] should be thrownBy activationStore.listActivationsMatchingName(
@@ -389,6 +401,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -408,6 +421,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -433,6 +447,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -472,6 +487,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
           val namespace = s"ns_${Random.alphanumeric.take(4).mkString}"
           val action1 = s"action1_${Random.alphanumeric.take(4).mkString}"
@@ -492,6 +508,7 @@ trait ActivationStoreQueryBehaviors extends ActivationStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transId()
 
           a[IllegalArgumentException] should be thrownBy activationStore

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreAttachmentBehaviors.scala
@@ -46,6 +46,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
           val exec = javaDefault(nonInlinedCode(entityStore), Some("hello"))
           val javaAction =
@@ -80,6 +81,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
           val code1 = nonInlinedCode(entityStore)
           val exec = javaDefault(code1, Some("hello"))
@@ -114,6 +116,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           assumeAttachmentInliningEnabled(entityStore)
           implicit val tid: TransactionId = transid()
           val code1 = encodedRandomBytes(inlinedAttachmentSize(entityStore))
@@ -145,6 +148,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
           val size = Math.max(nonInlinedAttachmentSize(entityStore), getAttachmentSizeForTest(entityStore))
           val base64 = encodedRandomBytes(size)
@@ -181,6 +185,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           assumeAttachmentInliningEnabled(entityStore)
           implicit val tid: TransactionId = transid()
           val attachmentSize = inlinedAttachmentSize(entityStore) - 1
@@ -215,6 +220,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
           val attachmentName = "foo-" + System.currentTimeMillis()
           val attachmentId =
@@ -239,6 +245,7 @@ trait ArtifactStoreAttachmentBehaviors extends ArtifactStoreBehaviorBase with Ex
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           val attachmentStore = getAttachmentStore(entityStore)
           assume(attachmentStore.isDefined, "ArtifactStore does not have attachmentStore configured")
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreQueryBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/behavior/ArtifactStoreQueryBehaviors.scala
@@ -31,6 +31,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -65,6 +66,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -94,6 +96,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -120,6 +123,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -146,6 +150,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -185,6 +190,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -213,6 +219,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -241,6 +248,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -271,6 +279,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
           a[IllegalArgumentException] should be thrownBy query[WhiskActivation](
             activationStore,
@@ -298,6 +307,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -324,6 +334,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
 
           val ns = newNS()
@@ -360,6 +371,7 @@ trait ArtifactStoreQueryBehaviors extends ArtifactStoreBehaviorBase {
     org.apache.openwhisk.utils
       .retry(
         {
+          afterEach()
           implicit val tid: TransactionId = transid()
           a[IllegalArgumentException] should be thrownBy count[WhiskActivation](
             activationStore,

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -19,7 +19,6 @@ package system.basic
 
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.util.UUID
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -45,28 +44,34 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
   val testResult = JsObject("count" -> testString.split(" ").length.toJson)
   val guestNamespace = wskprops.namespace
 
-  behavior of "Whisk actions"
+  val retriesOnTestFailures = 5
+  val waitBeforeRetry = 1.second
+
+  val behaviorname = "Whisk actions"
+  behavior of s"$behaviorname"
 
   it should "create an action with an empty file" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "empty-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "empty"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should create an action with an empty file not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should create an action with an empty file not successful, retrying.."))
   }
 
   it should "invoke an action returning a promise" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "hello promise-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "hello promise"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("helloPromise.js")))
           }
@@ -78,17 +83,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.logs.get.mkString(" ") shouldBe empty
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should invoke an action returning a promise not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should invoke an action returning a promise not successful, retrying.."))
   }
 
   it should "invoke an action with a space in the name" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "hello Async-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "hello Async"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
           }
@@ -100,10 +106,10 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.logs.get.mkString(" ") should include(testString)
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should invoke an action with a space in the name not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should invoke an action with a space in the name not successful, retrying.."))
   }
 
   it should "invoke an action that throws an uncaught exception and returns correct status code" in withAssetCleaner(
@@ -111,7 +117,8 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "throwExceptionAction-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "throwExceptionAction"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("runexception.js")))
           }
@@ -123,17 +130,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
               JsObject("error" -> "An error has occurred: Extraordinary exception".toJson))
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should invoke an action that throws an uncaught exception and returns correct status code not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should invoke an action that throws an uncaught exception and returns correct status code not successful, retrying.."))
   }
 
   it should "pass parameters bound on creation-time to the action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "printParams-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "printParams"
           val params = Map("param1" -> "test1", "param2" -> "test2")
 
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
@@ -154,18 +162,19 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             }
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should pass parameters bound on creation-time to the action not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should pass parameters bound on creation-time to the action not successful, retrying.."))
   }
 
   it should "copy an action and invoke it successfully" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "copied-" + UUID.randomUUID().toString()
-          val packageName = "samples-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "copied"
+          val packageName = "samples-copy-action-and-invoke"
           val actionName = "wordcount"
           val fullQualifiedName = s"/$guestNamespace/$packageName/$actionName"
 
@@ -190,10 +199,10 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.logs.get.mkString(" ") should include(testString)
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should copy an action and invoke it successfully not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should copy an action and invoke it successfully not successful, retrying.."))
   }
 
   it should "copy an action and ensure exec, parameters, and annotations copied" in withAssetCleaner(wskprops) {
@@ -201,8 +210,9 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
       org.apache.openwhisk.utils
         .retry(
           {
-            val origActionName = "origAction-" + UUID.randomUUID().toString()
-            val copiedActionName = "copiedAction-" + UUID.randomUUID().toString()
+            assetHelper.deleteAssets()
+            val origActionName = "origAction"
+            val copiedActionName = "copiedAction"
             val params = Map("a" -> "A".toJson)
             val annots = Map("b" -> "B".toJson)
 
@@ -224,10 +234,10 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             copiedAction.fields("exec") shouldBe origAction.fields("exec")
             copiedAction.fields("version") shouldBe JsString("0.0.1")
           },
-          10,
-          Some(1.second),
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
           Some(
-            s"system.basic.WskActionTests.Whisk actions.should copy an action and ensure exec, parameters, and annotations copied not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should copy an action and ensure exec, parameters, and annotations copied not successful, retrying.."))
   }
 
   it should "add new parameters and annotations while copying an action" in withAssetCleaner(wskprops) {
@@ -235,9 +245,10 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val runtime = "nodejs:default"
-            val origName = "origAction-" + UUID.randomUUID().toString()
-            val copiedName = "copiedAction-" + UUID.randomUUID().toString()
+            val origName = "origAction"
+            val copiedName = "copiedAction"
             val origParams = Map("origParam1" -> "origParamValue1".toJson, "origParam2" -> 999.toJson)
             val copiedParams = Map("copiedParam1" -> "copiedParamValue1".toJson, "copiedParam2" -> 123.toJson)
             val origAnnots = Map("origAnnot1" -> "origAnnotValue1".toJson, "origAnnot2" -> true.toJson)
@@ -289,10 +300,10 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
               .convertTo[Seq[JsObject]]
               .filter(annotation => annotation.fields("key").convertTo[String] != "exec") diff resAnnots shouldBe List.empty
           },
-          10,
-          Some(1.second),
+          retriesOnTestFailures,
+          Some(waitBeforeRetry),
           Some(
-            s"system.basic.WskActionTests.Whisk actions.should add new parameters and annotations while copying an action not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should add new parameters and annotations while copying an action not successful, retrying.."))
 
   }
 
@@ -300,7 +311,8 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "recreatedAction-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "recreatedAction"
           assetHelper.withCleaner(wsk.action, name, false) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("wc.js")))
           }
@@ -322,17 +334,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.logs.get.mkString(" ") should include(s"hello, $testString")
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should recreate and invoke a new action with different code not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should recreate and invoke a new action with different code not successful, retrying.."))
   }
 
   it should "fail to invoke an action with an empty file" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "empty-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "empty"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("empty.js")))
           }
@@ -342,17 +355,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.response.result shouldBe Some(JsObject("error" -> "Missing main/no code to execute.".toJson))
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should fail to invoke an action with an empty file not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should fail to invoke an action with an empty file not successful, retrying.."))
   }
 
   it should "blocking invoke of nested blocking actions" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "nestedBlockingAction-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "nestedBlockingAction"
           val child = "wc"
 
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
@@ -375,17 +389,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
               "binaryCount" -> s"${wordCount.toBinaryString} (base 2)".toJson)
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should blocking invoke of nested blocking actions not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should blocking invoke of nested blocking actions not successful, retrying.."))
   }
 
   it should "blocking invoke an asynchronous action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "helloAsync-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "helloAsync"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("helloAsync.js")))
           }
@@ -399,17 +414,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.logs shouldBe Some(List.empty)
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should blocking invoke an asynchronous action not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should blocking invoke an asynchronous action not successful, retrying.."))
   }
 
   it should "not be able to use 'ping' in an action" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "ping-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "ping"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("ping.js")))
           }
@@ -425,17 +441,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             }
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should not be able to use 'ping' in an action not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should not be able to use 'ping' in an action not successful, retrying.."))
   }
 
   it should "support UTF-8 as input and output format" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "utf8Test-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "utf8Test"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             action.create(name, Some(TestUtils.getTestActionFilename("hello.js")))
           }
@@ -447,17 +464,18 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.logs.get.mkString(" ") should include(s"hello, $utf8")
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should support UTF-8 as input and output format not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should support UTF-8 as input and output format not successful, retrying.."))
   }
 
   it should "invoke action with large code" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "big-hello-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val name = "big-hello"
           assetHelper.withCleaner(wsk.action, name) { (action, _) =>
             val filePath = TestUtils.getTestActionFilename("hello.js")
             val code = FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8)
@@ -476,10 +494,10 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
             activation.logs.get.mkString(" ") should include(s"hello, $hello")
           }
         },
-        10,
-        Some(1.second),
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
         Some(
-          s"system.basic.WskActionTests.Whisk actions.should invoke action with large code not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should invoke action with large code not successful, retrying.."))
   }
 
 }

--- a/tests/src/test/scala/system/basic/WskActivationTests.scala
+++ b/tests/src/test/scala/system/basic/WskActivationTests.scala
@@ -42,7 +42,8 @@ class WskActivationTests extends TestHelpers with WskTestHelpers with WskActorSy
     org.apache.openwhisk.utils
       .retry(
         {
-          val name = "hello-" + System.currentTimeMillis()
+          assetHelper.deleteAssets()
+          val name = "hello-fetch-result"
           val expectedResult = JsObject(
             "result" -> JsObject("payload" -> "hello, undefined!".toJson),
             "success" -> true.toJson,

--- a/tests/src/test/scala/system/basic/WskMultiRuntimeTests.scala
+++ b/tests/src/test/scala/system/basic/WskMultiRuntimeTests.scala
@@ -16,7 +16,6 @@
  */
 
 package system.basic
-import java.util.UUID
 
 import common.JsHelpers
 import common.TestHelpers
@@ -50,7 +49,8 @@ class WskMultiRuntimeTests extends TestHelpers with WskTestHelpers with JsHelper
       org.apache.openwhisk.utils
         .retry(
           {
-            val name = "updatedAction-" + UUID.randomUUID().toString()
+            assetHelper.deleteAssets()
+            val name = "updatedAction-update-action-with-different-language"
 
             assetHelper.withCleaner(wsk.action, name, false) { (action, _) =>
               wsk.action.create(

--- a/tests/src/test/scala/system/basic/WskPackageTests.scala
+++ b/tests/src/test/scala/system/basic/WskPackageTests.scala
@@ -17,7 +17,7 @@
 
 package system.basic
 
-import java.util.{Date, UUID}
+import java.util.Date
 
 import scala.language.postfixOps
 import scala.collection.mutable.HashMap
@@ -42,12 +42,14 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
   private val retriesOnTestFailures = 5
   private val waitBeforeRetry = 1.second
 
-  behavior of "Wsk Package"
+  val behaviorname = "Wsk Package"
+  behavior of s"$behaviorname"
 
   it should "allow creation and deletion of a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils.retry(
       {
-        val name = "simplepackage-" + UUID.randomUUID().toString()
+        assetHelper.deleteAssets()
+        val name = "simplepackage-allow"
         assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
           pkg.create(name, Map.empty)
         }
@@ -55,7 +57,7 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
       retriesOnTestFailures,
       Some(waitBeforeRetry),
       Some(
-        s"${this.getClass.getName} > Wsk Package should allow creation and deletion of a package not successful, retrying.."))
+        s"${this.getClass.getName} > $behaviorname should allow creation and deletion of a package not successful, retrying.."))
   }
 
   val params1 = Map("p1" -> "v1".toJson, "p2" -> "".toJson)
@@ -64,7 +66,8 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
   it should "allow creation of a package with parameters" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils.retry(
       {
-        val name = "simplepackagewithparams-" + UUID.randomUUID().toString()
+        assetHelper.deleteAssets()
+        val name = "simplepackagewithparams"
         assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
           pkg.create(name, params1)
         }
@@ -72,13 +75,14 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
       retriesOnTestFailures,
       Some(waitBeforeRetry),
       Some(
-        s"${this.getClass.getName} > Wsk Package should allow creation of a package with parameters not successful, retrying.."))
+        s"${this.getClass.getName} > $behaviorname should allow creation of a package with parameters not successful, retrying.."))
   }
 
   it should "allow updating a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils.retry(
       {
-        val name = "simplepackagetoupdate-" + UUID.randomUUID().toString()
+        assetHelper.deleteAssets()
+        val name = "simplepackagetoupdate"
         assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
           pkg.create(name, params1)
           pkg.create(name, params2, update = true)
@@ -86,14 +90,15 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
       },
       retriesOnTestFailures,
       Some(waitBeforeRetry),
-      Some(s"${this.getClass.getName} > Wsk Package should allow updating a package not successful, retrying.."))
+      Some(s"${this.getClass.getName} > $behaviorname should allow updating a package not successful, retrying.."))
   }
 
   it should "allow binding of a package" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils.retry(
       {
-        val name = "simplepackagetobind-" + UUID.randomUUID().toString()
-        val bindName = "simplebind-" + UUID.randomUUID().toString()
+        assetHelper.deleteAssets()
+        val name = "simplepackagetobind"
+        val bindName = "simplebind"
         assetHelper.withCleaner(wsk.pkg, name) { (pkg, _) =>
           pkg.create(name, params1)
         }
@@ -103,15 +108,16 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
       },
       retriesOnTestFailures,
       Some(waitBeforeRetry),
-      Some(s"${this.getClass.getName} > Wsk Package should allow binding of a package not successful, retrying.."))
+      Some(s"${this.getClass.getName} > $behaviorname should allow binding of a package not successful, retrying.."))
   }
 
   it should "perform package binds so parameters are inherited" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
-          val packageName = "package1-" + UUID.randomUUID().toString()
-          val bindName = "package2-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val packageName = "package1-perform-bind"
+          val bindName = "package2-perform-bind"
           val actionName = "print"
           val packageActionName = packageName + "/" + actionName
           val bindActionName = bindName + "/" + actionName
@@ -150,7 +156,7 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
         retriesOnTestFailures,
         Some(waitBeforeRetry),
         Some(
-          s"${this.getClass.getName} > Wsk Package should perform package binds so parameters are inherited not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should perform package binds so parameters are inherited not successful, retrying.."))
   }
 
   it should "contain an binding annotation if invoked action is in the package binding" in withAssetCleaner(wskprops) {
@@ -158,9 +164,10 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val ns = wsk.namespace.whois()
-            val packageName = "package1-" + UUID.randomUUID().toString()
-            val bindName = "package2-" + UUID.randomUUID().toString()
+            val packageName = "package1-contain-annotation"
+            val bindName = "package2-contain-annotation"
             val actionName = "print"
             val packageActionName = packageName + "/" + actionName
             val bindActionName = bindName + "/" + actionName
@@ -186,7 +193,7 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
           retriesOnTestFailures,
           Some(waitBeforeRetry),
           Some(
-            s"${this.getClass.getName} > Wsk Package should contain an binding annotation if invoked action is in the package binding not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should contain an binding annotation if invoked action is in the package binding not successful, retrying.."))
   }
 
   it should "not contain an binding annotation if invoked action is not in the package binding" in withAssetCleaner(
@@ -194,8 +201,9 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
     org.apache.openwhisk.utils
       .retry(
         {
-          val packageName = "package1-" + UUID.randomUUID().toString()
-          val actionName = "print-" + UUID.randomUUID().toString()
+          assetHelper.deleteAssets()
+          val packageName = "package1-contain-annotation-if"
+          val actionName = "print"
           val packageActionName = packageName + "/" + actionName
 
           val file = TestUtils.getTestActionFilename("echo.js")
@@ -222,7 +230,7 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
         retriesOnTestFailures,
         Some(waitBeforeRetry),
         Some(
-          s"${this.getClass.getName} > Wsk Package should not contain an binding annotation if invoked action is not in the package binding not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should not contain an binding annotation if invoked action is not in the package binding not successful, retrying.."))
   }
 
   /**

--- a/tests/src/test/scala/system/basic/WskRuleTests.scala
+++ b/tests/src/test/scala/system/basic/WskRuleTests.scala
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import common.TestHelpers
 import common.TestUtils
-import common.TestUtils.RunResult
 import common.WskOperations
 import common.WskProps
 import common.WskTestHelpers
@@ -41,8 +40,8 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
   val testString = "this is a test"
   val testResult = JsObject("count" -> testString.split(" ").length.toJson)
 
-  private val retriesOnTestFailures = 5
-  private val waitBeforeRetry = 1.second
+  val retriesOnTestFailures = 5
+  val waitBeforeRetry = 1.second
 
   /**
    * Sets up trigger -> rule -> action triplets. Deduplicates triggers and rules
@@ -78,13 +77,15 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
     }
   }
 
-  behavior of "Whisk rules"
+  val behaviorname = "Whisk rules"
+  behavior of s"$behaviorname"
 
   it should "invoke the action attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val ruleName = withTimestamp("r1to1")
           val triggerName = withTimestamp("t1to1")
           val actionName = withTimestamp("a1 to 1") // spaces in name intended for greater test coverage
@@ -112,7 +113,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         retriesOnTestFailures,
         Some(waitBeforeRetry),
         Some(
-          s"${this.getClass.getName} > Whisk rules should invoke the action attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should invoke the action attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
   }
 
   it should "invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
@@ -120,6 +121,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val ruleName = withTimestamp("pr1to1")
           val triggerName = withTimestamp("pt1to1")
           val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
@@ -153,7 +155,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         retriesOnTestFailures,
         Some(waitBeforeRetry),
         Some(
-          s"${this.getClass.getName} > Whisk rules should invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should invoke the action from a package attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
   }
 
   it should "invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause" in withAssetCleaner(
@@ -161,6 +163,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val ruleName = withTimestamp("pr1to1")
           val triggerName = withTimestamp("pt1to1")
           val pkgName = withTimestamp("rule pkg") // spaces in name intended to test uri path encoding
@@ -201,7 +204,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         retriesOnTestFailures,
         Some(waitBeforeRetry),
         Some(
-          s"${this.getClass.getName} > Whisk rules should invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should invoke the action from a package binding attached on trigger fire, creating an activation for each entity including the cause not successful, retrying.."))
   }
 
   it should "not activate an action if the rule is deleted when the trigger is fired" in withAssetCleaner(wskprops) {
@@ -209,6 +212,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val ruleName = withTimestamp("ruleDelete")
             val triggerName = withTimestamp("ruleDeleteTrigger")
             val actionName = withTimestamp("ruleDeleteAction")
@@ -233,7 +237,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
           retriesOnTestFailures,
           Some(waitBeforeRetry),
           Some(
-            s"${this.getClass.getName} > Whisk rules should not activate an action if the rule is deleted when the trigger is fired not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should not activate an action if the rule is deleted when the trigger is fired not successful, retrying.."))
   }
 
   it should "enable and disable a rule and check action is activated only when rule is enabled" in withAssetCleaner(
@@ -241,6 +245,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
     org.apache.openwhisk.utils
       .retry(
         {
+          assetHelper.deleteAssets()
           val ruleName = withTimestamp("ruleDisable")
           val triggerName = withTimestamp("ruleDisableTrigger")
           val actionName = withTimestamp("ruleDisableAction")
@@ -276,7 +281,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
         retriesOnTestFailures,
         Some(waitBeforeRetry),
         Some(
-          s"${this.getClass.getName} > Whisk rules should enable and disable a rule and check action is activated only when rule is enabled not successful, retrying.."))
+          s"${this.getClass.getName} > $behaviorname should enable and disable a rule and check action is activated only when rule is enabled not successful, retrying.."))
   }
 
   it should "be able to recreate a rule with the same name and match it successfully" in withAssetCleaner(wskprops) {
@@ -284,6 +289,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val ruleName = withTimestamp("ruleRecreate")
             val triggerName1 = withTimestamp("ruleRecreateTrigger1")
             val triggerName2 = withTimestamp("ruleRecreateTrigger2")
@@ -321,7 +327,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
           retriesOnTestFailures,
           Some(waitBeforeRetry),
           Some(
-            s"${this.getClass.getName} > Whisk rules should be able to recreate a rule with the same name and match it successfully not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should be able to recreate a rule with the same name and match it successfully not successful, retrying.."))
   }
 
   it should "connect two triggers via rules to one action and activate it accordingly" in withAssetCleaner(wskprops) {
@@ -329,6 +335,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val triggerName1 = withTimestamp("t2to1a")
             val triggerName2 = withTimestamp("t2to1b")
             val actionName = withTimestamp("a2to1")
@@ -358,7 +365,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
           retriesOnTestFailures,
           Some(waitBeforeRetry),
           Some(
-            s"${this.getClass.getName} > Whisk rules should connect two triggers via rules to one action and activate it accordingly not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should connect two triggers via rules to one action and activate it accordingly not successful, retrying.."))
   }
 
   it should "connect one trigger to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
@@ -366,6 +373,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val triggerName = withTimestamp("t1to2")
             val actionName1 = withTimestamp("a1to2a")
             val actionName2 = withTimestamp("a1to2b")
@@ -397,7 +405,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
           retriesOnTestFailures,
           Some(waitBeforeRetry),
           Some(
-            s"${this.getClass.getName} > Whisk rules should connect one trigger to two different actions, invoking them both eventually not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should connect one trigger to two different actions, invoking them both eventually not successful, retrying.."))
   }
 
   it should "connect two triggers to two different actions, invoking them both eventually" in withAssetCleaner(wskprops) {
@@ -405,6 +413,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val triggerName1 = withTimestamp("t1to1a")
             val triggerName2 = withTimestamp("t1to1b")
             val actionName1 = withTimestamp("a1to1a")
@@ -447,7 +456,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
           retriesOnTestFailures,
           Some(waitBeforeRetry),
           Some(
-            s"${this.getClass.getName} > Whisk rules should connect two triggers to two different actions, invoking them both eventually not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should connect two triggers to two different actions, invoking them both eventually not successful, retrying.."))
   }
 
   it should "disable a rule and check its status is displayed when listed" in withAssetCleaner(wskprops) {
@@ -455,6 +464,7 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
       org.apache.openwhisk.utils
         .retry(
           {
+            assetHelper.deleteAssets()
             val ruleName = withTimestamp("ruleDisable")
             val ruleName2 = withTimestamp("ruleEnable")
             val triggerName = withTimestamp("ruleDisableTrigger")
@@ -468,15 +478,16 @@ abstract class WskRuleTests extends TestHelpers with WskTestHelpers {
 
             wsk.rule.disable(ruleName)
             val ruleListResult = wsk.rule.list()
-            verifyRuleList(ruleListResult, ruleName2, ruleName)
+            verifyRuleList(ruleName2, ruleName)
           },
           retriesOnTestFailures,
           Some(waitBeforeRetry),
           Some(
-            s"${this.getClass.getName} > Whisk rules should disable a rule and check its status is displayed when listed not successful, retrying.."))
+            s"${this.getClass.getName} > $behaviorname should disable a rule and check its status is displayed when listed not successful, retrying.."))
   }
 
-  def verifyRuleList(ruleListResult: RunResult, ruleNameEnable: String, ruleName: String) = {
+  def verifyRuleList(ruleNameEnable: String, ruleName: String) = {
+    val ruleListResult = wsk.rule.list()
     val ruleList = ruleListResult.stdout
     val listOutput = ruleList.linesIterator
     listOutput.find(_.contains(ruleNameEnable)).get should (include(ruleNameEnable) and include("active"))

--- a/tests/src/test/scala/system/basic/WskUnicodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodeTests.scala
@@ -18,7 +18,6 @@
 package system.basic
 
 import java.io.File
-import java.util.UUID
 
 import io.restassured.RestAssured
 import org.junit.runner.RunWith
@@ -39,8 +38,8 @@ class WskUnicodeTests extends TestHelpers with WskTestHelpers with JsHelpers wit
   val activationMaxDuration = 2.minutes
   val activationPollDuration = 3.minutes
 
-  private val retriesOnTestFailures = 5
-  private val waitBeforeRetry = 1.second
+  private val retriesOnTestFailures = 7
+  private val waitBeforeRetry = 3.second
 
   import WskUnicodeTests._
 
@@ -84,7 +83,8 @@ class WskUnicodeTests extends TestHelpers with WskTestHelpers with JsHelpers wit
         org.apache.openwhisk.utils
           .retry(
             {
-              val name = s"unicodeGalore.${actionKind.replace(":", "")}" + UUID.randomUUID().toString()
+              assetHelper.deleteAssets()
+              val name = s"unicodeGalore.${actionKind.replace(":", "")}"
 
               assetHelper.withCleaner(wsk.action, name) { (action, _) =>
                 action


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds as well as the health tests performed as part of the production deployments.

```
[2021-03-23T13:06:23.054Z] system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed STANDARD_OUT
[2021-03-23T13:06:23.054Z]     assetsToDeleteAfterTest += common.rest.RestTriggerOperations@4fe4bb10,ruleDisableTrigger-1616504782518,true
[2021-03-23T13:06:23.510Z]     assetsToDeleteAfterTest += common.rest.RestActionOperations@47a7c9aa,ruleDisableAction-1616504782518,true
[2021-03-23T13:06:23.965Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleDisable-1616504782518,true
[2021-03-23T13:06:24.919Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleEnable-1616504782518,true
[2021-03-23T13:06:26.442Z]     caught exception: false was not equal to true
[2021-03-23T13:06:26.442Z]     system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed not successful, retrying..
[2021-03-23T13:06:27.661Z]     assetsToDeleteAfterTest += common.rest.RestTriggerOperations@4fe4bb10,ruleDisableTrigger-1616504787207,true
[2021-03-23T13:06:28.112Z]     assetsToDeleteAfterTest += common.rest.RestActionOperations@47a7c9aa,ruleDisableAction-1616504787207,true
[2021-03-23T13:06:29.063Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleDisable-1616504787207,true
[2021-03-23T13:06:29.515Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleEnable-1616504787207,true
[2021-03-23T13:06:31.678Z]     caught exception: false was not equal to true
[2021-03-23T13:06:31.678Z]     system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed not successful, retrying..
[2021-03-23T13:06:32.635Z]     assetsToDeleteAfterTest += common.rest.RestTriggerOperations@4fe4bb10,ruleDisableTrigger-1616504792047,true
[2021-03-23T13:06:33.087Z]     assetsToDeleteAfterTest += common.rest.RestActionOperations@47a7c9aa,ruleDisableAction-1616504792047,true
[2021-03-23T13:06:33.538Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleDisable-1616504792047,true
[2021-03-23T13:06:34.490Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleEnable-1616504792047,true
[2021-03-23T13:06:36.639Z]     caught exception: false was not equal to true
[2021-03-23T13:06:36.639Z]     system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed not successful, retrying..
[2021-03-23T13:06:37.605Z]     assetsToDeleteAfterTest += common.rest.RestTriggerOperations@4fe4bb10,ruleDisableTrigger-1616504797142,true
[2021-03-23T13:06:38.056Z]     assetsToDeleteAfterTest += common.rest.RestActionOperations@47a7c9aa,ruleDisableAction-1616504797142,true
[2021-03-23T13:06:38.509Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleDisable-1616504797142,true
[2021-03-23T13:06:39.480Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleEnable-1616504797142,true
[2021-03-23T13:06:41.637Z]     caught exception: false was not equal to true
[2021-03-23T13:06:41.637Z]     system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed not successful, retrying..
[2021-03-23T13:06:42.597Z]     assetsToDeleteAfterTest += common.rest.RestTriggerOperations@4fe4bb10,ruleDisableTrigger-1616504802108,true
[2021-03-23T13:06:43.048Z]     assetsToDeleteAfterTest += common.rest.RestActionOperations@47a7c9aa,ruleDisableAction-1616504802108,true
[2021-03-23T13:06:43.500Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleDisable-1616504802108,true
[2021-03-23T13:06:44.452Z]     assetsToDeleteAfterTest += common.rest.RestRuleOperations@39b88428,ruleEnable-1616504802108,true
[2021-03-23T13:06:46.873Z]     Exception occurred during test execution: org.scalatest.exceptions.TestFailedException: false was not equal to true
[2021-03-23T13:06:46.873Z] 
[2021-03-23T13:06:46.873Z] system.basic.WskRestRuleTests > Whisk rules should disable a rule and check its status is displayed when listed STANDARD_ERROR
[2021-03-23T13:06:46.873Z]     org.scalatest.exceptions.TestFailedException: false was not equal to true
[2021-03-23T13:06:46.873Z]     	at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
[2021-03-23T13:06:46.873Z]     	at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6919)
[2021-03-23T13:06:46.873Z]     	at system.basic.WskRestRuleTests.verifyRuleList(WskRestRuleTests.scala:48)
[2021-03-23T13:06:46.873Z]     	at system.basic.WskRuleTests.$anonfun$new$79(WskRuleTests.scala:471)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

