### PR TITLE
Make usage of activations db flexible (cont.)

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -53,14 +53,13 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   private def revHeader(forRev: String) = List(`If-Match`(EntityTagRange(EntityTag(forRev))))
 
   private val flexDb = db.endsWith("activations-")
-
   def useFlexDb: Boolean = flexDb // use flexible activations db
 
-  private def getCurrentDay: Long = System.currentTimeMillis / (24 * 60 * 60 * 1000) // epoch day
+  private val epochDay: Long = 24 * 60 * 60 * 1000
+  private def getDbSfx: Long = System.currentTimeMillis / epochDay // get db suffix based on epoch day
 
-  private def getDb: String = if (flexDb) db + getCurrentDay else db // get fully qualified db name
-
-  private def getPrevDb: String = db + (getCurrentDay - 1) // get previous activations db name
+  private def getDb: String = if (flexDb) db + getDbSfx else db // get fully qualified db name
+  private def getDb(dbSfx: Long): String = db + dbSfx // get fully qualified db name using passed suffix
 
   // Properly encodes the potential slashes in each segment.
   protected def uri(segments: Any*): Uri = {
@@ -74,12 +73,14 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#put--db-docid
   def putDoc(id: String, rev: String, doc: JsObject): Future[Either[StatusCode, JsObject]] = {
-    requestJson[JsObject](mkJsonRequest(HttpMethods.PUT, uri(getDb, id), doc, baseHeaders ++ revHeader(rev)))
+    val dbSfx = getDbSfx
+    requestJson[JsObject](
+      mkJsonRequest(HttpMethods.PUT, uri(if (flexDb) getDb(dbSfx) else db, id), doc, baseHeaders ++ revHeader(rev)))
       .flatMap { e =>
         e match {
           case Left(StatusCodes.NotFound) if flexDb =>
             requestJson[JsObject](
-              mkJsonRequest(HttpMethods.PUT, uri(getPrevDb, id), doc, baseHeaders ++ revHeader(rev)))
+              mkJsonRequest(HttpMethods.PUT, uri(getDb(dbSfx - 1), id), doc, baseHeaders ++ revHeader(rev)))
           case _ => Future(e)
         }
       }
@@ -92,23 +93,27 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
   def getDoc(id: String): Future[Either[StatusCode, JsObject]] = {
-    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(getDb, id), headers = baseHeaders)).flatMap { e =>
-      e match {
-        case Left(StatusCodes.NotFound) if flexDb =>
-          requestJson[JsObject](mkRequest(HttpMethods.GET, uri(getPrevDb, id), headers = baseHeaders))
-        case _ => Future(e)
+    val dbSfx = getDbSfx
+    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(if (flexDb) getDb(dbSfx) else db, id), headers = baseHeaders))
+      .flatMap { e =>
+        e match {
+          case Left(StatusCodes.NotFound) if flexDb =>
+            requestJson[JsObject](mkRequest(HttpMethods.GET, uri(getDb(dbSfx - 1), id), headers = baseHeaders))
+          case _ => Future(e)
+        }
       }
-    }
   }
 
   // http://docs.couchdb.org/en/1.6.1/api/document/common.html#get--db-docid
   def getDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] = {
-    requestJson[JsObject](mkRequest(HttpMethods.GET, uri(getDb, id), headers = baseHeaders ++ revHeader(rev)))
+    val dbSfx = getDbSfx
+    requestJson[JsObject](
+      mkRequest(HttpMethods.GET, uri(if (flexDb) getDb(dbSfx) else db, id), headers = baseHeaders ++ revHeader(rev)))
       .flatMap { e =>
         e match {
           case Left(StatusCodes.NotFound) if flexDb =>
             requestJson[JsObject](
-              mkRequest(HttpMethods.GET, uri(getPrevDb, id), headers = baseHeaders ++ revHeader(rev)))
+              mkRequest(HttpMethods.GET, uri(getDb(dbSfx - 1), id), headers = baseHeaders ++ revHeader(rev)))
           case _ => Future(e)
         }
       }
@@ -172,9 +177,153 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
       })
       .toMap
 
-    val viewUri = uri(getDb, "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
+    val dbSfx = getDbSfx
+    val viewUri =
+      uri(if (flexDb) getDb(dbSfx) else db, "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
 
-    requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri, headers = baseHeaders))
+    val res = requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri, headers = baseHeaders))
+    if (!flexDb) res
+    else {
+      res.flatMap { e =>
+        e match {
+          case Right(response) =>
+            val rows = response.fields("rows").convertTo[List[JsObject]]
+            rows match {
+              case _ if (!reduce || (rows.isEmpty || rows.length == 1)) =>
+                val viewUri =
+                  uri(getDb(dbSfx - 1), "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
+                requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri, headers = baseHeaders)).flatMap { e2 =>
+                  e2 match {
+                    case Right(response2) =>
+                      val rows2 = response2.fields("rows").convertTo[List[JsObject]]
+                      rows2 match {
+                        case _ if (!reduce || (rows2.isEmpty || rows2.length == 1)) =>
+                          // {"rows": [ ]}
+                          // {"rows": [{"key": null, "value": 3136}]}
+                          // {"total_rows": 8554, "offset": 0, "rows": [{"id": "id", "key": ["id", 1644779646989], "value": {"namespace": "namespace", "name": "wordCount"}}]}
+                          if (rows.isEmpty && rows2.isEmpty) {
+                            Future(JsObject("rows" -> JsArray.empty))
+                          } else if (reduce) {
+                            val v = if (rows.isEmpty) 0 else rows.head.fields("value").convertTo[Long]
+                            val v2 = if (rows2.isEmpty) 0 else rows2.head.fields("value").convertTo[Long]
+                            Future(JsObject("rows" -> JsArray(JsObject("key" -> JsNull, "value" -> JsNumber(v + v2)))))
+                          } else {
+                            Future(
+                              JsObject("rows" -> (rows ++ rows2).toArray.slice(0, limit.get).toJson.convertTo[JsArray]))
+                          }
+                        case _ => Future(e2) // return right response from second call if assertion is violated
+                      }
+                    case _ => Future(e2) // return left response from second call
+                  }
+                }
+              case _ => Future(e) // return right response from first call if assertion is violated
+            }
+            Future(e)
+          case _ => Future(e) // return left response from first call
+        }
+      }
+    }
+  }
+
+  // http://docs.couchdb.org/en/1.6.1/api/ddoc/views.html
+  def executeViewForCount(designDoc: String, viewName: String)(
+    startKey: List[Any] = Nil,
+    endKey: List[Any] = Nil,
+    skip: Option[Int] = None,
+    limit: Option[Int] = None,
+    stale: StaleParameter = StaleParameter.No,
+    includeDocs: Boolean = false,
+    descending: Boolean = false,
+    reduce: Boolean = false,
+    group: Boolean = false): Future[Either[StatusCode, JsObject]] = {
+
+    require(reduce || !group, "Parameter 'group=true' cannot be used together with the parameter 'reduce=false'.")
+
+    def any2json(any: Any): JsValue = any match {
+      case b: Boolean => JsBoolean(b)
+      case i: Int     => JsNumber(i)
+      case l: Long    => JsNumber(l)
+      case d: Double  => JsNumber(d)
+      case f: Float   => JsNumber(f)
+      case s: String  => JsString(s)
+      case _ =>
+        logging.warn(
+          this,
+          s"Serializing uncontrolled type '${any.getClass}' to string in JSON conversion ('${any.toString}').")
+        JsString(any.toString)
+    }
+
+    def list2OptJson(lst: List[Any]): Option[JsValue] = {
+      lst match {
+        case Nil => None
+        case _   => Some(JsArray(lst.map(any2json): _*))
+      }
+    }
+
+    def bool2OptStr(bool: Boolean): Option[String] = if (bool) Some("true") else None
+
+    val args = Seq[(String, Option[String])](
+      "startkey" -> list2OptJson(startKey).map(_.toString),
+      "endkey" -> list2OptJson(endKey).map(_.toString),
+      "skip" -> skip.filter(_ > 0).map(_.toString),
+      "limit" -> limit.filter(_ > 0).map(_.toString),
+      "stale" -> stale.value,
+      "include_docs" -> bool2OptStr(includeDocs),
+      "descending" -> bool2OptStr(descending),
+      "reduce" -> Some(reduce.toString),
+      "group" -> bool2OptStr(group))
+
+    // Throw out all undefined arguments.
+    val argMap: Map[String, String] = args
+      .collect({
+        case (l, Some(r)) => (l, r)
+      })
+      .toMap
+
+    val dbSfx = getDbSfx
+    val viewUri =
+      uri(if (flexDb) getDb(dbSfx) else db, "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
+
+    val res = requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri, headers = baseHeaders))
+    if (!flexDb) res
+    else {
+      res.flatMap { e =>
+        e match {
+          case Right(response) =>
+            val rows = response.fields("rows").convertTo[List[JsObject]]
+            rows match {
+              case _ if rows.isEmpty || rows.length == 1 =>
+                val viewUri =
+                  uri(getDb(dbSfx - 1), "_design", designDoc, "_view", viewName).withQuery(Uri.Query(argMap))
+                requestJson[JsObject](mkRequest(HttpMethods.GET, viewUri, headers = baseHeaders)).flatMap { e2 =>
+                  e2 match {
+                    case Right(response2) =>
+                      val rows2 = response2.fields("rows").convertTo[List[JsObject]]
+                      rows2 match {
+                        case _ if rows2.isEmpty || rows2.length == 1 =>
+                          val count = if (rows.nonEmpty) {
+                            val count = rows.head.fields("value").convertTo[Long]
+                            if (count > skip.get) count - skip.get else 0L
+                          } else 0L
+                          val count2 = if (rows2.nonEmpty) {
+                            val count = rows2.head.fields("value").convertTo[Long]
+                            if (count > skip.get) count - skip.get else 0L
+                          } else 0L
+                          // {"rows": [{"key": null, "value": 3136}]}
+                          Future(
+                            JsObject("rows" -> JsArray(JsObject("key" -> JsNull, "value" -> JsNumber(count + count2)))))
+                        case _ => Future(e2) // return right response from second call if assertion is violated
+                      }
+                    case _ => Future(e2) // return left response from second call
+                  }
+                }
+              case _ => Future(e) // return right response from first call if assertion is violated
+            }
+            Future(e)
+          case _ => Future(e) // return left response from first call
+        }
+      }
+    }
   }
 
   // https://docs.couchdb.org/en/1.6.1/api/database/changes.html
@@ -219,11 +368,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                     source: Source[ByteString, _]): Future[Either[StatusCode, JsObject]] = {
     val entity = HttpEntity.Chunked(contentType, source.map(bs => HttpEntity.ChunkStreamPart(bs)))
     val request =
-      mkRequest(
-        HttpMethods.PUT,
-        uri(getDb, id, attName),
-        Future.successful(entity),
-        baseHeaders ++ revHeader(rev))
+      mkRequest(HttpMethods.PUT, uri(getDb, id, attName), Future.successful(entity), baseHeaders ++ revHeader(rev))
     requestJson[JsObject](request)
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -220,7 +220,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
             val rows1 = response.fields("rows").convertTo[List[JsObject]]
             (sk match {
               case _ if sk > 0 && rows1.length == 0 =>
-                // do cloudant count (reduce=true) call to determine number of activations to mitigate fuzziness
+                // count (reduce=true) call to determine number of activations to mitigate fuzziness
                 // empty row set is either returned because there are no matching rows or
                 // its count is within the number to be excluded as specified by the skip param
                 val viewUri =

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -59,7 +59,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   private val flexDb = db.endsWith("activations-")
   // activations database flex logic (consider two activations dbs for crud and view operations)
   case class ActivationsDbConfig(useFlexLogic: Boolean)
-  private val activationsDbConfig = if (flexDb) loadConfig[ActivationsDbConfig]("whisk.activationsdb").toOption else None
+  private val activationsDbConfig =
+    if (flexDb) loadConfig[ActivationsDbConfig]("whisk.activationsdb").toOption else None
   private val useFlexLogic = activationsDbConfig.exists(_.useFlexLogic)
   if (db.contains("activations")) logging.info(this, s"useFlexActivationsLogic: $useFlexLogic")
   def useFlexActivationsLogic: Boolean = useFlexLogic // use extended flexible activations database logic
@@ -84,7 +85,11 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   def putDoc(id: String, rev: String, doc: JsObject): Future[Either[StatusCode, JsObject]] = {
     val dbSfx = if (useFlexLogic) getDbSfx else 0L // pin database suffix if needed
     requestJson[JsObject](
-      mkJsonRequest(HttpMethods.PUT, uri(if (useFlexLogic) getDb(dbSfx) else getDb, id), doc, baseHeaders ++ revHeader(rev)))
+      mkJsonRequest(
+        HttpMethods.PUT,
+        uri(if (useFlexLogic) getDb(dbSfx) else getDb, id),
+        doc,
+        baseHeaders ++ revHeader(rev)))
       .flatMap { e =>
         e match {
           case Left(StatusCodes.NotFound) if useFlexLogic =>
@@ -118,7 +123,10 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   def getDoc(id: String, rev: String): Future[Either[StatusCode, JsObject]] = {
     val dbSfx = if (useFlexLogic) getDbSfx else 0L // pin database suffix if needed
     requestJson[JsObject](
-      mkRequest(HttpMethods.GET, uri(if (useFlexLogic) getDb(dbSfx) else getDb, id), headers = baseHeaders ++ revHeader(rev)))
+      mkRequest(
+        HttpMethods.GET,
+        uri(if (useFlexLogic) getDb(dbSfx) else getDb, id),
+        headers = baseHeaders ++ revHeader(rev)))
       .flatMap { e =>
         e match {
           case Left(StatusCodes.NotFound) if useFlexLogic =>
@@ -201,7 +209,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
         .toMap
 
     if (!useFlexLogic || group || reduce) {
-      if (flexDb) logging.warn(this, s"Parameter 'group=$group' or 'reduce=$reduce' set for activations database '${getDb}'.")
+      if (flexDb)
+        logging.warn(this, s"Parameter 'group=$group' or 'reduce=$reduce' set for activations database '${getDb}'.")
       val viewUri =
         uri(getDb, "_design", designDoc, "_view", viewName)
           .withQuery(Uri.Query(argMap(args(skip = skip, limit = limit))))
@@ -242,7 +251,8 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                           val rows = countresponse.fields("rows").convertTo[List[JsObject]]
                           val count = if (rows.nonEmpty) rows.head.fields("value").convertTo[Long] else 0
                           if (sk > count) sk - count else 0
-                        }.toInt else 0
+                        }.toInt
+                        else 0
                       val viewUri =
                         uri(getDb(dbSfx - 1), "_design", designDoc, "_view", viewName)
                           .withQuery(Uri.Query(argMap(args(skip = Some(sk2), limit = Some(li2)))))

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -219,11 +219,16 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
                               Right(
                                 JsObject("rows" -> JsArray(JsObject("key" -> JsNull, "value" -> JsNumber(v + v2))))))
                           } else {
+                            val allrows = rows ++ rows2
                             logging.info(this, s"@StR return ${JsObject(
-                              "rows" -> (rows ++ rows2).toArray.slice(0, limit.get).toJson.convertTo[JsArray])}")
+                              "rows" -> allrows.toArray.slice(0, if (limit.get > 0) limit.get else allrows.length).toJson.convertTo[JsArray])}")
                             Future(
-                              Right(JsObject(
-                                "rows" -> (rows ++ rows2).toArray.slice(0, limit.get).toJson.convertTo[JsArray])))
+                              Right(
+                                JsObject(
+                                  "rows" -> allrows.toArray
+                                    .slice(0, if (limit.get > 0) limit.get else allrows.length)
+                                    .toJson
+                                    .convertTo[JsArray])))
                           }
                         case _ =>
                           logging.info(
@@ -288,7 +293,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
     val args = Seq[(String, Option[String])](
       "startkey" -> list2OptJson(startKey).map(_.toString),
       "endkey" -> list2OptJson(endKey).map(_.toString),
-      "skip" -> skip.filter(_ > 0).map(_.toString),
+      "skip" -> None,
       "limit" -> limit.filter(_ > 0).map(_.toString),
       "stale" -> stale.value,
       "include_docs" -> bool2OptStr(includeDocs),

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -61,7 +61,7 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
   case class ActivationsDbConfig(useFlexLogic: Boolean)
   private val activationsDbConfig = if (flexDb) loadConfig[ActivationsDbConfig]("whisk.activationsdb").toOption else None
   private val useFlexLogic = activationsDbConfig.exists(_.useFlexLogic)
-  logging.info(this, s"useFlexLogic: $useFlexLogic")
+  if (db.contains("activations")) logging.info(this, s"useFlexActivationsLogic: $useFlexLogic")
   def useFlexActivationsLogic: Boolean = useFlexLogic // use extended flexible activations db logic
 
   private val epochDay: Long = 24 * 60 * 60 * 1000

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -329,10 +329,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     val start = transid.started(this, LoggingMarkers.DATABASE_QUERY, s"[COUNT] '$dbName' searching '$table")
 
     val f = client
-      .executeViewForCount(firstPart, secondPart)(
-        startKey = startKey,
-        endKey = endKey,
-        stale = stale)
+      .executeViewForCount(firstPart, secondPart)(startKey = startKey, endKey = endKey, stale = stale)
       .map {
         case Right(response) =>
           val rows = response.fields("rows").convertTo[List[JsObject]]

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -88,7 +88,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     val docinfoStr = s"id: $id, rev: ${rev.getOrElse("null")}"
     val start = transid.started(this, LoggingMarkers.DATABASE_SAVE, s"[PUT] '$dbName' saving document: '${docinfoStr}'")
 
-    val f = if (useBatching) {
+    val f = if (useBatching && (rev.isEmpty || !dbName.endsWith("activations-"))) { // use batching only for creation of new activations documents
       batcher.put(asJson).map { e =>
         e match {
           case Right(response) =>

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -88,7 +88,8 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     val docinfoStr = s"id: $id, rev: ${rev.getOrElse("null")}"
     val start = transid.started(this, LoggingMarkers.DATABASE_SAVE, s"[PUT] '$dbName' saving document: '${docinfoStr}'")
 
-    val f = if (useBatching && (rev.isEmpty || !dbName.endsWith("activations-"))) { // use batching only for creation of new activations documents
+    val f = if (useBatching && (rev.isEmpty || !client.useFlexDb)) {
+      // for activations db use batching only for creation of new documents to allow look back in previous db
       batcher.put(asJson).map { e =>
         e match {
           case Right(response) =>

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -333,8 +333,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
         startKey = startKey,
         endKey = endKey,
         skip = Some(skip),
-        stale = stale,
-        reduce = true)
+        stale = stale)
       .map {
         case Right(response) =>
           val rows = response.fields("rows").convertTo[List[JsObject]]

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -329,7 +329,12 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     val start = transid.started(this, LoggingMarkers.DATABASE_QUERY, s"[COUNT] '$dbName' searching '$table")
 
     val f = client
-      .executeViewForCount(firstPart, secondPart)(startKey = startKey, endKey = endKey, stale = stale, reduce = true)
+      .executeViewForCount(firstPart, secondPart)(
+        startKey = startKey,
+        endKey = endKey,
+        skip = Some(skip),
+        stale = stale,
+        reduce = true)
       .map {
         case Right(response) =>
           val rows = response.fields("rows").convertTo[List[JsObject]]

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -332,7 +332,6 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
       .executeViewForCount(firstPart, secondPart)(
         startKey = startKey,
         endKey = endKey,
-        skip = Some(skip),
         stale = stale)
       .map {
         case Right(response) =>
@@ -341,8 +340,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
           val out = if (rows.nonEmpty) {
             assert(rows.length == 1, s"result of reduced view contains more than one value: '$rows'")
             val count = rows.head.fields("value").convertTo[Long]
-            // in case of flexible activations db use count as returned
-            if (client.useFlexActivationsLogic) count else if (count > skip) count - skip else 0L
+            if (count > skip) count - skip else 0L
           } else 0L
 
           transid.finished(this, start, s"[COUNT] '$dbName' completed: count $out")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -88,7 +88,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
     val docinfoStr = s"id: $id, rev: ${rev.getOrElse("null")}"
     val start = transid.started(this, LoggingMarkers.DATABASE_SAVE, s"[PUT] '$dbName' saving document: '${docinfoStr}'")
 
-    val f = if (useBatching && (rev.isEmpty || !client.useFlexDb)) {
+    val f = if (useBatching && (rev.isEmpty || !client.useFlexActivationsLogic)) {
       // for activations db use batching only for creation of new documents to allow look back in previous db
       batcher.put(asJson).map { e =>
         e match {
@@ -342,7 +342,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
             assert(rows.length == 1, s"result of reduced view contains more than one value: '$rows'")
             val count = rows.head.fields("value").convertTo[Long]
             // in case of flexible activations db use count as returned
-            if (client.useFlexDb) count else if (count > skip) count - skip else 0L
+            if (client.useFlexActivationsLogic) count else if (count > skip) count - skip else 0L
           } else 0L
 
           transid.finished(this, start, s"[COUNT] '$dbName' completed: count $out")


### PR DESCRIPTION
Make the usage of activations databases flexible.

## Description

This code change enables the controller and invoker to perform CRUD operations (read and update activation document) and view operations (list activations in namespace, list activations matching name in namespace and count activations in namespace) in two databases to ensure that activation documents are accessible for (at least) 24 hours after creation and thereby not relying on activations documents being replicated by means of Cloudant. The change is done within the data store layer. 

The code change was successfully tested using a fully qualified activations database (`PG6#564`), using a not fully qualified activations database but with disabled extended flexible activations database logic (`PG6#565`) and using a not fully qualified activations database and enabled extended flexible activations database logic (`PG2#253`).

<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation
