### PR TITLE
Add isBlacklisted flag to ping message (cont.)

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -316,7 +316,8 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
   /** An Offline invoker represents an existing but broken invoker. This means, that it does not send pings anymore. */
   when(Offline) {
     case Event(p: PingMessage, _) if !p.isBlacklisted => goto(Unhealthy)
-    case Event(p: PingMessage, _) if p.isBlacklisted => stay // avoid unhandled event {"isBlacklisted":true,..} in state Offline
+    case Event(p: PingMessage, _) if p.isBlacklisted =>
+      stay // avoid unhandled event {"isBlacklisted":true,..} in state Offline
   }
 
   // To be used for all states that should send test actions to reverify the invoker


### PR DESCRIPTION
Blacklist invoker using same means as blacklisting namespaces

## Description
This is a continuation of the PR https://github.com/ibm-functions/openwhisk/pull/82
It corrects the Scala formatting of `InvokerSupervision.scala`
```
Execution failed for task ':core:controller:checkScalafmt'.
346> Files incorrectly formatted: /home/travis/build/BlueMix-Fabric/bluewhisk/open/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
```
## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation