### PR TITLE
Make duration for warm containers up configurable

### DIFF
--- a/tests/performance/gatling_tests/src/gatling/scala/org/apache/openwhisk/BlockingInvokeOneActionSimulation.scala
+++ b/tests/performance/gatling_tests/src/gatling/scala/org/apache/openwhisk/BlockingInvokeOneActionSimulation.scala
@@ -36,6 +36,7 @@ class BlockingInvokeOneActionSimulation extends Simulation {
   val Array(uuid, key) = sys.env("API_KEY").split(":")
 
   val connections: Int = sys.env("CONNECTIONS").toInt
+  val secondsWarmup: FiniteDuration = sys.env.getOrElse("SECONDSWARMUP", "5").toInt.seconds
   val seconds: FiniteDuration = sys.env.getOrElse("SECONDS", "10").toInt.seconds
 
   // Specify thresholds
@@ -64,7 +65,7 @@ class BlockingInvokeOneActionSimulation extends Simulation {
             .readFileToString(Resource.body(actionfile).get.file, StandardCharsets.UTF_8)))
     }
     .rendezVous(connections)
-    .during(5.seconds) {
+    .during(secondsWarmup) {
       exec(openWhisk("Warm containers up").authenticate(uuid, key).action(actionName).invoke())
     }
     .rendezVous(connections)


### PR DESCRIPTION
Make duration for warm containers up configurable for Scala Gatling test `BlockingInvokeOneActionSimulation`

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

