### PR TITLE
Log full  invoker info

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -154,7 +154,7 @@ class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef
 
   def logStatus(): Unit = {
     monitor.foreach(_ ! CurrentInvokerPoolState(status))
-    val pretty = status.map(i => s"${i.id.toInt} -> ${i.status}")
+    val pretty = status.map(i => s"${i.id.toString} -> ${i.status}")
     logging.info(this, s"invoker status changed to ${pretty.mkString(", ")}")
     val all = status.length
     val healthy = status.filter(_.status == InvokerState.Healthy).length

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -136,7 +136,11 @@ object Invoker {
         if (config.zookeeperHosts.startsWith(":") || config.zookeeperHosts.endsWith(":")) {
           abort(s"Must provide valid zookeeper host and port to use dynamicId assignment (${config.zookeeperHosts})")
         }
-        new InstanceIdAssigner(config.zookeeperHosts).getId(unique)
+        val newId = new InstanceIdAssigner(config.zookeeperHosts).getId(unique)
+        // eg invoker2/10.208.32.124/invoker-cjtth
+        logger.warn(this, s"invoker: invoker$newId/$unique/${cmdLineArgs.displayedName.getOrElse("")}")
+        logger.warn(this, (Seq("invoker" + newId) ++ unique ++ cmdLineArgs.displayedName.getOrElse("")).mkString("/"))
+        newId
 
       case _ => abort(s"Either --id or --uniqueName must be configured with correct values")
     }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -138,7 +138,7 @@ object Invoker {
         }
         val newId = new InstanceIdAssigner(config.zookeeperHosts).getId(unique)
         // eg invoker2/10.208.32.124/invoker-cjtth
-        logger.warn(this, (Seq("invoker" + newId) ++ unique ++ cmdLineArgs.displayedName.getOrElse("")).mkString("/"))
+        logger.warn(this, s"invoker: invoker$newId/$unique/${cmdLineArgs.displayedName.getOrElse("")}")
         newId
 
       case _ => abort(s"Either --id or --uniqueName must be configured with correct values")

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -138,7 +138,6 @@ object Invoker {
         }
         val newId = new InstanceIdAssigner(config.zookeeperHosts).getId(unique)
         // eg invoker2/10.208.32.124/invoker-cjtth
-        logger.warn(this, s"invoker: invoker$newId/$unique/${cmdLineArgs.displayedName.getOrElse("")}")
         logger.warn(this, (Seq("invoker" + newId) ++ unique ++ cmdLineArgs.displayedName.getOrElse("")).mkString("/"))
         newId
 


### PR DESCRIPTION
Log invoker info `invokerid/uniqueName/displayName` (eg `invoker2/10.208.32.124/invoker-cjtth`) in invoker and controller log.

## Description
Show full invoker info to easier identify offline/unhealthy invokers from the log.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation