### PR TITLE
Make sure replication doc was deleted (cont.)

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
@@ -483,6 +483,10 @@ class ReplicatorTests
             createdDatabasesVar.foreach(removeReplicationDoc)
             removeDatabase(expiredName)
             removeDatabase(notExpiredName)
+            retry({
+              // make sure replication doc was deleted
+              removeReplicationDoc(notExpiredName) shouldBe (None)
+            }, 10, Some(1.second))
           }
         },
         retriesOnTestFailures,


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Make sure that the replication doc was deleted
## Description
This code change checks if a certain replication document created in a testcase was really deleted in Cloudant and retries the delete if not. Currently some of the replication documents (e.g `backup_1627265878_replicatortest_fn-dev-pg1_notexpired_backup` stay in the database forever.


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).
