### PR TITLE
Controller cache invalidation

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -170,8 +170,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
     val changesUri = uri(db, "_changes").withQuery(Uri.Query(argMap))
 
-    logging.info(this, s"@StR doing _changes request on host $host with uri $changesUri")
-    requestJsonChanges[JsObject](mkRequest(HttpMethods.GET, changesUri, headers = baseHeaders))
+    logging.debug(this, s"doing _changes request on host $host with uri $changesUri")
+    requestJson[JsObject](mkRequest(HttpMethods.GET, changesUri, headers = baseHeaders))
   }
 
   // Streams an attachment to the database

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -151,7 +151,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   def changes()(since: Option[String] = None,
                 limit: Option[Int] = None,
                 includeDocs: Boolean = false,
-                descending: Boolean = false): Future[Either[StatusCode, JsObject]] = {
+                descending: Boolean = false): Future[JsObject] = {
 
     def bool2OptStr(bool: Boolean): Option[String] = if (bool) Some("true") else None
 
@@ -172,6 +172,12 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
     logging.debug(this, s"doing _changes request on host $host with uri $changesUri")
     requestJson[JsObject](mkRequest(HttpMethods.GET, changesUri, headers = baseHeaders))
+      .map {
+        case Right(resp) =>
+          resp
+        case Left(code) =>
+          throw new Exception("Unexpected http response code: " + code)
+      }
   }
 
   // Streams an attachment to the database

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -170,7 +170,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
     val changesUri = uri(db, "_changes").withQuery(Uri.Query(argMap))
 
-    logging.info(this, s"@StR doing get request $changesUri")
+    logging.info(this, s"@StR doing get request on host $host with uri $changesUri")
     requestJson[JsObject](mkRequest(HttpMethods.GET, changesUri, headers = baseHeaders))
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -170,8 +170,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
     val changesUri = uri(db, "_changes").withQuery(Uri.Query(argMap))
 
-    logging.info(this, s"@StR doing get request on host $host with uri $changesUri")
-    requestJson[JsObject](mkRequest(HttpMethods.GET, changesUri, headers = baseHeaders))
+    logging.info(this, s"@StR doing _changes request on host $host with uri $changesUri")
+    requestJsonChanges[JsObject](mkRequest(HttpMethods.GET, changesUri, headers = baseHeaders))
   }
 
   // Streams an attachment to the database

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -86,12 +86,28 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
 
     CacheInvalidationMessage.parse(raw) match {
       case Success(msg: CacheInvalidationMessage) => {
+        logging.warn(
+          this,
+          s"@StR msg: $msg, " +
+            s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+            s"actsize: ${WhiskAction.cacheSize}, " +
+            s"pkgsize: ${WhiskPackage.cacheSize}, " +
+            s"rulesize: ${WhiskRule.cacheSize}, " +
+            s"trgsize: ${WhiskTrigger.cacheSize}")
         if (msg.instanceId != instanceId) {
           WhiskActionMetaData.removeId(msg.key)
           WhiskAction.removeId(msg.key)
           WhiskPackage.removeId(msg.key)
           WhiskRule.removeId(msg.key)
           WhiskTrigger.removeId(msg.key)
+          logging.warn(
+            this,
+            s"@StR " +
+              s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+              s"actsize: ${WhiskAction.cacheSize}, " +
+              s"pkgsize: ${WhiskPackage.cacheSize}, " +
+              s"rulesize: ${WhiskRule.cacheSize}, " +
+              s"trgsize: ${WhiskTrigger.cacheSize}")
         }
       }
       case Failure(t) => logging.error(this, s"failed processing message: $raw with $t")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -24,12 +24,12 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import akka.actor.ActorSystem
 import akka.actor.Props
 import spray.json._
-import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.core.WhiskConfig
+import spray.json.DefaultJsonProtocol._
+import org.apache.openwhisk.common._
+import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.core.connector.Message
 import org.apache.openwhisk.core.connector.MessageFeed
 import org.apache.openwhisk.core.connector.MessagingProvider
@@ -37,10 +37,13 @@ import org.apache.openwhisk.core.entity.CacheKey
 import org.apache.openwhisk.core.entity.ControllerInstanceId
 import org.apache.openwhisk.core.entity.WhiskAction
 import org.apache.openwhisk.core.entity.WhiskActionMetaData
+import org.apache.openwhisk.core.entity.WhiskEntity
 import org.apache.openwhisk.core.entity.WhiskPackage
 import org.apache.openwhisk.core.entity.WhiskRule
 import org.apache.openwhisk.core.entity.WhiskTrigger
 import org.apache.openwhisk.spi.SpiLoader
+import pureconfig._
+import pureconfig.generic.auto._
 
 case class CacheInvalidationMessage(key: CacheKey, instanceId: String) extends Message {
   override def serialize = CacheInvalidationMessage.serdes.write(this).compactPrint
@@ -64,6 +67,132 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
     msgProvider.getConsumer(config, s"$cacheInvalidationTopic$instanceId", cacheInvalidationTopic, maxPeek = 128)
   private val cacheInvalidationProducer = msgProvider.getProducer(config)
 
+  private val dbConfig = loadConfigOrThrow[CouchDbConfig](ConfigKeys.couchdb)
+  private val dbClient: CouchDbRestClient =
+    new CouchDbRestClient(
+      dbConfig.protocol,
+      dbConfig.host,
+      dbConfig.port,
+      dbConfig.username,
+      dbConfig.password,
+      dbConfig.databaseFor[WhiskEntity])
+
+  private val lcuskey = "last_seq" // last change update sequence key
+  private var lcus = ""
+
+  dbClient
+    .changes()(limit = Some(1), descending = true)
+    .map {
+      case Right(response) =>
+        lcus = Try(response.fields(lcuskey).asInstanceOf[JsString].convertTo[String]).getOrElse("")
+        assert(!lcus.isEmpty, s"no or invalid last change update sequence in response: '$response'")
+        logging.info(this, s"@StR initial last change update sequence: $lcus")
+
+        Scheduler.scheduleWaitAtMost(60.seconds) { () =>
+          dbClient
+            .changes()(since = Some(lcus), descending = false)
+            .map {
+              case Right(response) =>
+                val nlcus = response.fields(lcuskey).asInstanceOf[JsString].convertTo[String]
+                logging.info(this, s"@StR lcus: $lcus, nlcus: $nlcus")
+                val seqs = response.fields("results").convertTo[List[JsObject]]
+                val seqsdel = seqs.filter(_.fields.contains("deleted"))
+                logging.info(this, s"@StR found ${seqs.length} changes (${seqsdel} deletions)")
+                if (seqs.length > 0) {
+                  logging.info(
+                    this,
+                    s"@StR cache before invalidation: " +
+                      s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+                      s"actsize: ${WhiskAction.cacheSize}, " +
+                      s"pkgsize: ${WhiskPackage.cacheSize}, " +
+                      s"rulesize: ${WhiskRule.cacheSize}, " +
+                      s"trgsize: ${WhiskTrigger.cacheSize}")
+
+                  seqs.foreach { seq =>
+                    // [RemoteCacheInvalidation] @StR msg: {"instanceId":"controller1001","key":{"mainId":"srost@de.ibm.com_myspace/strxxx"}},
+                    val ck = CacheKey(seq.fields("id").asInstanceOf[JsString].convertTo[String])
+                    logging.info(this, s"@StR going to remove key from cache: $ck")
+                    WhiskActionMetaData.removeId(ck)
+                    WhiskAction.removeId(ck)
+                    WhiskPackage.removeId(ck)
+                    WhiskRule.removeId(ck)
+                    WhiskTrigger.removeId(ck)
+                  }
+
+                  logging.info(
+                    this,
+                    s"@StR cache after invalidation: " +
+                      s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+                      s"actsize: ${WhiskAction.cacheSize}, " +
+                      s"pkgsize: ${WhiskPackage.cacheSize}, " +
+                      s"rulesize: ${WhiskRule.cacheSize}, " +
+                      s"trgsize: ${WhiskTrigger.cacheSize}")
+                }
+
+                lcus = nlcus
+                logging.info(this, s"@StR new last change update sequence: $lcus")
+
+              case Left(code) =>
+                logging.error(this, s"Unexpected http response code: $code, keep old lcus: $lcus")
+            }
+        }
+
+      case Left(code) =>
+        assert(false, s"Unexpected http response code: $code from ${dbConfig.databaseFor[WhiskEntity]}/_changes call")
+    }
+
+  /*Scheduler.scheduleWaitAtMost(60.seconds) { () =>
+    dbClient
+      .changes()(since = Some(lcus), descending = false)
+      .map {
+        case Right(response) =>
+          val nlcus = response.fields(lcuskey).asInstanceOf[JsString].convertTo[String]
+          logging.info(this, s"@StR lcus: $lcus, nlcus: $nlcus")
+          val seqs = response.fields("results").convertTo[List[JsObject]]
+          val seqsdel = seqs.filter(_.fields.contains("deleted"))
+          logging.info(this, s"@StR found ${seqs.length} changes (${seqsdel} deletions)")
+          if (seqs.length > 0) {
+            logging.info(
+              this,
+              s"@StR cache before invalidation: " +
+                s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+                s"actsize: ${WhiskAction.cacheSize}, " +
+                s"pkgsize: ${WhiskPackage.cacheSize}, " +
+                s"rulesize: ${WhiskRule.cacheSize}, " +
+                s"trgsize: ${WhiskTrigger.cacheSize}")
+
+            seqs.foreach { seq =>
+              // [RemoteCacheInvalidation] @StR msg: {"instanceId":"controller1001","key":{"mainId":"srost@de.ibm.com_myspace/strxxx"}},
+              val ck = CacheKey(seq.fields("id").asInstanceOf[JsString].convertTo[String])
+              logging.info(this, s"@StR going to remove key from cache: $ck")
+              WhiskActionMetaData.removeId(ck)
+              WhiskAction.removeId(ck)
+              WhiskPackage.removeId(ck)
+              WhiskRule.removeId(ck)
+              WhiskTrigger.removeId(ck)
+            }
+
+            logging.info(
+              this,
+              s"@StR cache after invalidation: " +
+                s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+                s"actsize: ${WhiskAction.cacheSize}, " +
+                s"pkgsize: ${WhiskPackage.cacheSize}, " +
+                s"rulesize: ${WhiskRule.cacheSize}, " +
+                s"trgsize: ${WhiskTrigger.cacheSize}")
+          }
+
+          lcus = nlcus
+          logging.info(this, s"@StR new last change update sequence: $lcus")
+
+        case Left(code) =>
+          logging.error(this, s"Unexpected http response code: $code, keep old lcus: $lcus")
+      }
+  }*/
+
+  //val entityStore = WhiskEntityStore.datastore()(as, logging, ActorMaterializer())
+  //entityStore.query()
+
   def notifyOtherInstancesAboutInvalidation(key: CacheKey): Future[Unit] = {
     cacheInvalidationProducer.send(cacheInvalidationTopic, CacheInvalidationMessage(key, instanceId)).map(_ => Unit)
   }
@@ -86,7 +215,8 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
 
     CacheInvalidationMessage.parse(raw) match {
       case Success(msg: CacheInvalidationMessage) => {
-        logging.warn(
+        logging.warn(this, s"@StR skip cache invalidation via kafka message")
+        /*logging.warn(
           this,
           s"@StR msg: $msg, " +
             s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
@@ -108,7 +238,7 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
               s"pkgsize: ${WhiskPackage.cacheSize}, " +
               s"rulesize: ${WhiskRule.cacheSize}, " +
               s"trgsize: ${WhiskTrigger.cacheSize}")
-        }
+        }*/
       }
       case Failure(t) => logging.error(this, s"failed processing message: $raw with $t")
     }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -142,9 +142,15 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
           Success(lcus)
 
         case Left(code) =>
-          Failure(
-            new Throwable(
-              s"Unexpected http response code: $code from ${dbConfig.databaseFor[WhiskEntity]}/_changes call"))
+          val msg = s"@StR '${dbConfig.databaseFor[WhiskEntity]}' unexecpted response code: $code from _changes call"
+          logging.error(this, msg)
+          Failure(new Throwable(msg))
+      }
+      .recoverWith {
+        case t =>
+          val msg = s"@StR '${dbConfig.databaseFor[WhiskEntity]}' internal error, failure: '${t.getMessage}'"
+          logging.error(this, msg)
+          Future(Failure(new Throwable(msg)))
       }
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -19,8 +19,10 @@ package org.apache.openwhisk.core.database
 
 import java.nio.charset.StandardCharsets
 
+//import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.Await
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -79,96 +81,196 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
 
   private val lcuskey = "last_seq" // last change update sequence key
   private var lcus = "" // last change update sequence
-  private var lcusnum = -1 // num last change update sequences
 
-  def ensureLastChangeUpdateSequence() = {
+  /**
+   * Retry an operation 'step()' awaiting its result up to 'timeout'.
+   * Attempt the operation up to 'count' times. The future from the
+   * step is not aborted --- TODO fix this.
+   */
+  /*def retry[T](step: () => Future[T],
+               timeout: Duration,
+               count: Int = 100,
+               graceBeforeRetry: FiniteDuration = 50.milliseconds): Try[T] = {
+    val future = step()
+    if (count > 0) try {
+      val result = Await.result(future, timeout)
+      Success(result)
+    } catch {
+      case n: NoDocumentException =>
+        println("no document exception, retrying")
+        Thread.sleep(graceBeforeRetry.toMillis)
+        retry(step, timeout, count - 1, graceBeforeRetry)
+      case RetryOp() =>
+        println("condition not met, retrying")
+        Thread.sleep(graceBeforeRetry.toMillis)
+        retry(step, timeout, count - 1, graceBeforeRetry)
+      case t: TimeoutException =>
+        println("timed out, retrying")
+        Thread.sleep(graceBeforeRetry.toMillis)
+        retry(step, timeout, count - 1, graceBeforeRetry)
+      case t: Throwable =>
+        println(s"unexpected failure $t")
+        Failure(t)
+    } else Failure(new NoDocumentException("timed out"))
+  }*/
+
+  case class PaginationException(message: String) extends Exception(message)
+  case class PagingOp() extends Throwable
+
+  def paging2[T](step: () => Future[T]): Try[T] = {
+    val future = step()
+    try {
+      val result = Await.result(future, 5.seconds)
+      Success(result)
+    } catch {
+      case PagingOp() =>
+        println("condition not met, retrying")
+        paging2(step)
+      case t: Throwable =>
+        println(s"unexpected failure $t")
+        Failure(t)
+    }
+  }
+
+  def paging3[T](fn: => Future[String]): Future[String] = {
+    logging.info(this, s"@StR inside paging function..")
+    Try(fn).recover {
+      case PagingOp() =>
+        logging.error(this, s"@StR caught PagingOp() in paging function")
+        paging(fn)
+      case t: Throwable =>
+        logging.error(this, s"@StR caught t: ${t.getMessage}")
+        throw t
+    }.get
+  }
+
+  def paging[T](fn: => Future[String]): Future[String] = {
+    logging.info(this, s"@StR inside paging function..")
+    try fn
+    catch {
+      case PagingOp() =>
+        logging.error(this, s"@StR caught PagingOp() in paging function")
+        paging(fn)
+      case t: Throwable =>
+        logging.error(this, s"@StR caught t: ${t.getMessage}")
+        throw t
+    }
+  }
+
+  private def removeFromLocalCacheBySeqs(seqs: List[JsObject]) = {
+    logging.info(
+      this,
+      s"@StR found ${seqs.length} changes (${seqs.filter(_.fields.contains("deleted")).length} deletions)")
+    if (seqs.length > 0) {
+      logging.info(
+        this,
+        s"@StR cache before invalidation: " +
+          s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+          s"actsize: ${WhiskAction.cacheSize}, " +
+          s"pkgsize: ${WhiskPackage.cacheSize}, " +
+          s"rulesize: ${WhiskRule.cacheSize}, " +
+          s"trgsize: ${WhiskTrigger.cacheSize}")
+
+      seqs.foreach { seq =>
+        // [RemoteCacheInvalidation] @StR msg: {"instanceId":"controller1001","key":{"mainId":"srost@de.ibm.com_myspace/strxxx"}},
+        val ck = CacheKey(seq.fields("id").asInstanceOf[JsString].convertTo[String])
+        logging.info(this, s"@StR going to remove key from cache: $ck")
+        WhiskActionMetaData.removeId(ck)
+        WhiskAction.removeId(ck)
+        WhiskPackage.removeId(ck)
+        WhiskRule.removeId(ck)
+        WhiskTrigger.removeId(ck)
+      }
+
+      logging.info(
+        this,
+        s"@StR cache after invalidation: " +
+          s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
+          s"actsize: ${WhiskAction.cacheSize}, " +
+          s"pkgsize: ${WhiskPackage.cacheSize}, " +
+          s"rulesize: ${WhiskRule.cacheSize}, " +
+          s"trgsize: ${WhiskTrigger.cacheSize}")
+    }
+  }
+
+  //@tailrec
+  private def getLastChangeUpdateSequences(limit: Int = 1): Future[Unit] = {
+    //paging3({
+    require(limit >= 0, "limit should be non negative")
+    dbClient
+      .changes()(since = Some(lcus), limit = Some(limit), descending = false)
+      .map {
+        case Right(resp) =>
+          val newlcus = resp.fields(lcuskey).asInstanceOf[JsString].convertTo[String]
+          logging.info(this, s"@StR lcus: $lcus, newlcus: $newlcus")
+          val seqs = resp.fields("results").convertTo[List[JsObject]]
+          removeFromLocalCacheBySeqs(seqs)
+
+          lcus = newlcus
+          logging.info(this, s"@StR new last change update sequence: $lcus")
+
+          if (seqs.length == limit) {
+            logging.warn(this, s"@StR fetched maximum limit of $limit changes from db")
+            getLastChangeUpdateSequences(limit)
+          }
+
+        /*seqs.length match {
+            case l if l == limit =>
+              logging.warn(this, s"@StR fetched maximum limit of $limit changes from db")
+              //throw PagingOp()
+              getLastChangeUpdateSequences(limit, newlcus)
+            //Future.successful(())
+            //lcus
+            case _ =>
+              val foo = Future.successful(())
+              foo
+            //lcus
+          }*/
+        case Left(code) =>
+          logging.error(this, s"Unexpected http response code: $code, keep old lcus '$lcus'")
+          Future.successful(())
+        //lcus
+      }
+      .recoverWith {
+        /*case PagingOp() =>
+            logging.error(this, s"@StR caught PagingOp() in recoverWith block")
+            throw PagingOp()*/
+        case t: Throwable =>
+          logging.error(
+            this,
+            s"@StR '${dbConfig.databaseFor[WhiskEntity]}' internal error for _changes call, failure: '${t.getMessage}', keep old lcus '$lcus'")
+          Future.successful(())
+      }
+      .mapTo[Unit]
+    //})
+  }
+
+  def scheduleCacheInvalidation() = {
+    Scheduler.scheduleWaitAtLeast(interval = 15.seconds, initialDelay = 60.seconds, name = "CacheInvalidation") { () =>
+      getLastChangeUpdateSequences(10)
+    }
+  }
+
+  def ensureInitialLastChangeUpdateSequence() = {
 
     dbClient
       .changes()(limit = Some(1), descending = true)
       .map {
         case Right(response) =>
-          lcus = Try(response.fields(lcuskey).asInstanceOf[JsString].convertTo[String]).getOrElse("")
-          assert(!lcus.isEmpty, s"no or invalid last change update sequence in response: '$response'")
+          lcus = response.fields(lcuskey).asInstanceOf[JsString].convertTo[String]
+          assert(!lcus.isEmpty, s"invalid initial last change update sequence in response: '$response'")
           logging.info(this, s"@StR initial last change update sequence: $lcus")
-
-          Scheduler.scheduleWaitAtLeast(interval = 15.seconds, initialDelay = 60.seconds, name = "CacheInvalidation")(
-            () => {
-              val limit = 10
-              do {
-                lcusnum = -1 // reset num of fetched seqs
-                dbClient
-                  .changes()(since = Some(lcus), limit = Some(limit), descending = false)
-                  .map {
-                    case Right(response) =>
-                      val newlcus = response.fields(lcuskey).asInstanceOf[JsString].convertTo[String]
-                      logging.info(this, s"@StR lcus: $lcus, newlcus: $newlcus")
-                      val seqs = response.fields("results").convertTo[List[JsObject]]
-                      val seqsdel = seqs.filter(_.fields.contains("deleted"))
-                      logging.info(this, s"@StR found ${seqs.length} changes (${seqsdel.length} deletions)")
-                      if (seqs.length > 0) {
-                        logging.info(
-                          this,
-                          s"@StR cache before invalidation: " +
-                            s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
-                            s"actsize: ${WhiskAction.cacheSize}, " +
-                            s"pkgsize: ${WhiskPackage.cacheSize}, " +
-                            s"rulesize: ${WhiskRule.cacheSize}, " +
-                            s"trgsize: ${WhiskTrigger.cacheSize}")
-
-                        seqs.foreach {
-                          seq =>
-                            // [RemoteCacheInvalidation] @StR msg: {"instanceId":"controller1001","key":{"mainId":"srost@de.ibm.com_myspace/strxxx"}},
-                            val ck = CacheKey(seq.fields("id").asInstanceOf[JsString].convertTo[String])
-                            logging.info(this, s"@StR going to remove key from cache: $ck")
-                            WhiskActionMetaData.removeId(ck)
-                            WhiskAction.removeId(ck)
-                            WhiskPackage.removeId(ck)
-                            WhiskRule.removeId(ck)
-                            WhiskTrigger.removeId(ck)
-                        }
-
-                        logging.info(
-                          this,
-                          s"@StR cache after invalidation: " +
-                            s"actmetasize: ${WhiskActionMetaData.cacheSize}, " +
-                            s"actsize: ${WhiskAction.cacheSize}, " +
-                            s"pkgsize: ${WhiskPackage.cacheSize}, " +
-                            s"rulesize: ${WhiskRule.cacheSize}, " +
-                            s"trgsize: ${WhiskTrigger.cacheSize}")
-                      }
-
-                      lcus = newlcus
-                      lcusnum = seqs.length
-                      logging.info(this, s"@StR new last change update sequence: $lcus")
-
-                    case Left(code) =>
-                      logging.error(this, s"Unexpected http response code: $code, keep old lcus '$lcus'")
-                  }
-                  .recoverWith {
-                    case t =>
-                      logging.error(
-                        this,
-                        s"@StR '${dbConfig.databaseFor[WhiskEntity]}' internal error for _changes call, failure: '${t.getMessage}', keep old lcus '$lcus'")
-                      Future(Success(lcus))
-                  }
-                if (lcusnum == limit) {
-                  logging.info(this, s"@StR pagination..")
-                }
-              } while (lcusnum == limit) // continue in case of pending changes
-              Future(Success(lcus))
-            })
-          Success(lcus)
-
+        //lcus
         case Left(code) =>
           val msg = s"@StR '${dbConfig.databaseFor[WhiskEntity]}' unexecpted response code: $code from _changes call"
           logging.error(this, msg)
-          Failure(new Throwable(msg))
+          throw new Throwable(msg)
       }
       .recoverWith {
         case t =>
           val msg = s"@StR '${dbConfig.databaseFor[WhiskEntity]}' internal error, failure: '${t.getMessage}'"
           logging.error(this, msg)
-          Future(Failure(new Throwable(msg)))
+          throw t
       }
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/PoolingRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/PoolingRestClient.scala
@@ -128,30 +128,6 @@ class PoolingRestClient(
       }
     }
 
-  def requestJsonChanges[T: RootJsonReader](futureRequest: Future[HttpRequest]): Future[Either[StatusCode, T]] =
-    request(futureRequest).flatMap { response =>
-      println(s"@StR response from _changes request: $response(${response.status})")
-      if (response.status.isSuccess) {
-        Unmarshal(response.entity.withoutSizeLimit).to[T].map(Right.apply)
-      } else {
-        println(s"@StR failed response from _changes request: $response(${response.status})")
-        Unmarshal(response.entity).to[String].flatMap { body =>
-          println(s"@StR body from failed _changes request: $body")
-          val statusCode = response.status
-          println(s"@StR statusCode from failed _changes request: $statusCode")
-          val reason =
-            if (body.nonEmpty) s"${statusCode.reason} (details: $body)" else statusCode.reason
-          println(s"@StR reason from failed _changes request: $reason")
-          val customStatusCode = StatusCodes
-            .custom(intValue = statusCode.intValue, reason = reason, defaultMessage = statusCode.defaultMessage)
-          println(s"@StR customStatusCode from failed _changes request: $customStatusCode")
-          // This is important, as it drains the entity stream.
-          // Otherwise the connection stays open and the pool dries up.
-          response.discardEntityBytes().future.map(_ => Left(customStatusCode))
-        }
-      }
-    }
-
   def shutdown(): Future[Unit] = Future.successful(materializer.shutdown())
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/PoolingRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/PoolingRestClient.scala
@@ -30,7 +30,6 @@ import spray.json._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-import org.apache.openwhisk.common.Logging
 
 /**
  * Http client to talk to a known host.

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -46,6 +46,7 @@ import org.apache.openwhisk.spi.SpiLoader
 import scala.concurrent.ExecutionContext.Implicits
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.Await
+import scala.language.reflectiveCalls
 import scala.util.{Failure, Success}
 
 /**
@@ -110,7 +111,7 @@ class Controller(val instance: ControllerInstanceId,
     }
   })
 
-  implicit val ec = actorSystem.dispatcher
+  implicit val executionContext = actorSystem.dispatcher
   cacheChangeNotification.value.remoteCacheInvalidaton.ensureLastChangeUpdateSequence().map {
     case Success(lcus) => logging.info(this, s"@StR initial last change update sequence: $lcus")
     case Failure(t) =>
@@ -152,7 +153,7 @@ class Controller(val instance: ControllerInstanceId,
    * @return JSON with details of invoker health or count of healthy invokers respectively.
    */
   private val internalInvokerHealth = {
-    implicit val executionContext = actorSystem.dispatcher
+    //implicit val executionContext = actorSystem.dispatcher
     (pathPrefix("invokers") & get) {
       pathEndOrSingleSlash {
         complete {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -112,7 +112,8 @@ class Controller(val instance: ControllerInstanceId,
   })
 
   implicit val executionContext = actorSystem.dispatcher
-  cacheChangeNotification.value.remoteCacheInvalidaton.ensureInitialLastChangeUpdateSequence
+  cacheChangeNotification.value.remoteCacheInvalidaton
+    .ensureInitialSequence()
     .map {
       case _ =>
         cacheChangeNotification.value.remoteCacheInvalidaton.scheduleCacheInvalidation

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -120,7 +120,7 @@ class Controller(val instance: ControllerInstanceId,
     }
     .recoverWith {
       case t =>
-        logging.error(this, t.getMessage)
+        logging.error(this, s"failure during remoteCacheInvalidaton.ensureInitialSequence: ${t.getMessage}")
         actorSystem.terminate()
         Await.result(actorSystem.whenTerminated, 30.seconds)
         sys.exit(1)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -112,14 +112,18 @@ class Controller(val instance: ControllerInstanceId,
   })
 
   implicit val executionContext = actorSystem.dispatcher
-  cacheChangeNotification.value.remoteCacheInvalidaton.ensureLastChangeUpdateSequence().map {
-    case Success(lcus) => logging.info(this, s"@StR initial last change update sequence: $lcus")
-    case Failure(t) =>
-      logging.error(this, t.getMessage)
-      actorSystem.terminate()
-      Await.result(actorSystem.whenTerminated, 30.seconds)
-      sys.exit(1)
-  }
+  cacheChangeNotification.value.remoteCacheInvalidaton.ensureInitialLastChangeUpdateSequence
+    .map {
+      case _ =>
+        cacheChangeNotification.value.remoteCacheInvalidaton.scheduleCacheInvalidation
+    }
+    .recoverWith {
+      case t =>
+        logging.error(this, t.getMessage)
+        actorSystem.terminate()
+        Await.result(actorSystem.whenTerminated, 30.seconds)
+        sys.exit(1)
+    }
 
   // initialize backend services
   private implicit val loadBalancer =

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -157,7 +157,6 @@ class Controller(val instance: ControllerInstanceId,
    * @return JSON with details of invoker health or count of healthy invokers respectively.
    */
   private val internalInvokerHealth = {
-    //implicit val executionContext = actorSystem.dispatcher
     (pathPrefix("invokers") & get) {
       pathEndOrSingleSlash {
         complete {


### PR DESCRIPTION
Controller cache invalidation

## Description
Current implementation invalidate caches between controllers on updating the cache on one of the controllers and informing the other controller in the same cluster about the change using Kafka.
This PR adds the ability to invalidate caches between controllers on different clusters using CouchDB. If configured controllers are polling the `/db/_changes` resource and based on the list of changes made to documents in the database updates its caches accordingly.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

