### PR TITLE
Blacklist on account level

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/BasicAuthenticationAuthKey.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/BasicAuthenticationAuthKey.scala
@@ -30,7 +30,8 @@ import spray.json.DefaultJsonProtocol._
 protected[core] case class BasicAuthenticationAuthKey(uuid: UUID,
                                                       key: Secret,
                                                       keyEncrypted: String = "",
-                                                      namespaceCrnEncoded: String = "")
+                                                      namespaceCrnEncoded: String = "",
+                                                      account: String = "")
     extends GenericAuthKey(
       JsObject(
         "api_key" -> s"$uuid:$key".toJson,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Identity.scala
@@ -298,7 +298,7 @@ object Identity extends MultipleReadersSingleWriterCache[Option[Identity], DocIn
         Identity(
           subject,
           Namespace(EntityName(namespace), UUID(uuid)),
-          BasicAuthenticationAuthKey(UUID(uuid), Secret(key), keyenc, crnEncoded),
+          BasicAuthenticationAuthKey(UUID(uuid), Secret(key), keyenc, crnEncoded, account),
           Privilege.ALL,
           limits)
       case _ =>

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -48,7 +48,12 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
       if (namespaceBlacklist.isDefined) namespaceBlacklist.get
       else {
         val whiskConfig = new WhiskConfig(Map.empty)
-        logging.info(this, s"whiskconfig: $whiskConfig")
+        logging.info(this, s"controller name: ${whiskConfig.controllerName}")
+        logging.info(this, s"sys.env: ${sys.env}")
+        logging.info(this, s"sys.props: ${sys.props}")
+        logging.info(this, s"System.getenv(): ${System.getenv()}")
+        logging.info(this, s"System.getProperties(): ${System.getProperties()}")
+
         //implicit val ec = authStore.executionContext
         //implicit val logging = authStore.logging
         logging.info(this, "creating blacklist..")

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -21,18 +21,54 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.{AuthenticationDirective, AuthenticationResult}
-import org.apache.openwhisk.common.{Logging, TransactionId}
+import akka.stream.ActorMaterializer
+import org.apache.openwhisk.common.{Logging, Scheduler, TransactionId}
+import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.database.NoDocumentException
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.types.AuthStore
+import org.apache.openwhisk.core.invoker.{NamespaceBlacklist, NamespaceBlacklistConfig}
+import pureconfig.loadConfigOrThrow
+//import pureconfig._
+import pureconfig.generic.auto._
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 import spray.json.JsString
 
 object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
 
+  var namespaceBlacklist: Option[NamespaceBlacklist] = None
+  def getOrCreateBlacklist()(implicit transid: TransactionId,
+                             system: ActorSystem,
+                             ec: ExecutionContext,
+                             logging: Logging): NamespaceBlacklist = {
+    val blacklist =
+      if (namespaceBlacklist.isDefined) namespaceBlacklist.get
+      else {
+        //implicit val ec = authStore.executionContext
+        //implicit val logging = authStore.logging
+        logging.info(this, "creating blacklist..")
+        val authStore = WhiskAuthStore.datastore()(system, logging, ActorMaterializer())
+        val namespaceBlacklist = new NamespaceBlacklist(authStore)
+        Scheduler.scheduleWaitAtMost(loadConfigOrThrow[NamespaceBlacklistConfig](ConfigKeys.blacklist).pollInterval) {
+          () =>
+            logging.info(this, "running background job to update blacklist")
+            namespaceBlacklist.refreshBlacklist()(authStore.executionContext, transid).andThen {
+              case Success(set) => {
+                logging.info(this, s"updated blacklist to ${set.size} entries($set)")
+              }
+              case Failure(t) => logging.error(this, s"error on updating the blacklist: ${t.getMessage}")
+            }
+        }
+        namespaceBlacklist
+      }
+    namespaceBlacklist = Some(blacklist)
+    blacklist
+  }
+
   def validateCredentials(credentials: Option[BasicHttpCredentials])(implicit transid: TransactionId,
+                                                                     system: ActorSystem,
                                                                      ec: ExecutionContext,
                                                                      logging: Logging,
                                                                      authStore: AuthStore): Future[Option[Identity]] = {
@@ -42,19 +78,30 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
         val authkey = BasicAuthenticationAuthKey(UUID(pw.username), Secret(pw.password))
         logging.info(this, s"authenticate: ${authkey.uuid}")
         val future = Identity.get(authStore, authkey) map { result =>
+          val account = result.authkey.asInstanceOf[BasicAuthenticationAuthKey].account
+          val identity = if (getOrCreateBlacklist.isBlacklisted(account)) {
+            Identity(
+              subject = result.subject,
+              namespace = result.namespace,
+              authkey = result.authkey,
+              rights = result.rights,
+              limits =
+                UserLimits(invocationsPerMinute = Some(0), concurrentInvocations = Some(0), firesPerMinute = Some(0)))
+          } else result
+
           // store info for activity tracker
-          val name = result.subject.asString
-          transid.setTag(TransactionId.tagNamespaceId, result.namespace.name.asString)
+          val name = identity.subject.asString
+          transid.setTag(TransactionId.tagNamespaceId, identity.namespace.name.asString)
           transid.setTag(TransactionId.tagInitiatorId, name)
           transid.setTag(TransactionId.tagInitiatorName, name)
           transid.setTag(TransactionId.tagGrantType, "password")
           val JsString(crnEncoded) =
-            result.authkey.toEnvironment.fields.getOrElse("namespace_crn_encoded", JsString.empty)
+            identity.authkey.toEnvironment.fields.getOrElse("namespace_crn_encoded", JsString.empty)
           transid.setTag(TransactionId.tagTargetIdEncoded, crnEncoded)
 
-          if (authkey == result.authkey) {
+          if (authkey == identity.authkey) {
             logging.debug(this, s"authentication valid")
-            Some(result)
+            Some(identity)
           } else {
             logging.debug(this, s"authentication not valid")
             None
@@ -87,10 +134,25 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
 
   def identityByNamespace(
     namespace: EntityName)(implicit transid: TransactionId, system: ActorSystem, authStore: AuthStore) = {
-    Identity.get(authStore, namespace)
+    //Identity.get(authStore, namespace)
+    implicit val ec = authStore.executionContext
+    implicit val logging = authStore.logging
+    Identity.get(authStore, namespace) map { result =>
+      val account = result.authkey.asInstanceOf[BasicAuthenticationAuthKey].account
+      val identity = if (getOrCreateBlacklist.isBlacklisted(account)) {
+        Identity(
+          subject = result.subject,
+          namespace = result.namespace,
+          authkey = result.authkey,
+          rights = result.rights,
+          limits = UserLimits(invocationsPerMinute = Some(0), concurrentInvocations = Some(0), firesPerMinute = Some(0)))
+      } else result
+      identity
+    }
   }
 
   def authenticate(implicit transid: TransactionId,
+                   system: ActorSystem,
                    authStore: AuthStore,
                    logging: Logging): AuthenticationDirective[Identity] = {
     extractExecutionContext.flatMap { implicit ec =>

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -24,7 +24,7 @@ import akka.http.scaladsl.server.directives.{AuthenticationDirective, Authentica
 import akka.stream.ActorMaterializer
 import org.apache.openwhisk.common.{Logging, Scheduler, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
-import org.apache.openwhisk.core.WhiskConfig
+//import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.database.NoDocumentException
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.types.AuthStore
@@ -47,19 +47,21 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
     val blacklist =
       if (namespaceBlacklist.isDefined) namespaceBlacklist.get
       else {
-        val whiskConfig = new WhiskConfig(Map.empty)
-        logging.info(this, s"controller name: ${whiskConfig.controllerName}")
+        logging.info(this, s"controller name: ${sys.env.get("CONTROLLER_NAME").getOrElse("")}")
+        //sys.env.get("CONTROLLER_NAME").getOrElse("")
+        //val whiskConfig = new WhiskConfig(Map.empty)
+        //logging.info(this, s"controller name: ${whiskConfig.controllerName}")
         logging.info(this, s"sys.env: ${sys.env}")
-        logging.info(this, s"sys.props: ${sys.props}")
-        logging.info(this, s"System.getenv(): ${System.getenv()}")
-        logging.info(this, s"System.getProperties(): ${System.getProperties()}")
+        //logging.info(this, s"sys.props: ${sys.props}")
+        //logging.info(this, s"System.getenv(): ${System.getenv()}")
+        //logging.info(this, s"System.getProperties(): ${System.getProperties()}")
 
         //implicit val ec = authStore.executionContext
         //implicit val logging = authStore.logging
         logging.info(this, "creating blacklist..")
         val authStore = WhiskAuthStore.datastore()(system, logging, ActorMaterializer())
         val namespaceBlacklist = new NamespaceBlacklist(authStore)
-        if (!whiskConfig.controllerName.equals("crudcontroller")) {
+        if (!sys.env.get("CONTROLLER_NAME").getOrElse("").equals("crudcontroller")) {
           logging.info(this, "creating background job to update blacklist..")
           Scheduler.scheduleWaitAtMost(loadConfigOrThrow[NamespaceBlacklistConfig](ConfigKeys.blacklist).pollInterval) {
             () =>

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/BasicAuthenticationDirective.scala
@@ -157,11 +157,12 @@ object BasicAuthenticationDirective extends AuthenticationDirectiveProvider {
   }
 
   def authenticate(implicit transid: TransactionId,
-                   system: ActorSystem,
                    authStore: AuthStore,
                    logging: Logging): AuthenticationDirective[Identity] = {
-    extractExecutionContext.flatMap { implicit ec =>
-      basicAuth(validateCredentials)
+    extractActorSystem.flatMap { implicit system =>
+      extractExecutionContext.flatMap { implicit ec =>
+        basicAuth(validateCredentials)
+      }
     }
   }
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -206,7 +206,7 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
     prefix {
       sendResponseHeaders {
         info ~
-          authenticationDirectiveProvider.authenticate(transid, actorSystem, authStore, logging) { user =>
+          authenticationDirectiveProvider.authenticate(transid, authStore, logging) { user =>
             namespaces.routes(user) ~
               pathPrefix(Collection.NAMESPACES) {
                 actions.routes(user) ~
@@ -220,7 +220,7 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
       } ~ {
         // web actions are distinct to separate the cors header
         // and allow the actions themselves to respond to options
-        authenticationDirectiveProvider.authenticate(transid, actorSystem, authStore, logging) { user =>
+        authenticationDirectiveProvider.authenticate(transid, authStore, logging) { user =>
           web.routes(user)
         } ~ {
           web.routes()
@@ -338,7 +338,6 @@ trait AuthenticationDirectiveProvider extends Spi {
    * @return authentication directive used to verify the user credentials
    */
   def authenticate(implicit transid: TransactionId,
-                   system: ActorSystem,
                    authStore: AuthStore,
                    logging: Logging): AuthenticationDirective[Identity]
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -206,7 +206,7 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
     prefix {
       sendResponseHeaders {
         info ~
-          authenticationDirectiveProvider.authenticate(transid, authStore, logging) { user =>
+          authenticationDirectiveProvider.authenticate(transid, actorSystem, authStore, logging) { user =>
             namespaces.routes(user) ~
               pathPrefix(Collection.NAMESPACES) {
                 actions.routes(user) ~
@@ -220,7 +220,7 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
       } ~ {
         // web actions are distinct to separate the cors header
         // and allow the actions themselves to respond to options
-        authenticationDirectiveProvider.authenticate(transid, authStore, logging) { user =>
+        authenticationDirectiveProvider.authenticate(transid, actorSystem, authStore, logging) { user =>
           web.routes(user)
         } ~ {
           web.routes()
@@ -338,6 +338,7 @@ trait AuthenticationDirectiveProvider extends Spi {
    * @return authentication directive used to verify the user credentials
    */
   def authenticate(implicit transid: TransactionId,
+                   system: ActorSystem,
                    authStore: AuthStore,
                    logging: Logging): AuthenticationDirective[Identity]
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
@@ -54,6 +54,13 @@ class NamespaceBlacklist(authStore: AuthStore) {
    */
   def isBlacklisted(name: String): Boolean = blacklist.contains(name)
 
+  /**
+   * Check if blacklist is empty.
+   *
+   * @return whether or not the blacklist is empty
+   */
+  def isEmpty(): Boolean = blacklist.isEmpty
+
   /** Refreshes the current blacklist from the database. */
   /** Limit query parameter set to 0 for limitless record query. */
   def refreshBlacklist()(implicit ec: ExecutionContext, tid: TransactionId): Future[Set[String]] = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/BasicAuthenticateTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/BasicAuthenticateTests.scala
@@ -77,7 +77,7 @@ class BasicAuthenticateTests extends ControllerTestCommon {
                 val pass = BasicHttpCredentials(ns.authkey.uuid.asString, ns.authkey.key.asString)
                 val user = Await.result(
                   BasicAuthenticationDirective
-                    .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+                    .validateCredentials(Some(pass))(transid, actorSystem, executionContext, logging, authStore),
                   dbOpTimeout)
                 user.get shouldBe Identity(subject, ns.namespace, ns.authkey, rights = Privilege.ALL)
 
@@ -88,7 +88,7 @@ class BasicAuthenticateTests extends ControllerTestCommon {
                 // repeat query, now should be served from cache
                 val cachedUser = Await.result(
                   BasicAuthenticationDirective
-                    .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+                    .validateCredentials(Some(pass))(transid, actorSystem, executionContext, logging, authStore),
                   dbOpTimeout)
                 cachedUser.get shouldBe Identity(subject, ns.namespace, ns.authkey, rights = Privilege.ALL)
 
@@ -104,7 +104,7 @@ class BasicAuthenticateTests extends ControllerTestCommon {
             val pass = BasicHttpCredentials(ns.authkey.uuid.asString, k)
             val user = Await.result(
               BasicAuthenticationDirective
-                .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+                .validateCredentials(Some(pass))(transid, actorSystem, executionContext, logging, authStore),
               dbOpTimeout)
             user shouldBe empty
           }
@@ -123,7 +123,8 @@ class BasicAuthenticateTests extends ControllerTestCommon {
           val creds = WhiskAuthHelpers.newIdentity()
           val pass = creds.authkey.getCredentials.asInstanceOf[Option[BasicHttpCredentials]]
           val user = Await.result(
-            BasicAuthenticationDirective.validateCredentials(pass)(transid, executionContext, logging, authStore),
+            BasicAuthenticationDirective
+              .validateCredentials(pass)(transid, actorSystem, executionContext, logging, authStore),
             dbOpTimeout)
           user should be(None)
           stream.toString should not include pass.get.password
@@ -142,7 +143,8 @@ class BasicAuthenticateTests extends ControllerTestCommon {
           val creds = WhiskAuthHelpers.newIdentity()
           val pass = creds.authkey.getCredentials.asInstanceOf[Option[BasicHttpCredentials]]
           val user = Await.result(
-            BasicAuthenticationDirective.validateCredentials(pass)(transid, executionContext, logging, authStore),
+            BasicAuthenticationDirective
+              .validateCredentials(pass)(transid, actorSystem, executionContext, logging, authStore),
             dbOpTimeout)
           user should be(None)
         },
@@ -158,7 +160,8 @@ class BasicAuthenticateTests extends ControllerTestCommon {
         {
           implicit val tid = transid()
           val user = Await.result(
-            BasicAuthenticationDirective.validateCredentials(None)(transid, executionContext, logging, authStore),
+            BasicAuthenticationDirective
+              .validateCredentials(None)(transid, actorSystem, executionContext, logging, authStore),
             dbOpTimeout)
           user should be(None)
         },
@@ -176,7 +179,7 @@ class BasicAuthenticateTests extends ControllerTestCommon {
           val pass = BasicHttpCredentials("x", Secret().asString)
           val user = Await.result(
             BasicAuthenticationDirective
-              .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+              .validateCredentials(Some(pass))(transid, actorSystem, executionContext, logging, authStore),
             dbOpTimeout)
           user should be(None)
         },
@@ -194,7 +197,7 @@ class BasicAuthenticateTests extends ControllerTestCommon {
           val pass = BasicHttpCredentials(UUID().asString, "x")
           val user = Await.result(
             BasicAuthenticationDirective
-              .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+              .validateCredentials(Some(pass))(transid, actorSystem, executionContext, logging, authStore),
             dbOpTimeout)
           user should be(None)
         },
@@ -212,7 +215,7 @@ class BasicAuthenticateTests extends ControllerTestCommon {
           val pass = BasicHttpCredentials("x", "y")
           val user = Await.result(
             BasicAuthenticationDirective
-              .validateCredentials(Some(pass))(transid, executionContext, logging, authStore),
+              .validateCredentials(Some(pass))(transid, actorSystem, executionContext, logging, authStore),
             dbOpTimeout)
           user should be(None)
         },


### PR DESCRIPTION
Blacklist on account level

## Description
This code change enables the blacklisting on account level. By doing so invokes on all namespaces of the blacklisted account will be rejected (`error: Unable to invoke action.. Too many requests in the last minute (count: 1, allowed: 0).`)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation