### PR TITLE
Retry on testcase failures (cont.)

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/common/SchedulerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/SchedulerTests.scala
@@ -59,172 +59,267 @@ class SchedulerTests extends FlatSpec with Matchers with WskActorSystem with Str
   def waitForCalls(calls: Int = callsToProduce, interval: FiniteDuration = timeBetweenCalls) =
     Thread.sleep((calls + 1) * interval toMillis)
 
-  behavior of "A WaitAtLeast Scheduler"
+  private val retriesOnTestFailures = 5
+  private val waitBeforeRetry = 1.second
+
+  val behaviorwaitatleast = "A WaitAtLeast Scheduler"
+  behavior of s"$behaviorwaitatleast"
 
   ignore should "be killable by sending it a poison pill" in {
-    var callCount = 0
-    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-      callCount += 1
-      Future successful true
-    }
+    val testname = "be killable by sending it a poison pill"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          var callCount = 0
+          val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+            callCount += 1
+            Future successful true
+          }
 
-    waitForCalls()
-    // This is equal to a scheduled ! PoisonPill
-    val shutdownTimeout = 10.seconds
-    Await.result(akka.pattern.gracefulStop(scheduled, shutdownTimeout, PoisonPill), shutdownTimeout)
+          waitForCalls()
+          // This is equal to a scheduled ! PoisonPill
+          val shutdownTimeout = 10.seconds
+          Await.result(akka.pattern.gracefulStop(scheduled, shutdownTimeout, PoisonPill), shutdownTimeout)
 
-    val countAfterKill = callCount
-    callCount should be >= callsToProduce
+          val countAfterKill = callCount
+          callCount should be >= callsToProduce
 
-    waitForCalls()
+          waitForCalls()
 
-    callCount shouldBe countAfterKill
+          callCount shouldBe countAfterKill
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatleast should $testname not successful, retrying.."))
+
   }
 
   it should "throw an expection when passed a negative duration" in {
-    an[IllegalArgumentException] should be thrownBy Scheduler.scheduleWaitAtLeast(-100 milliseconds) { () =>
-      Future.successful(true)
-    }
+    val testname = "throw an expection when passed a negative duration"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          an[IllegalArgumentException] should be thrownBy Scheduler.scheduleWaitAtLeast(-100 milliseconds) { () =>
+            Future.successful(true)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatleast should $testname not successful, retrying.."))
+
   }
 
   it should "wait at least the given interval between scheduled calls" in {
-    val calls = Buffer[Instant]()
+    val testname = "wait at least the given interval between scheduled calls"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val calls = Buffer[Instant]()
 
-    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-      calls += Instant.now
-      Future successful true
-    }
+          val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+            calls += Instant.now
+            Future successful true
+          }
 
-    waitForCalls()
-    scheduled ! PoisonPill
+          waitForCalls()
+          scheduled ! PoisonPill
 
-    val differences = calculateDifferences(calls)
-    withClue(s"expecting all $differences to be >= $timeBetweenCalls") {
-      differences.forall(_ >= timeBetweenCalls)
-    }
+          val differences = calculateDifferences(calls)
+          withClue(s"expecting all $differences to be >= $timeBetweenCalls") {
+            differences.forall(_ >= timeBetweenCalls)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatleast should $testname not successful, retrying.."))
+
   }
 
   it should "stop the scheduler if an uncaught exception is thrown by the passed closure" in {
-    var callCount = 0
-    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-      callCount += 1
-      throw new Exception
-    }
+    val testname = "stop the scheduler if an uncaught exception is thrown by the passed closure"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          var callCount = 0
+          val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+            callCount += 1
+            throw new Exception
+          }
 
-    waitForCalls()
+          waitForCalls()
 
-    callCount shouldBe 1
+          callCount shouldBe 1
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatleast should $testname not successful, retrying.."))
+
   }
 
   it should "log scheduler halt message with tid" in {
-    implicit val transid = TransactionId.testing
-    val msg = "test threw an exception"
+    val testname = "log scheduler halt message with tid"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          implicit val transid = TransactionId.testing
+          val msg = "test threw an exception"
 
-    stream.reset()
-    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-      throw new Exception(msg)
-    }
+          stream.reset()
+          val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+            throw new Exception(msg)
+          }
 
-    waitForCalls()
-    stream.toString.split(" ").drop(1).mkString(" ") shouldBe {
-      s"[ERROR] [$transid] [Scheduler] halted because $msg\n"
-    }
+          waitForCalls()
+          stream.toString.split(" ").drop(1).mkString(" ") shouldBe {
+            s"[ERROR] [$transid] [Scheduler] halted because $msg\n"
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatleast should $testname not successful, retrying.."))
+
   }
 
   it should "not stop the scheduler if the future from the closure is failed" in {
-    var callCount = 0
+    val testname = "not stop the scheduler if the future from the closure is failed"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          var callCount = 0
 
-    val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
-      callCount += 1
-      Future failed new Exception
-    }
+          val scheduled = Scheduler.scheduleWaitAtLeast(timeBetweenCalls) { () =>
+            callCount += 1
+            Future failed new Exception
+          }
 
-    waitForCalls()
-    scheduled ! PoisonPill
+          waitForCalls()
+          scheduled ! PoisonPill
 
-    callCount shouldBe callsToProduce
+          callCount shouldBe callsToProduce
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatleast should $testname not successful, retrying.."))
+
   }
 
+  val behaviorwaitatmost = "A WaitAtMost Scheduler"
   "A WaitAtMost Scheduler" should "wait at most the given interval between scheduled calls" in {
-    val calls = Buffer[Instant]()
-    val timeBetweenCalls = 200 milliseconds
-    val computationTime = 100 milliseconds
+    val testname = "wait at most the given interval between scheduled calls"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val calls = Buffer[Instant]()
+          val timeBetweenCalls = 200 milliseconds
+          val computationTime = 100 milliseconds
 
-    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
-      calls += Instant.now
-      akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
-    }
+          val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
+            calls += Instant.now
+            akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
+          }
 
-    waitForCalls(interval = timeBetweenCalls)
-    scheduled ! PoisonPill
+          waitForCalls(interval = timeBetweenCalls)
+          scheduled ! PoisonPill
 
-    val differences = calculateDifferences(calls)
-    withClue(s"expecting all $differences to be <= $timeBetweenCalls") {
-      differences should not be 'empty
-      differences.forall(_ <= timeBetweenCalls + schedulerSlack)
-    }
+          val differences = calculateDifferences(calls)
+          withClue(s"expecting all $differences to be <= $timeBetweenCalls") {
+            differences should not be 'empty
+            differences.forall(_ <= timeBetweenCalls + schedulerSlack)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatmost should $testname not successful, retrying.."))
+
   }
 
   it should "delay initial schedule by given duration" in {
-    val timeBetweenCalls = 200 milliseconds
-    val initialDelay = 1.second
-    var callCount = 0
+    val testname = "delay initial schedule by given duration"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val timeBetweenCalls = 200 milliseconds
+          val initialDelay = 1.second
+          var callCount = 0
 
-    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
-      callCount += 1
-      Future successful true
-    }
+          val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
+            callCount += 1
+            Future successful true
+          }
 
-    try {
-      Thread.sleep(initialDelay.toMillis)
-      callCount should be <= 1
+          try {
+            Thread.sleep(initialDelay.toMillis)
+            callCount should be <= 1
 
-      Thread.sleep(2 * timeBetweenCalls.toMillis)
-      callCount should be > 1
-    } finally {
-      scheduled ! PoisonPill
-    }
+            Thread.sleep(2 * timeBetweenCalls.toMillis)
+            callCount should be > 1
+          } finally {
+            scheduled ! PoisonPill
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatmost should $testname not successful, retrying.."))
+
   }
 
   it should "perform work immediately when requested" in {
-    val timeBetweenCalls = 200 milliseconds
-    val initialDelay = 1.second
-    var callCount = 0
+    val testname = "perform work immediately when requested"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val timeBetweenCalls = 200 milliseconds
+          val initialDelay = 1.second
+          var callCount = 0
 
-    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
-      callCount += 1
-      Future successful true
-    }
+          val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls, initialDelay) { () =>
+            callCount += 1
+            Future successful true
+          }
 
-    try {
-      Thread.sleep(2 * timeBetweenCalls.toMillis)
-      callCount should be(0)
+          try {
+            Thread.sleep(2 * timeBetweenCalls.toMillis)
+            callCount should be(0)
 
-      scheduled ! Scheduler.WorkOnceNow
-      Thread.sleep(timeBetweenCalls.toMillis)
-      callCount should be(1)
-    } finally {
-      scheduled ! PoisonPill
-    }
+            scheduled ! Scheduler.WorkOnceNow
+            Thread.sleep(timeBetweenCalls.toMillis)
+            callCount should be(1)
+          } finally {
+            scheduled ! PoisonPill
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatmost should $testname not successful, retrying.."))
+
   }
 
   it should "not wait when the closure takes longer than the interval" in {
-    val calls = Buffer[Instant]()
-    val timeBetweenCalls = 200 milliseconds
-    val computationTime = 300 milliseconds
+    val testname = "not wait when the closure takes longer than the interval"
+    org.apache.openwhisk.utils
+      .retry(
+        {
+          val calls = Buffer[Instant]()
+          val timeBetweenCalls = 200 milliseconds
+          val computationTime = 300 milliseconds
 
-    val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
-      calls += Instant.now
-      akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
-    }
+          val scheduled = Scheduler.scheduleWaitAtMost(timeBetweenCalls) { () =>
+            calls += Instant.now
+            akka.pattern.after(computationTime, actorSystem.scheduler)(Future.successful(true))
+          }
 
-    waitForCalls(interval = timeBetweenCalls)
-    scheduled ! PoisonPill
+          waitForCalls(interval = timeBetweenCalls)
+          scheduled ! PoisonPill
 
-    val differences = calculateDifferences(calls)
-    withClue(s"expecting all $differences to be <= $computationTime") {
-      differences should not be 'empty
-      differences.forall(_ <= computationTime + schedulerSlack)
-    }
+          val differences = calculateDifferences(calls)
+          withClue(s"expecting all $differences to be <= $computationTime") {
+            differences should not be 'empty
+            differences.forall(_ <= computationTime + schedulerSlack)
+          }
+        },
+        retriesOnTestFailures,
+        Some(waitBeforeRetry),
+        Some(s"${this.getClass.getName} > $behaviorwaitatmost should $testname not successful, retrying.."))
+
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
In our tests we encounter every now and then failing tests that fail because of timeouts, Cloudant's eventual consistency or other reasons.
## Description
This code change tries to recover from these intermittent failures by retrying the failed test. Objective is to stabilize the `mainBluewhisk` builds as well as the health tests performed as part of the production deployments.

```
02:21:44  org.apache.openwhisk.common.SchedulerTests > A WaitAtLeast Scheduler should not stop the scheduler if the future from the closure is failed FAILED
02:21:44      org.scalatest.exceptions.TestFailedException: 6 was not equal to 5
02:21:44          at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
02:21:44          at org.scalatest.Matchers$AnyShouldWrapper.shouldBe(Matchers.scala:6919)
02:21:44          at org.apache.openwhisk.common.SchedulerTests.$anonfun$new$14(SchedulerTests.scala:145)

02:04:47  org.apache.openwhisk.core.controller.test.PackageActionsApiTests > Package Actions API should include action in package when listing all actions STANDARD_OUT
02:04:47      caught exception: false was not true
02:04:47      caught exception: false was not true
02:04:47  
02:04:47  org.apache.openwhisk.core.controller.test.PackageActionsApiTests > Package Actions API should include action in package when listing all actions FAILED
02:04:47      org.scalatest.exceptions.TestFailedException: false was not true
02:04:47          at org.scalatest.MatchersHelper$.indicateFailure(MatchersHelper.scala:343)
02:04:47          at org.scalatest.Matchers$ShouldMethodHelper$.shouldMatcher(Matchers.scala:6723)
02:04:47          at org.scalatest.Matchers$AnyShouldWrapper.should(Matchers.scala:6759)
02:04:47          at org.apache.openwhisk.core.controller.test.PackageActionsApiTests.$anonfun$new$15(PackageActionsApiTests.scala:120)
02:04:47          at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
02:04:47          at akka.http.scaladsl.testkit.RouteTest.$anonfun$check$1(RouteTest.scala:56)
02:04:47          at akka.http.scaladsl.testkit.RouteTestResultComponent$RouteTestResult.$tilde$greater(RouteTestResultComponent.scala:50)
02:04:47          at org.apache.openwhisk.core.controller.test.PackageActionsApiTests.$anonfun$new$14(PackageActionsApiTests.scala:115)
02:04:47          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:41)
02:04:47          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:47)
02:04:47          at org.apache.openwhisk.utils.retry$.apply(Retry.scala:47)
02:04:47          at org.apache.openwhisk.core.controller.test.PackageActionsApiTests.$anonfun$new$13(PackageActionsApiTests.scala:114)
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

