### PR TITLE
Make usage of activations db flexible

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -52,6 +52,10 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   private def revHeader(forRev: String) = List(`If-Match`(EntityTagRange(EntityTag(forRev))))
 
+  private def getCurrentDay = System.currentTimeMillis / (24 * 60 * 60 * 1000)
+
+  protected def getDbName(db: String) = if (db.endsWith("activations-")) db + getCurrentDay else db
+
   // Properly encodes the potential slashes in each segment.
   protected def uri(segments: Any*): Uri = {
     val encodedSegments = segments.map(s => URLEncoder.encode(s.toString, StandardCharsets.UTF_8.name))
@@ -60,28 +64,28 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#put--db-docid
   def putDoc(id: String, doc: JsObject): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(db, id), doc, baseHeaders))
+    requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(getDbName(db), id), doc, baseHeaders))
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#put--db-docid
   def putDoc(id: String, rev: String, doc: JsObject): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(db, id), doc, baseHeaders ++ revHeader(rev)))
+    requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(getDbName(db), id), doc, baseHeaders ++ revHeader(rev)))
 
   // http://docs.couchdb.org/en/2.1.0/api/database/bulk-api.html#inserting-documents-in-bulk
   def putDocs(docs: Seq[JsObject]): Future[Either[StatusCode, JsArray]] =
     requestJson[JsArray](
-      mkJsonRequest(HttpMethods.POST, uri(db, "_bulk_docs"), JsObject("docs" -> docs.toJson), baseHeaders))
+      mkJsonRequest(HttpMethods.POST, uri(getDbName(db), "_bulk_docs"), JsObject("docs" -> docs.toJson), baseHeaders))
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
   def getDoc(id: String): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(db, id), headers = baseHeaders))
+    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(getDbName(db), id), headers = baseHeaders))
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
   def getDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(db, id), headers = baseHeaders ++ revHeader(rev)))
+    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(getDbName(db), id), headers = baseHeaders ++ revHeader(rev)))
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#delete--db-docid
   def deleteDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db, id), headers = baseHeaders ++ revHeader(rev)))
+    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(getDbName(db), id), headers = baseHeaders ++ revHeader(rev)))
 
   // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
   def executeView(designDoc: String, viewName: String)(startKey: List[Any] = Nil,
@@ -137,7 +141,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
       })
       .toMap
 
-    val viewUri = uri(db, "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
+    val viewUri = uri(getDbName(db), "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
 
     requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri, headers = baseHeaders))
   }
@@ -151,7 +155,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                     source: Source[ByteString, _]): Future[Either[StatusCode, JsObject]] = {
     val entity = HttpEntity.Chunked(contentType, source.map(bs => HttpEntity.ChunkStreamPart(bs)))
     val request =
-      mkRequest(HttpMethods.PUT, uri(db, id, attName), Future.successful(entity), baseHeaders ++ revHeader(rev))
+      mkRequest(HttpMethods.PUT, uri(getDbName(db), id, attName), Future.successful(entity), baseHeaders ++ revHeader(rev))
     requestJson[JsObject](request)
   }
 
@@ -161,7 +165,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                        rev: String,
                        attName: String,
                        sink: Sink[ByteString, Future[T]]): Future[Either[StatusCode, (ContentType, T)]] = {
-    val httpRequest = mkRequest(HttpMethods.GET, uri(db, id, attName), headers = baseHeaders ++ revHeader(rev))
+    val httpRequest = mkRequest(HttpMethods.GET, uri(getDbName(db), id, attName), headers = baseHeaders ++ revHeader(rev))
 
     request(httpRequest).flatMap { response =>
       if (response.status.isSuccess) {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -85,7 +85,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#delete--db-docid
   def deleteDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(getDbName(db), id), headers = baseHeaders ++ revHeader(rev)))
+    requestJson[JsObject](
+      mkRequest(HttpMethods.DELETE, uri(getDbName(db), id), headers = baseHeaders ++ revHeader(rev)))
 
   // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
   def executeView(designDoc: String, viewName: String)(startKey: List[Any] = Nil,
@@ -155,7 +156,11 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                     source: Source[ByteString, _]): Future[Either[StatusCode, JsObject]] = {
     val entity = HttpEntity.Chunked(contentType, source.map(bs => HttpEntity.ChunkStreamPart(bs)))
     val request =
-      mkRequest(HttpMethods.PUT, uri(getDbName(db), id, attName), Future.successful(entity), baseHeaders ++ revHeader(rev))
+      mkRequest(
+        HttpMethods.PUT,
+        uri(getDbName(db), id, attName),
+        Future.successful(entity),
+        baseHeaders ++ revHeader(rev))
     requestJson[JsObject](request)
   }
 
@@ -165,7 +170,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                        rev: String,
                        attName: String,
                        sink: Sink[ByteString, Future[T]]): Future[Either[StatusCode, (ContentType, T)]] = {
-    val httpRequest = mkRequest(HttpMethods.GET, uri(getDbName(db), id, attName), headers = baseHeaders ++ revHeader(rev))
+    val httpRequest =
+      mkRequest(HttpMethods.GET, uri(getDbName(db), id, attName), headers = baseHeaders ++ revHeader(rev))
 
     request(httpRequest).flatMap { response =>
       if (response.status.isSuccess) {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -34,15 +34,15 @@ import org.apache.openwhisk.http.PoolingRestClient._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * A client implementing the CouchDb API.
-  *
-  * This client only handles communication to the respective endpoints and works in a Json-in -> Json-out fashion. It's
-  * up to the client to interpret the results accordingly.
-  */
+ * A client implementing the CouchDb API.
+ *
+ * This client only handles communication to the respective endpoints and works in a Json-in -> Json-out fashion. It's
+ * up to the client to interpret the results accordingly.
+ */
 class CouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(
   implicit system: ActorSystem,
   logging: Logging)
-  extends PoolingRestClient(protocol, host, port, 16 * 1024) {
+    extends PoolingRestClient(protocol, host, port, 16 * 1024) {
 
   protected implicit override val context: ExecutionContext = system.dispatchers.lookup("dispatchers.couch-dispatcher")
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -86,7 +86,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#delete--db-docid
   def deleteDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
     requestJson[JsObject](
-      mkRequest(HttpMethods.DELETE, uri(getDbName(db), id), headers = baseHeaders ++ revHeader(rev)))
+      mkRequest(HttpMethods.DELETE, uri(db, id), headers = baseHeaders ++ revHeader(rev)))
 
   // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
   def executeView(designDoc: String, viewName: String)(startKey: List[Any] = Nil,
@@ -158,7 +158,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
     val request =
       mkRequest(
         HttpMethods.PUT,
-        uri(getDbName(db), id, attName),
+        uri(db, id, attName),
         Future.successful(entity),
         baseHeaders ++ revHeader(rev))
     requestJson[JsObject](request)
@@ -171,7 +171,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                        attName: String,
                        sink: Sink[ByteString, Future[T]]): Future[Either[StatusCode, (ContentType, T)]] = {
     val httpRequest =
-      mkRequest(HttpMethods.GET, uri(getDbName(db), id, attName), headers = baseHeaders ++ revHeader(rev))
+      mkRequest(HttpMethods.GET, uri(db, id, attName), headers = baseHeaders ++ revHeader(rev))
 
     request(httpRequest).flatMap { response =>
       if (response.status.isSuccess) {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -85,8 +85,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#delete--db-docid
   def deleteDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](
-      mkRequest(HttpMethods.DELETE, uri(db, id), headers = baseHeaders ++ revHeader(rev)))
+    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db, id), headers = baseHeaders ++ revHeader(rev)))
 
   // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
   def executeView(designDoc: String, viewName: String)(startKey: List[Any] = Nil,
@@ -156,11 +155,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                     source: Source[ByteString, _]): Future[Either[StatusCode, JsObject]] = {
     val entity = HttpEntity.Chunked(contentType, source.map(bs => HttpEntity.ChunkStreamPart(bs)))
     val request =
-      mkRequest(
-        HttpMethods.PUT,
-        uri(db, id, attName),
-        Future.successful(entity),
-        baseHeaders ++ revHeader(rev))
+      mkRequest(HttpMethods.PUT, uri(db, id, attName), Future.successful(entity), baseHeaders ++ revHeader(rev))
     requestJson[JsObject](request)
   }
 
@@ -170,8 +165,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                        rev: String,
                        attName: String,
                        sink: Sink[ByteString, Future[T]]): Future[Either[StatusCode, (ContentType, T)]] = {
-    val httpRequest =
-      mkRequest(HttpMethods.GET, uri(db, id, attName), headers = baseHeaders ++ revHeader(rev))
+    val httpRequest = mkRequest(HttpMethods.GET, uri(db, id, attName), headers = baseHeaders ++ revHeader(rev))
 
     request(httpRequest).flatMap { response =>
       if (response.status.isSuccess) {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -52,9 +52,9 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   private def revHeader(forRev: String) = List(`If-Match`(EntityTagRange(EntityTag(forRev))))
 
-  private def getCurrentDay = System.currentTimeMillis / (24 * 60 * 60 * 1000)
+  private def getCurrentDay: Long = System.currentTimeMillis / (24 * 60 * 60 * 1000)
 
-  private def getDbName(db: String) = if (db.endsWith("activations-")) db + getCurrentDay else db
+  private def getDbName(db: String): String = if (db.endsWith("activations-")) db + getCurrentDay else db
 
   // Properly encodes the potential slashes in each segment.
   protected def uri(segments: Any*): Uri = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -34,15 +34,15 @@ import org.apache.openwhisk.http.PoolingRestClient._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
- * A client implementing the CouchDb API.
- *
- * This client only handles communication to the respective endpoints and works in a Json-in -> Json-out fashion. It's
- * up to the client to interpret the results accordingly.
- */
+  * A client implementing the CouchDb API.
+  *
+  * This client only handles communication to the respective endpoints and works in a Json-in -> Json-out fashion. It's
+  * up to the client to interpret the results accordingly.
+  */
 class CouchDbRestClient(protocol: String, host: String, port: Int, username: String, password: String, db: String)(
   implicit system: ActorSystem,
   logging: Logging)
-    extends PoolingRestClient(protocol, host, port, 16 * 1024) {
+  extends PoolingRestClient(protocol, host, port, 16 * 1024) {
 
   protected implicit override val context: ExecutionContext = system.dispatchers.lookup("dispatchers.couch-dispatcher")
 
@@ -85,7 +85,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#delete--db-docid
   def deleteDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db, id), headers = baseHeaders ++ revHeader(rev)))
+    requestJson[JsObject](
+      mkRequest(HttpMethods.DELETE, uri(getDbName(db), id), headers = baseHeaders ++ revHeader(rev)))
 
   // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
   def executeView(designDoc: String, viewName: String)(startKey: List[Any] = Nil,
@@ -155,7 +156,11 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                     source: Source[ByteString, _]): Future[Either[StatusCode, JsObject]] = {
     val entity = HttpEntity.Chunked(contentType, source.map(bs => HttpEntity.ChunkStreamPart(bs)))
     val request =
-      mkRequest(HttpMethods.PUT, uri(db, id, attName), Future.successful(entity), baseHeaders ++ revHeader(rev))
+      mkRequest(
+        HttpMethods.PUT,
+        uri(getDbName(db), id, attName),
+        Future.successful(entity),
+        baseHeaders ++ revHeader(rev))
     requestJson[JsObject](request)
   }
 
@@ -165,7 +170,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                        rev: String,
                        attName: String,
                        sink: Sink[ByteString, Future[T]]): Future[Either[StatusCode, (ContentType, T)]] = {
-    val httpRequest = mkRequest(HttpMethods.GET, uri(db, id, attName), headers = baseHeaders ++ revHeader(rev))
+    val httpRequest =
+      mkRequest(HttpMethods.GET, uri(getDbName(db), id, attName), headers = baseHeaders ++ revHeader(rev))
 
     request(httpRequest).flatMap { response =>
       if (response.status.isSuccess) {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -54,7 +54,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   private def getCurrentDay = System.currentTimeMillis / (24 * 60 * 60 * 1000)
 
-  protected def getDbName(db: String) = if (db.endsWith("activations-")) db + getCurrentDay else db
+  private def getDbName(db: String) = if (db.endsWith("activations-")) db + getCurrentDay else db
 
   // Properly encodes the potential slashes in each segment.
   protected def uri(segments: Any*): Uri = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
@@ -53,15 +53,15 @@ class ExtendedCouchDbRestClient(protocol: String,
 
   // http://docs.couchdb.org/en/1.6.1/api/database/common.html#put--db
   def createDb(): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.PUT, uri(getDbName(db)), headers = baseHeaders))
+    requestJson[JsObject](mkRequest(HttpMethods.PUT, uri(db), headers = baseHeaders))
 
   // http://docs.couchdb.org/en/1.6.1/api/database/common.html#delete--db
   def deleteDb(): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(getDbName(db)), headers = baseHeaders))
+    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db), headers = baseHeaders))
 
   // http://docs.couchdb.org/en/1.6.1/api/database/common.html#head--db
   def doesDbExist(): Future[Boolean] = {
-    requestJson[JsObject](mkRequest(HttpMethods.HEAD, uri(getDbName(db)), headers = baseHeaders))
+    requestJson[JsObject](mkRequest(HttpMethods.HEAD, uri(db), headers = baseHeaders))
       .map {
         case Right(_)                   => true
         case Left(StatusCodes.NotFound) => false
@@ -87,7 +87,7 @@ class ExtendedCouchDbRestClient(protocol: String,
       })
       .toMap
 
-    val url = uri(getDbName(db), "_all_docs").withQuery(Uri.Query(argMap))
+    val url = uri(db, "_all_docs").withQuery(Uri.Query(argMap))
     requestJson[JsObject](mkRequest(HttpMethods.GET, url, headers = baseHeaders))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
@@ -53,15 +53,15 @@ class ExtendedCouchDbRestClient(protocol: String,
 
   // http://docs.couchdb.org/en/1.6.1/api/database/common.html#put--db
   def createDb(): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.PUT, uri(db), headers = baseHeaders))
+    requestJson[JsObject](mkRequest(HttpMethods.PUT, uri(getDbName(db)), headers = baseHeaders))
 
   // http://docs.couchdb.org/en/1.6.1/api/database/common.html#delete--db
   def deleteDb(): Future[Either[StatusCode, JsObject]] =
-    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(db), headers = baseHeaders))
+    requestJson[JsObject](mkRequest(HttpMethods.DELETE, uri(getDbName(db)), headers = baseHeaders))
 
   // http://docs.couchdb.org/en/1.6.1/api/database/common.html#head--db
   def doesDbExist(): Future[Boolean] = {
-    requestJson[JsObject](mkRequest(HttpMethods.HEAD, uri(db), headers = baseHeaders))
+    requestJson[JsObject](mkRequest(HttpMethods.HEAD, uri(getDbName(db)), headers = baseHeaders))
       .map {
         case Right(_)                   => true
         case Left(StatusCodes.NotFound) => false
@@ -87,7 +87,7 @@ class ExtendedCouchDbRestClient(protocol: String,
       })
       .toMap
 
-    val url = uri(db, "_all_docs").withQuery(Uri.Query(argMap))
+    val url = uri(getDbName(db), "_all_docs").withQuery(Uri.Query(argMap))
     requestJson[JsObject](mkRequest(HttpMethods.GET, url, headers = baseHeaders))
   }
 }


### PR DESCRIPTION
Make the usage of activations databases flexible.

## Description

This code change allows _Functions_ to not pin the activations database at deployment time, but instead use it on a daily base (e.g. ` fn-dev-build_activations-18827`). This allows a much better cleanup of old activations databases.

The new logic is controlled by the setting of the activations database name (`db.whisk.activations`) at deployment time. If the name does not end with suffix `activations-` the old behavior applies and the activations database as defined is used for storing and reading activation documents.

Activation documents are copied from one activations database to the next by Cloudant replication means, so if a new activations database is being used activation documents stored before in the previous database are also available in the one currently used.

The code change was successfully tested (green PGs) applying the old (`PG1#1542`) and the new (`PG2#115`) logic.

<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation
