### PR TITLE
Make sure replication doc was deleted

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
@@ -533,7 +533,10 @@ class ReplicatorTests
             // cleanup backup database
             createdDatabasesVar.foreach(removeDatabase(_))
             createdDatabasesVar.foreach(removeReplicationDoc)
-            removeReplicationDoc(wrongPrefixName)
+            retry({
+              // make sure replication doc was deleted
+              removeReplicationDoc(wrongPrefixName) shouldBe(None)
+            }, 10, Some(1.second))
             removeDatabase(correctPrefixName)
             removeDatabase(wrongPrefixName)
           }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
@@ -535,7 +535,7 @@ class ReplicatorTests
             createdDatabasesVar.foreach(removeReplicationDoc)
             retry({
               // make sure replication doc was deleted
-              removeReplicationDoc(wrongPrefixName) shouldBe(None)
+              removeReplicationDoc(wrongPrefixName) shouldBe (None)
             }, 10, Some(1.second))
             removeDatabase(correctPrefixName)
             removeDatabase(wrongPrefixName)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Make sure that the replication doc was deleted
## Description
This code change checks if a certain replication document created in a testcase was really deleted in Cloudant and retries the delete if not. Currently most of the replication documents (e.g `backup_1619575874_replicatortest_wrongprefix_fn-dev-pg2_expired_backup_wrong_prefix` stay in the database forever.

```
    Removing replication doc: backup_1627018780_replicatortest_wrongprefix_fn-dev-pg2_expired_backup_wrong_prefix
    caught exception: Some(Right({"id":"backup_1627018780_replicatortest_wrongprefix_fn-dev-pg2_expired_backup_wrong_prefix","ok":true,"rev":"2-046d25e794983c3187bc408d3a209f19"})) was not equal to None
    Removing replication doc: backup_1627018780_replicatortest_wrongprefix_fn-dev-pg2_expired_backup_wrong_prefix
    caught exception: Some(Right({"id":"backup_1627018780_replicatortest_wrongprefix_fn-dev-pg2_expired_backup_wrong_prefix","ok":true,"rev":"3-e9037a9f76eef0006fdbcdaa73c14e30"})) was not equal to None
    Removing replication doc: backup_1627018780_replicatortest_wrongprefix_fn-dev-pg2_expired_backup_wrong_prefix
```

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).
