### PR TITLE
Avoid file does not end with EOL error in Unicode.cs

### DIFF
--- a/tests/dat/actions/unicode.tests/src/dotnet2.2/Apache.OpenWhisk.UnicodeTests.Dotnet/Unicode.cs
+++ b/tests/dat/actions/unicode.tests/src/dotnet2.2/Apache.OpenWhisk.UnicodeTests.Dotnet/Unicode.cs
@@ -33,3 +33,4 @@ namespace Apache.OpenWhisk.UnicodeTests.Dotnet
         }
     }
 }
+


### PR DESCRIPTION
Avoid file does not end with EOL error in `Unicode.cs`

## Description
This is to avoid the following error:
```
can detected 1 error(s) in 1 file(s):
704  [/home/travis/build/ibm-functions/openwhisk/tools/travis/../../tests/dat/actions/unicode.tests/src/dotnet2.2/Apache.OpenWhisk.UnicodeTests.Dotnet/Unicode.cs]:
705      35: file does not end with EOL.
706
707Scan detected 1 error(s) in 1 file(s):
708The command "./tools/travis/runUnitTests.sh" exited with 1.
```
## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation