### PR TITLE
Add Content-Security-Policy response header in controller RestAPI

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -158,6 +158,7 @@ protected[controller] trait RespondWithHeaders extends Directives with CorsSetti
     RawHeader("X-XSS-Protection", "1; mode=block"),
     RawHeader("Cache-Control", "no-store, max-age=0"),
     RawHeader("Pragma", "no-cache"),
+    RawHeader("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'"),
     allowHeaders,
     allowMethods)
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RespondWithHeadersTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RespondWithHeadersTests.scala
@@ -68,6 +68,7 @@ class RespondWithHeadersTests extends ControllerTestCommon with RespondWithHeade
       RawHeader("X-XSS-Protection", "1; mode=block"),
       RawHeader("Cache-Control", "no-store, max-age=0"),
       RawHeader("Pragma", "no-cache"),
+      RawHeader("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'"),
       allowHeaders)
       headers should not contain (allowOrigin)
     }
@@ -79,6 +80,7 @@ class RespondWithHeadersTests extends ControllerTestCommon with RespondWithHeade
       RawHeader("X-XSS-Protection", "1; mode=block"),
       RawHeader("Cache-Control", "no-store, max-age=0"),
       RawHeader("Pragma", "no-cache"),
+      RawHeader("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'"),
       allowHeaders)
       headers should not contain (allowOrigin)
     }
@@ -87,6 +89,7 @@ class RespondWithHeadersTests extends ControllerTestCommon with RespondWithHeade
       RawHeader("X-XSS-Protection", "1; mode=block"),
       RawHeader("Cache-Control", "no-store, max-age=0"),
       RawHeader("Pragma", "no-cache"),
+      RawHeader("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'"),
       allowHeaders)
       headers should not contain (allowOrigin)
     }
@@ -98,6 +101,7 @@ class RespondWithHeadersTests extends ControllerTestCommon with RespondWithHeade
       RawHeader("X-XSS-Protection", "1; mode=block"),
       RawHeader("Cache-Control", "no-store, max-age=0"),
       RawHeader("Pragma", "no-cache"),
+      RawHeader("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'"),
       allowHeaders)
       headers should not contain (allowOrigin)
     }


### PR DESCRIPTION
## Description
Add Content-Security-Policy response header in controller RestAPI

- Dynamic App Scan complains about Cloud Functions RestApi not setting `Content-Security-Policy` security response header which can help to protect against cross-site scripting attacks.
- Adding the following header:
  - `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`
- Impact to end-users cannot be estimated as we don't know their usage/integration pattern of our RestApi, but risk seems low.
- The change does not impact WebActions, only the RestAPI.
- Existing test cases are adjusted accordingly. Additionally, changes are verified via cURL and Functions CLI verbose output.

## Related issue and scope
- n/a

## My changes affect the following components
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I added tests to cover my changes.
