### PR TITLE
Add isBlacklisted flag to ping message

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -254,13 +254,13 @@ object AcknowledegmentMessage extends DefaultJsonProtocol {
   }
 }
 
-case class PingMessage(instance: InvokerInstanceId) extends Message {
+case class PingMessage(instance: InvokerInstanceId, isBlacklisted: Boolean = false) extends Message {
   override def serialize = PingMessage.serdes.write(this).compactPrint
 }
 
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
-  implicit val serdes = jsonFormat(PingMessage.apply _, "name")
+  implicit val serdes = jsonFormat(PingMessage.apply, "name", "isBlacklisted")
 }
 
 trait EventMessageBody extends Message {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -159,9 +159,9 @@ class InvokerReactive(
     logging.debug(this, "running background job to update blacklist")
     namespaceBlacklist.refreshBlacklist()(ec, TransactionId.invoker).andThen {
       case Success(set) => {
-        logging.info(this, s"updated blacklist to ${set.size} entries")
+        logging.warn(this, s"updated blacklist to ${set.size} entries")
         if (set.contains(instance.displayedName.getOrElse(""))) {
-          logging.warn(this, s"invoker ${instance.toString} is blacklisted, no controller pings will be sent")
+          logging.warn(this, s"invoker ${instance.toString} is blacklisted")
         }
       }
       case Failure(t) => logging.error(this, s"error on updating the blacklist: ${t.getMessage}")

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -343,12 +343,10 @@ class InvokerReactive(
 
   private val healthProducer = msgProvider.getProducer(config)
   Scheduler.scheduleWaitAtMost(1.seconds)(() => {
-    if (!namespaceBlacklist.isBlacklisted(instance.displayedName.getOrElse(""))) {
-      healthProducer.send("health", PingMessage(instance)).andThen {
+    healthProducer
+      .send("health", PingMessage(instance, namespaceBlacklist.isBlacklisted(instance.displayedName.getOrElse(""))))
+      .andThen {
         case Failure(t) => logging.error(this, s"failed to ping the controller: $t")
       }
-    } else {
-      Future.successful(())
-    }
   })
 }


### PR DESCRIPTION
Blacklist invoker using same means as blacklisting namespaces

## Description
Blacklist invoker by adding the info if a certain invoker is being blacklisted to the ping message and consider this info in the invoker supervision logic (`FSM`) to transition the state of an invoker to offline if it blacklisted.
Just suppressing the ping messages sent every second by each invoker is not sufficient as in high load scenarios where constantly invocations are scheduled to an invoker the `StateTimeout` message is not not sent by Scala `FSM` as the the acknowledgment messages sent for the processed activations will cancel the timeout. 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation