### PR TITLE
Handle actions with orphaned attachments

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -33,7 +33,7 @@ import org.apache.openwhisk.core.entity.{BulkEntityResult, DocInfo, DocumentRead
 import org.apache.openwhisk.http.Messages
 
 import scala.concurrent.Future
-import scala.util.{Failure,Try}
+import scala.util.{Failure, Try}
 
 /**
  * Basic client to put and delete artifacts in a data store.


### PR DESCRIPTION
Handle actions with orphaned couch attachments by not failing on updates or deletes, but instead fallback to an empty attachment to keep those action processable by customers

## Description

This code change recovers from a rare error situation where updates on actions with couch attachments leads to orphaned/broken attachments. The code now deals with this situation by falling back to an empty attachment instead of raising an exception if the couch stub is missing in the action document. 

<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation
