### PR TITLE
Check the file system disk space usage to avoid that invokers run out of space

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -41,7 +41,9 @@ import spray.json._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.language.postfixOps
+import scala.sys.process._
+import scala.util.{Failure, Success, Try}
 
 object InvokerReactive extends InvokerProvider {
 
@@ -154,9 +156,23 @@ class InvokerReactive(
   private val authStore = WhiskAuthStore.datastore()
 
   private val namespaceBlacklist = new NamespaceBlacklist(authStore)
+  private val rootfs = "/"
+  private val logsfs = "/logs"
+  private var rootfspcent = -1
+  private var logsfspcent = -1
 
   Scheduler.scheduleWaitAtMost(loadConfigOrThrow[NamespaceBlacklistConfig](ConfigKeys.blacklist).pollInterval) { () =>
     logging.debug(this, "running background job to update blacklist")
+
+    //val rootfspcentraw = (s"df $rootfs" #| s"grep $rootfs" #| "awk '{ print $5}'" !!)
+    val rootfsraw = Try((s"df $rootfs" #| s"grep $rootfs" !!).trim).getOrElse("??")
+    val rootfspcentraw = Try(rootfsraw.replaceAll(" +", " ").split(" ")(4)).getOrElse("??")
+    rootfspcent = Try(rootfspcentraw.substring(0, rootfspcentraw.indexOf("%")).toInt).getOrElse(-1)
+    val logsfsraw = Try((s"df $logsfs" #| s"grep $logsfs" !!).trim).getOrElse("??")
+    val logsfspcentraw = Try(logsfsraw.replaceAll(" +", " ").split(" ")(4)).getOrElse("??")
+    logsfspcent = Try(logsfspcentraw.substring(0, logsfspcentraw.indexOf("%")).toInt).getOrElse(-1)
+    logging.warn(this, s"$rootfsraw($rootfspcentraw($rootfspcent)), $logsfsraw($logsfspcentraw($logsfspcent))")
+
     namespaceBlacklist.refreshBlacklist()(ec, TransactionId.invoker).andThen {
       case Success(set) => {
         logging.warn(this, s"updated blacklist to ${set.size} entries")
@@ -344,7 +360,12 @@ class InvokerReactive(
   private val healthProducer = msgProvider.getProducer(config)
   Scheduler.scheduleWaitAtMost(1.seconds)(() => {
     healthProducer
-      .send("health", PingMessage(instance, namespaceBlacklist.isBlacklisted(instance.displayedName.getOrElse(""))))
+      .send(
+        "health",
+        PingMessage(
+          instance,
+          namespaceBlacklist
+            .isBlacklisted(instance.displayedName.getOrElse("")) || rootfspcent >= 85 || logsfspcent >= 85))
       .andThen {
         case Failure(t) => logging.error(this, s"failed to ping the controller: $t")
       }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -165,13 +165,15 @@ class InvokerReactive(
     logging.debug(this, "running background job to update blacklist")
 
     //val rootfspcentraw = (s"df $rootfs" #| s"grep $rootfs" #| "awk '{ print $5}'" !!)
-    val rootfsraw = Try((s"df $rootfs" #| s"grep $rootfs" !!).trim).getOrElse("??")
-    val rootfspcentraw = Try(rootfsraw.replaceAll(" +", " ").split(" ")(4)).getOrElse("??")
+    val rootfsraw = Try((s"df $rootfs" #| s"grep $rootfs" !!).trim.replaceAll(" +", " ")).getOrElse("??")
+    val rootfspcentraw = Try(rootfsraw.split(" ")(4)).getOrElse("??")
     rootfspcent = Try(rootfspcentraw.substring(0, rootfspcentraw.indexOf("%")).toInt).getOrElse(-1)
-    val logsfsraw = Try((s"df $logsfs" #| s"grep $logsfs" !!).trim).getOrElse("??")
-    val logsfspcentraw = Try(logsfsraw.replaceAll(" +", " ").split(" ")(4)).getOrElse("??")
+    val logsfsraw = Try((s"df $logsfs" #| s"grep $logsfs" !!).trim.replaceAll(" +", " ")).getOrElse("??")
+    val logsfspcentraw = Try(logsfsraw.split(" ")(4)).getOrElse("??")
     logsfspcent = Try(logsfspcentraw.substring(0, logsfspcentraw.indexOf("%")).toInt).getOrElse(-1)
-    logging.warn(this, s"$rootfsraw($rootfspcentraw($rootfspcent)), $logsfsraw($logsfspcentraw($logsfspcent))")
+    logging.warn(
+      this,
+      s"invoker fs space: '$rootfsraw ($rootfspcentraw($rootfspcent))', '$logsfsraw ($logsfspcentraw($logsfspcent))'")
 
     namespaceBlacklist.refreshBlacklist()(ec, TransactionId.invoker).andThen {
       case Success(set) => {


### PR DESCRIPTION
Check the file system disk space usage to avoid that invokers run out of space

## Description

Invoker pods may run out of space on their log volume for very frequent scheduled actions producing a high load of log messages. By this code change this situation is taken into consideration and the affected invoker will be temporary evacuated until the situation relaxes.  


## Related issue and scope

- [x] none

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

