### PR TITLE
[Scala] Fix compile warnings

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -28,7 +28,6 @@ import akka.util.ByteString
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.core.entity.UUIDs
 import org.apache.openwhisk.http.PoolingRestClient
 import org.apache.openwhisk.http.PoolingRestClient._
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -68,7 +68,7 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
   private val cacheInvalidationProducer = msgProvider.getProducer(config)
 
   // config for controller cache invalidation
-  final case class CacheInvalidationConfig(enabled: Boolean,
+  case class CacheInvalidationConfig(enabled: Boolean,
                                            initDelay: Int,
                                            pollInterval: Int,
                                            pageSize: Int,

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
@@ -207,7 +207,7 @@ object BasicHttpService {
     RejectionHandler.default.mapRejectionResponse {
       case res @ HttpResponse(_, _, ent: HttpEntity.Strict, _) =>
         val error = ErrorResponse(ent.data.utf8String, transid).toJson
-        res.copy(entity = HttpEntity(ContentTypes.`application/json`, error.compactPrint))
+        res.withEntity(HttpEntity(ContentTypes.`application/json`, error.compactPrint))
       case x => x
     }
   }

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/OpenWhiskEvents.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/OpenWhiskEvents.scala
@@ -54,7 +54,7 @@ object OpenWhiskEvents extends SLF4JLogging {
     }
     val port = metricConfig.port
     val api = new PrometheusEventsApi(eventConsumer, prometheusRecorder)
-    val httpBinding = Http().bindAndHandle(api.routes, "0.0.0.0", port)
+    val httpBinding = Http().newServerAt("0.0.0.0", port).bindFlow(api.routes)
     httpBinding.foreach(_ => log.info(s"Started the http server on http://localhost:$port"))(system.dispatcher)
     httpBinding
   }

--- a/tests/src/test/scala/org/apache/openwhisk/common/PrometheusTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/PrometheusTests.scala
@@ -16,7 +16,7 @@
  */
 
 package org.apache.openwhisk.common
-import akka.http.scaladsl.coding.Gzip
+import akka.http.scaladsl.coding.Coders
 import akka.http.scaladsl.model.{HttpCharsets, HttpResponse}
 import akka.http.scaladsl.model.headers.HttpEncodings.gzip
 import akka.http.scaladsl.model.headers.{`Accept-Encoding`, `Content-Encoding`, HttpEncoding, HttpEncodings}
@@ -65,7 +65,7 @@ class PrometheusTests extends FlatSpec with Matchers with ScalatestRouteTest wit
       contentType.mediaType.params("version") shouldBe "0.0.4"
       response should haveContentEncoding(gzip)
 
-      val responseText = Unmarshal(Gzip.decodeMessage(response)).to[String].futureValue
+      val responseText = Unmarshal(Coders.Gzip.decodeMessage(response)).to[String].futureValue
       withClue(responseText) {
         responseText should include("foo_bar")
       }

--- a/tests/src/test/scala/org/apache/openwhisk/test/http/RESTProxy.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/test/http/RESTProxy.scala
@@ -80,7 +80,7 @@ class RESTProxy(val host: String, val port: Int)(val serviceAuthority: Uri.Autho
       implicit val m = ActorMaterializer()
       materializer = Some(m)
       log.debug(s"[RESTProxy] Binding to '$host:$port'.")
-      val b = Await.result(Http().bindAndHandle(mkRequestFlow(m), host, port), 5.seconds)
+      val b = Await.result(Http().newServerAt(host, port).bindFlow(mkRequestFlow(m)), 5.seconds)
       binding = Some(b)
     }
   }
@@ -128,7 +128,7 @@ class RESTProxy(val host: String, val port: Int)(val serviceAuthority: Uri.Autho
         }
 
         // akka-http doesn't like us to set those headers ourselves.
-        val upstreamRequest = request.copy(headers = request.headers.filter(_ match {
+        val upstreamRequest = request.withHeaders(headers = request.headers.filter(_ match {
           case `Timeout-Access`(_) => false
           case _                   => true
         }))


### PR DESCRIPTION
Fix Scala compile deprecation warnings:

## Description

[2022-03-14T20:56:13.947Z] > Task :common:scala:compileScala
[2022-03-14T20:56:13.947Z] Pruning sources from previous analysis, due to incompatible CompileSetup.
[2022-03-14T20:56:37.826Z] /home/cusina/workspace/Playground2-Fyre/open/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala:31: Unused import
[2022-03-14T20:56:37.826Z] import org.apache.openwhisk.core.entity.UUIDs
[2022-03-14T20:56:37.826Z]                                         ^
[2022-03-14T20:57:11.270Z] /home/cusina/workspace/Playground2-Fyre/open/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala:71: The outer reference in this type test cannot be checked at run time.
[2022-03-14T20:57:11.270Z]   final case class CacheInvalidationConfig(enabled: Boolean,

[2022-03-14T21:00:15.617Z] /home/cusina/workspace/Playground2-Fyre/open/tests/src/test/scala/org/apache/openwhisk/common/PrometheusTests.scala:68: object Gzip in package coding is deprecated (since 10.2.0): Actual implementation of Gzip is internal API, use Coders.Gzip instead
[2022-03-14T21:00:15.617Z]       val responseText = Unmarshal(Gzip.decodeMessage(response)).to[String].futureValue
[2022-03-14T21:00:15.617Z]                                    ^
[2022-03-14T21:00:16.426Z] /home/cusina/workspace/Playground2-Fyre/open/tests/src/test/scala/org/apache/openwhisk/test/http/RESTProxy.scala:83: method bindAndHandle in class HttpExt is deprecated (since 10.2.0): Use Http().newServerAt(...)...bindFlow() to create server bindings.
[2022-03-14T21:00:16.426Z]       val b = Await.result(Http().bindAndHandle(mkRequestFlow(m), host, port), 5.seconds)
[2022-03-14T21:00:16.426Z]                                   ^
[2022-03-14T21:00:16.426Z] /home/cusina/workspace/Playground2-Fyre/open/tests/src/test/scala/org/apache/openwhisk/test/http/RESTProxy.scala:131: method copy in class HttpRequest is deprecated (since 10.2.0): Use the `withXYZ` methods instead. Kept for binary compatibility
[2022-03-14T21:00:16.427Z]         val upstreamRequest = request.copy(headers = request.headers.filter(_ match {

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

