### PR TITLE
bump akka_http to 10.2.7

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -47,7 +47,7 @@ gradle.ext.scalafmt = [
 
 gradle.ext.akka = [version : '2.5.31']
 gradle.ext.akka_kafka = [version : '1.1.0']
-gradle.ext.akka_http = [version : '10.1.14']
+gradle.ext.akka_http = [version : '10.2.7']
 gradle.ext.akka_management = [version : '1.0.5']
 
 gradle.ext.curator = [version : '4.0.0']


### PR DESCRIPTION
## Description

bump akka_http to version 10.2.7

## Related issue and scope

mitigate CVE-2021-42697

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation
