### PR TITLE
Catch and log all exceptions that occur in the basic authentication

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -63,6 +63,9 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
           case _: NoDocumentException | _: IllegalArgumentException =>
             logging.debug(this, s"authentication not valid")
             None
+          case e =>
+            logging.info(this, s"authentication not valid: ${e.getMessage}")
+            None
         }
         future.failed.foreach(t => logging.error(this, s"authentication error: $t"))
         future

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -60,12 +60,15 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
             None
           }
         } recover {
-          case _: NoDocumentException | _: IllegalArgumentException =>
-            logging.info(this, s"authentication not valid")
+          case e: NoDocumentException =>
+            logging.info(this, s"authentication not valid(nodocexc): ${e.getMessage}")
+            None
+          case e: IllegalArgumentException =>
+            logging.info(this, s"authentication not valid(illargexc): ${e.getMessage}")
             None
           case e =>
             logging.info(this, s"authentication not valid: ${e.getMessage}")
-            None
+            throw e
         }
         future.failed.foreach(t => logging.error(this, s"authentication error: $t"))
         future

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -60,14 +60,11 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
             None
           }
         } recover {
-          case e: NoDocumentException =>
-            logging.info(this, s"authentication not valid(nodocexc): ${e.getMessage}")
-            None
-          case e: IllegalArgumentException =>
-            logging.info(this, s"authentication not valid(illargexc): ${e.getMessage}")
+          case _: NoDocumentException | _: IllegalArgumentException =>
+            logging.info(this, s"authentication not valid")
             None
           case e =>
-            logging.info(this, s"authentication not valid: ${e.getMessage}")
+            logging.error(this, s"authentication error: ${e.getMessage}")
             throw e
         }
         future.failed.foreach(t => logging.error(this, s"authentication error: $t"))

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -61,7 +61,7 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
           }
         } recover {
           case _: NoDocumentException | _: IllegalArgumentException =>
-            logging.debug(this, s"authentication not valid")
+            logging.info(this, s"authentication not valid")
             None
           case e =>
             logging.info(this, s"authentication not valid: ${e.getMessage}")


### PR DESCRIPTION
Catch and log all exceptions that occur in the basic authentication

## Description
This is to log errors/exception that occur in the basic authentication flow of the controller. This will help to understand 401 errors (`The supplied authentication is invalid`) we see every now and then where we don't have any indication in the logs why the authenticate failed.

```
Mar 24 03:39:29 crudcontroller-1 crudcontroller INFO [#tid_e613268f322ae9c11a23a61aaf5369f3] GET /api/v1/namespaces/_/activations/879cbb2d4cb048ea9cbb2d4cb0b8ea02 
Mar 24 03:39:29 crudcontroller-1 crudcontroller INFO [#tid_e613268f322ae9c11a23a61aaf5369f3] [BasicAuthenticationDirective] authenticate: 0338071b-61f0-4468-a67c-f763b540b5a1
Mar 24 03:39:29 crudcontroller-1 crudcontroller INFO [#tid_e613268f322ae9c11a23a61aaf5369f3] [BasicAuthenticationDirective] authenticate: 0338071b-61f0-4468-a67c-f763b540b5a1
Mar 24 03:39:29 kube-bl9a2e4d0911d94n2ugg-fndevys0-ingress-00001a76 customerlogAccess_public-crbl9a2e4d0911d94n2ugg-alb1-66b896f8f5-gcfk2.log {client: 198.23.106.188, host: fn-dev-ys0.us-south.containers.appdomain.cloud, scheme: https, request_method: GET, request_uri: /api/v1/namespaces/_/activations/879cbb2d4cb048ea9cbb2d4cb0b8ea02, time_date: 24/Mar/2021:03:39:29 +0000, status: 401, http_user_agent: CloudFunctions-CLI/1.0 (2019-06-18T22:05:37+00:00) linux 386, request_id: e613268f322ae9c11a23a61aaf5369f3, content_type: application/json, upstream_addr: 172.30.135.57:8080, upstream_status: 401, request_time: 0.012, upstream_response_time: 0.012, upstream_connect_time: 0.000, upstream_header_time: 0.012}
Mar 24 03:39:29 public-crbl9a2e4d0911d94n2ugg-alb1-66b896f8f5-gcfk2 nginx-ingress {client: 198.23.106.188, host: fn-dev-ys0.us-south.containers.appdomain.cloud, scheme: https, request_method: GET, request_uri: /api/v1/namespaces/_/activations/879cbb2d4cb048ea9cbb2d4cb0b8ea02, time_date: 24/Mar/2021:03:39:29 +0000, status: 401, http_user_agent: CloudFunctions-CLI/1.0 (2019-06-18T22:05:37+00:00) linux 386, request_id: e613268f322ae9c11a23a61aaf5369f3, content_type: application/json, upstream_addr: 172.30.135.57:8080, upstream_status: 401, request_time: 0.012, upstream_response_time: 0.012, upstream_connect_time: 0.000, upstream_header_time: 0.012}

```

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation