### PR TITLE
Controller cache invalidation (cont.)

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
@@ -82,6 +82,12 @@ trait DocumentSerializer {
  */
 trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSingleWriterCache[W, DocInfo] {
 
+  val isController = sys.env.get("CONTROLLER_NAME").getOrElse("").equals("controller")
+  val cacheInvalidationEnabled =
+    sys.env.get("CONFIG_whisk_controller_cacheinvalidation_enabled").getOrElse("false").toBoolean
+  // bypass cache for crud action get for cloudant enabled cache invalidation
+  val useCache = isController || !cacheInvalidationEnabled
+
   /**
    * Puts a record of type W in the datastore.
    *

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentFactory.scala
@@ -85,7 +85,7 @@ trait DocumentFactory[W <: DocumentRevisionProvider] extends MultipleReadersSing
   val isController = sys.env.get("CONTROLLER_NAME").getOrElse("").equals("controller")
   val cacheInvalidationEnabled =
     sys.env.get("CONFIG_whisk_controller_cacheinvalidation_enabled").getOrElse("false").toBoolean
-  // bypass cache for crud action get for cloudant enabled cache invalidation
+  // bypass cache for crud operations if cloudant based cache invalidation is enabled
   val useCache = isController || !cacheInvalidationEnabled
 
   /**

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -203,11 +203,15 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
             // a pre-existing owner will take care of the invalidation
             invalidator
         }
+      } andThen {
+        case _ => notifier.foreach(_(key))
       }
-    } else {
-      invalidator // not caching
-    } andThen {
-      case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))
+    }
+    else {
+      // not caching
+      invalidator andThen {
+        case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))
+      }
     }
   }
 
@@ -299,11 +303,15 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
             invalidateEntryAfter(generator, key, actualEntry)
           }
         }
+      } andThen {
+        case _ => notifier.foreach(_(key))
       }
-    } else {
-      generator // not caching
-    } andThen {
-      case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))
+    }
+    else {
+      // not caching
+      generator andThen {
+        case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))
+      }
     }
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -92,6 +92,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
   import MultipleReadersSingleWriterCache._
 
   /** Subclasses: Toggle this to enable/disable caching for your entity type. */
+  protected val cacheChangeNotificationEnabled = true
   protected val cacheEnabled = true
   protected val evictionPolicy: EvictionPolicy = AccessTime
   protected val fixedCacheSize = 0
@@ -202,10 +203,12 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
             // a pre-existing owner will take care of the invalidation
             invalidator
         }
-      } andThen {
-        case _ => notifier.foreach(_(key))
       }
-    } else invalidator // not caching
+    } else {
+      invalidator // not caching
+    } andThen {
+      case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))
+    }
   }
 
   /**
@@ -296,10 +299,12 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
             invalidateEntryAfter(generator, key, actualEntry)
           }
         }
-      } andThen {
-        case _ => notifier.foreach(_(key))
       }
-    } else generator // not caching
+    } else {
+      generator // not caching
+    } andThen {
+      case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))
+    }
   }
 
   def cacheSize: Int = cache.size

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -206,8 +206,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
       } andThen {
         case _ => notifier.foreach(_(key))
       }
-    }
-    else {
+    } else {
       // not caching
       invalidator andThen {
         case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))
@@ -306,8 +305,7 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
       } andThen {
         case _ => notifier.foreach(_(key))
       }
-    }
-    else {
+    } else {
       // not caching
       generator andThen {
         case _ if cacheChangeNotificationEnabled => notifier.foreach(_(key))

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -167,6 +167,8 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
   }
 
   def scheduleCacheInvalidation(): Any = {
+    // do cloudant based cache invalidation only on controller side
+    // as caching is bypassed on crudcontroller side in this case
     if (cacheInvalidationEnabled && isController) {
       Scheduler.scheduleWaitAtMost(
         interval = FiniteDuration(cacheInvalidationPollInterval, TimeUnit.SECONDS),
@@ -178,6 +180,8 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
   }
 
   def ensureInitialSequence(): Future[Unit] = {
+    // do cloudant based cache invalidation only on controller side
+    // as caching is bypassed on crudcontroller side in this case
     if (cacheInvalidationEnabled && isController) {
       dbChanges.ensureInitialSequence()
     } else {
@@ -207,9 +211,9 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
 
     CacheInvalidationMessage.parse(raw) match {
       case Success(msg: CacheInvalidationMessage) => {
-        logging.warn(
-          this,
-          s"@StR msg: $msg, msg.instanceId: ${msg.instanceId}, instanceId: $instanceId, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled")
+        // do kafka based cache invalidation only on controller side if
+        // cloudant based cache invalidation is enabled as caching is bypassed
+        // on crudcontroller side in this case
         if (msg.instanceId != instanceId && (isController || !cacheInvalidationEnabled)) {
           WhiskActionMetaData.removeId(msg.key)
           WhiskAction.removeId(msg.key)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -168,7 +168,7 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
 
   def scheduleCacheInvalidation(): Any = {
     if (cacheInvalidationEnabled && isController) {
-      Scheduler.scheduleWaitAtLeast(
+      Scheduler.scheduleWaitAtMost(
         interval = FiniteDuration(cacheInvalidationPollInterval, TimeUnit.SECONDS),
         initialDelay = FiniteDuration(cacheInvalidationInitDelay, TimeUnit.SECONDS),
         name = "CacheInvalidation") { () =>

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -210,7 +210,7 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
         logging.warn(
           this,
           s"@StR msg: $msg, msg.instanceId: ${msg.instanceId}, instanceId: $instanceId, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled")
-        if (msg.instanceId != instanceId && (isController || !cacheInvalidationEnabled) && false) {
+        if (msg.instanceId != instanceId && (isController || !cacheInvalidationEnabled)) {
           WhiskActionMetaData.removeId(msg.key)
           WhiskAction.removeId(msg.key)
           WhiskPackage.removeId(msg.key)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -128,10 +128,10 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
         .changes()(since = Some(lcus), limit = Some(limit), descending = false)
         .map { resp =>
           val seqs = resp.fields("results").convertTo[List[JsObject]]
-          logging.info(this, s"found ${seqs.length} changes (${seqs.count(_.fields.contains("deleted"))} deletions)")
           if (seqs.length > 0) {
             lcus = resp.fields("last_seq").asInstanceOf[JsString].convertTo[String]
-            logging.info(this, s"new lcus: $lcus")
+            logging.info(this, s"found ${seqs.length} changes (${seqs
+              .count(_.fields.contains("deleted"))} deletions), lcus: $lcus")
           }
           seqs.map(_.fields("id").convertTo[String])
         }
@@ -178,7 +178,7 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
   }
 
   def ensureInitialSequence(): Future[Unit] = {
-    if (cacheInvalidationEnabled) {
+    if (cacheInvalidationEnabled && isController) {
       dbChanges.ensureInitialSequence()
     } else {
       Future.successful(())

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{Logging, PrintStreamLogging, TransactionId}
 import org.apache.openwhisk.core.database.ArtifactStore
 import org.apache.openwhisk.core.database.DocumentFactory
 import org.apache.openwhisk.core.database.CacheChangeNotification
@@ -346,13 +346,19 @@ case class ExecutableWhiskActionMetaData(namespace: EntityPath,
 }
 
 object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[WhiskAction] with DefaultJsonProtocol {
+
   import WhiskActivation.instantSerdes
 
   val execFieldName = "exec"
   val requireWhiskAuthHeader = "x-require-whisk-auth"
 
   override val collectionName = "actions"
-  override val cacheEnabled = true
+  override val cacheEnabled = useCache
+
+  implicit val logging: Logging = new PrintStreamLogging()
+  logging.info(
+    this,
+    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 
   override implicit val serdes = jsonFormat(
     WhiskAction.apply,
@@ -436,7 +442,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           Future.successful(action)
       }
     }
-    super.getWithAttachment(db, doc, rev, fromCache, attachmentHandler, inlineActionCode)
+    super.getWithAttachment(db, doc, rev, fromCache && useCache, attachmentHandler, inlineActionCode)
   }
 
   def attachmentHandler(action: WhiskAction, attached: Attached): WhiskAction = {
@@ -445,6 +451,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
         name == attached.attachmentName,
         s"Attachment name '${attached.attachmentName}' does not match the expected name '$name'")
     }
+
     val eu = action.exec match {
       case exec @ CodeExecAsAttachment(_, Attached(attachmentName, _, _, _), _, _) =>
         checkName(attachmentName)
@@ -555,7 +562,12 @@ object WhiskActionMetaData
   import WhiskActivation.instantSerdes
 
   override val collectionName = "actions"
-  override val cacheEnabled = true
+  override val cacheEnabled = useCache
+
+  implicit val logging: Logging = new PrintStreamLogging()
+  logging.info(
+    this,
+    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 
   override implicit val serdes = jsonFormat(
     WhiskActionMetaData.apply,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -358,7 +358,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
   implicit val logging: Logging = new PrintStreamLogging()
   logging.info(
     this,
-    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
+    s"isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 
   override implicit val serdes = jsonFormat(
     WhiskAction.apply,
@@ -419,6 +419,7 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
     fromCache: Boolean)(implicit transid: TransactionId, mw: Manifest[WhiskAction]): Future[WhiskAction] = {
 
     implicit val ec = db.executionContext
+    implicit val logger = db.logging
 
     val inlineActionCode: WhiskAction => Future[WhiskAction] = { action =>
       def getWithAttachment(attached: Attached, binary: Boolean, exec: AttachedCode) = {
@@ -442,7 +443,8 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           Future.successful(action)
       }
     }
-    super.getWithAttachment(db, doc, rev, fromCache && useCache, attachmentHandler, inlineActionCode)
+    logger.warn(this, s"@StR get fromCache: $fromCache")
+    super.getWithAttachment(db, doc, rev, fromCache, attachmentHandler, inlineActionCode)
   }
 
   def attachmentHandler(action: WhiskAction, attached: Attached): WhiskAction = {
@@ -567,7 +569,7 @@ object WhiskActionMetaData
   implicit val logging: Logging = new PrintStreamLogging()
   logging.info(
     this,
-    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
+    s"isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 
   override implicit val serdes = jsonFormat(
     WhiskActionMetaData.apply,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -419,7 +419,6 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
     fromCache: Boolean)(implicit transid: TransactionId, mw: Manifest[WhiskAction]): Future[WhiskAction] = {
 
     implicit val ec = db.executionContext
-    implicit val logger = db.logging
 
     val inlineActionCode: WhiskAction => Future[WhiskAction] = { action =>
       def getWithAttachment(attached: Attached, binary: Boolean, exec: AttachedCode) = {
@@ -443,7 +442,6 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
           Future.successful(action)
       }
     }
-    logger.warn(this, s"@StR get fromCache: $fromCache")
     super.getWithAttachment(db, doc, rev, fromCache, attachmentHandler, inlineActionCode)
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskActivation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskActivation.scala
@@ -185,6 +185,7 @@ object WhiskActivation
   // Caching activations doesn't make much sense in the common case as usually,
   // an activation is only asked for once.
   override val cacheEnabled = false
+  override val cacheChangeNotificationEnabled = false
 
   /**
    * Queries datastore for activation records which have an entity name matching the

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
@@ -210,7 +210,7 @@ object WhiskPackage
   implicit val logging: Logging = new PrintStreamLogging()
   logging.info(
     this,
-    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
+    s"isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 
 
   lazy val publicPackagesView: View = WhiskQueries.entitiesView(collection = s"$collectionName-public")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
@@ -212,7 +212,6 @@ object WhiskPackage
     this,
     s"isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 
-
   lazy val publicPackagesView: View = WhiskQueries.entitiesView(collection = s"$collectionName-public")
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 import spray.json.DefaultJsonProtocol
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{Logging, PrintStreamLogging, TransactionId}
 import org.apache.openwhisk.core.database.DocumentFactory
 import org.apache.openwhisk.core.entity.types.EntityStore
 
@@ -205,7 +205,13 @@ object WhiskPackage
     jsonFormat8(WhiskPackage.apply)
   }
 
-  override val cacheEnabled = true
+  override val cacheEnabled = useCache
+
+  implicit val logging: Logging = new PrintStreamLogging()
+  logging.info(
+    this,
+    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
+
 
   lazy val publicPackagesView: View = WhiskQueries.entitiesView(collection = s"$collectionName-public")
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskRule.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskRule.scala
@@ -236,6 +236,7 @@ object WhiskRule extends DocumentFactory[WhiskRule] with WhiskEntityQueries[Whis
   }
 
   override val cacheEnabled = false
+  override val cacheChangeNotificationEnabled = false
 }
 
 object WhiskRuleResponse extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskTrigger.scala
@@ -125,7 +125,7 @@ object WhiskTrigger
   implicit val logging: Logging = new PrintStreamLogging()
   logging.info(
     this,
-    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
+    s"isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 }
 
 object WhiskTriggerPut extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskTrigger.scala
@@ -20,6 +20,7 @@ package org.apache.openwhisk.core.entity
 import java.time.Instant
 
 import spray.json.DefaultJsonProtocol
+import org.apache.openwhisk.common.{Logging, PrintStreamLogging}
 import org.apache.openwhisk.core.database.DocumentFactory
 import spray.json._
 
@@ -119,7 +120,12 @@ object WhiskTrigger
   private implicit val fqnSerdesAsDocId = FullyQualifiedEntityName.serdesAsDocId
   override implicit val serdes = jsonFormat9(WhiskTrigger.apply)
 
-  override val cacheEnabled = true
+  override val cacheEnabled = useCache
+
+  implicit val logging: Logging = new PrintStreamLogging()
+  logging.info(
+    this,
+    s"cacheEnabled: $cacheEnabled, isController: $isController, cacheInvalidationEnabled: $cacheInvalidationEnabled, useCache: $useCache, cacheChangeNotificationEnabled: $cacheChangeNotificationEnabled")
 }
 
 object WhiskTriggerPut extends DefaultJsonProtocol {


### PR DESCRIPTION
Controller cache invalidation (cont.)

## Description
Current implementation invalidate caches between controllers on updating the cache on one of the controllers and informing the other controller in the same cluster about the change using Kafka.
This PR adds the ability to invalidate caches between controllers on different clusters using CouchDB. If configured controllers are polling the `/db/_changes` resource and based on the list of changes made to documents in the database updates its caches accordingly. This will be done only on the controller side. For the crudcontroller caching is bypassed if CouchDB based cache invalidation is active.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

