### PR TITLE
Consider disk pressure in ping protocol

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -254,13 +254,13 @@ object AcknowledegmentMessage extends DefaultJsonProtocol {
   }
 }
 
-case class PingMessage(instance: InvokerInstanceId, isBlacklisted: Boolean = false) extends Message {
+case class PingMessage(instance: InvokerInstanceId, isBlacklisted: Boolean = false, hasDiskPressure: Boolean = false, rootfspcent: Int = -1, logsfspcent: Int = -1) extends Message {
   override def serialize = PingMessage.serdes.write(this).compactPrint
 }
 
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
-  implicit val serdes = jsonFormat(PingMessage.apply, "name", "isBlacklisted")
+  implicit val serdes = jsonFormat(PingMessage.apply, "name", "isBlacklisted", "hasDiskPressure", "rootfspcent", "logsfspcent")
 }
 
 trait EventMessageBody extends Message {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -69,7 +69,7 @@ object InvokerState {
       extends Unusable {
     val DOWN = "down"
     val asString =
-      if (isBlacklisted) s"$DOWN/disabled($rootfspcent,$logsfspcent,${System.currentTimeMillis})"
+      if (isBlacklisted) s"$DOWN/disabled(${System.currentTimeMillis})"
       else if (hasDiskPressure) s"$DOWN/diskpressure($rootfspcent,$logsfspcent,${System.currentTimeMillis})"
       else DOWN
     def canEqual(a: Any) = a.isInstanceOf[InvokerState]

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -78,7 +78,7 @@ object InvokerState {
         case that: InvokerState => that.asString.startsWith(DOWN)
         case _                  => false
       }
-    override def hashCode = DOWN.hashCode
+    override def hashCode = s"${isUsable}.$DOWN".hashCode
   }
 }
 // Possible answers of an activation

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -78,7 +78,7 @@ object InvokerState {
         case that: InvokerState => that.asString.startsWith(DOWN)
         case _                  => false
       }
-    override def hashCode = s"${isUsable}.$DOWN".hashCode
+    override def hashCode = s"$isUsable.$DOWN".hashCode
   }
 }
 // Possible answers of an activation

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -193,7 +193,7 @@ class ShardingContainerPoolBalancer(
     MetricEmitter.emitGaugeMetric(
       UNRESPONSIVE_INVOKER_MANAGED,
       schedulingState.managedInvokers.count(_.status == Unresponsive))
-    MetricEmitter.emitGaugeMetric(OFFLINE_INVOKER_MANAGED, schedulingState.managedInvokers.count(_.status == Offline))
+    MetricEmitter.emitGaugeMetric(OFFLINE_INVOKER_MANAGED, schedulingState.managedInvokers.count(_.status == Offline()))
     MetricEmitter.emitGaugeMetric(HEALTHY_INVOKER_BLACKBOX, schedulingState.blackboxInvokers.count(_.status == Healthy))
     MetricEmitter.emitGaugeMetric(
       UNHEALTHY_INVOKER_BLACKBOX,
@@ -201,7 +201,7 @@ class ShardingContainerPoolBalancer(
     MetricEmitter.emitGaugeMetric(
       UNRESPONSIVE_INVOKER_BLACKBOX,
       schedulingState.blackboxInvokers.count(_.status == Unresponsive))
-    MetricEmitter.emitGaugeMetric(OFFLINE_INVOKER_BLACKBOX, schedulingState.blackboxInvokers.count(_.status == Offline))
+    MetricEmitter.emitGaugeMetric(OFFLINE_INVOKER_BLACKBOX, schedulingState.blackboxInvokers.count(_.status == Offline()))
   }
 
   /** State needed for scheduling. */

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -365,9 +365,11 @@ class InvokerReactive(
       .send(
         "health",
         PingMessage(
-          instance,
-          namespaceBlacklist
-            .isBlacklisted(instance.displayedName.getOrElse("")) || rootfspcent >= 85 || logsfspcent >= 85))
+          instance = instance,
+          isBlacklisted = namespaceBlacklist.isBlacklisted(instance.displayedName.getOrElse("")),
+          hasDiskPressure = rootfspcent >= 85 || logsfspcent >= 85,
+          rootfspcent = rootfspcent,
+          logsfspcent = logsfspcent))
       .andThen {
         case Failure(t) => logging.error(this, s"failed to ping the controller: $t")
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -121,7 +121,7 @@ class InvokerSupervisionTests
       invoker5.expectMsg(ping0)
 
       invoker5.send(supervisor, CurrentState(invoker5.ref, Healthy))
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Offline, Offline, Offline, Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Offline(), Offline(), Offline(), Healthy))
 
       // create second invoker
       val ping1 = PingMessage(invoker2Instance)
@@ -130,17 +130,17 @@ class InvokerSupervisionTests
       invoker2.expectMsg(ping1)
 
       invoker2.send(supervisor, CurrentState(invoker2.ref, Healthy))
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Healthy, Offline, Offline, Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Healthy, Offline(), Offline(), Healthy))
 
       // ping the first invoker again
       supervisor ! ping0
       invoker5.expectMsg(ping0)
 
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Healthy, Offline, Offline, Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Healthy, Offline(), Offline(), Healthy))
 
       // one invoker goes offline
-      invoker2.send(supervisor, Transition(invoker2.ref, Healthy, Offline))
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline, Offline, Offline, Offline, Offline, Healthy))
+      invoker2.send(supervisor, Transition(invoker2.ref, Healthy, Offline()))
+      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Offline(), Offline(), Offline(), Healthy))
     }
   }
 
@@ -218,10 +218,10 @@ class InvokerSupervisionTests
       pool.send(invoker, SubscribeTransitionCallBack(pool.ref))
       pool.expectMsg(CurrentState(invoker, Unhealthy))
       timeout(invoker)
-      pool.expectMsg(Transition(invoker, Unhealthy, Offline))
+      pool.expectMsg(Transition(invoker, Unhealthy, Offline()))
 
       invoker ! PingMessage(InvokerInstanceId(0, userMemory = defaultUserMemory))
-      pool.expectMsg(Transition(invoker, Offline, Unhealthy))
+      pool.expectMsg(Transition(invoker, Offline(), Unhealthy))
     }
   }
 
@@ -310,10 +310,10 @@ class InvokerSupervisionTests
       pool.expectMsg(CurrentState(invoker, Unhealthy))
 
       timeout(invoker)
-      pool.expectMsg(Transition(invoker, Unhealthy, Offline))
+      pool.expectMsg(Transition(invoker, Unhealthy, Offline()))
 
       invoker ! PingMessage(InvokerInstanceId(0, userMemory = defaultUserMemory))
-      pool.expectMsg(Transition(invoker, Offline, Unhealthy))
+      pool.expectMsg(Transition(invoker, Offline(), Unhealthy))
     }
   }
 
@@ -355,7 +355,7 @@ class InvokerSupervisionTests
       invoker0.expectMsgType[SubscribeTransitionCallBack]
       invoker0.expectMsg(ping)
 
-      allStates(supervisor) shouldBe IndexedSeq(new InvokerHealth(invokerInstance, Offline))
+      allStates(supervisor) shouldBe IndexedSeq(new InvokerHealth(invokerInstance, Offline()))
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -90,7 +90,7 @@ class ShardingContainerPoolBalancerTests
   def healthy(i: Int, memory: ByteSize = defaultUserMemory) =
     new InvokerHealth(InvokerInstanceId(i, userMemory = memory), Healthy)
   def unhealthy(i: Int) = new InvokerHealth(InvokerInstanceId(i, userMemory = defaultUserMemory), Unhealthy)
-  def offline(i: Int) = new InvokerHealth(InvokerInstanceId(i, userMemory = defaultUserMemory), Offline)
+  def offline(i: Int) = new InvokerHealth(InvokerInstanceId(i, userMemory = defaultUserMemory), Offline())
 
   def semaphores(count: Int, max: Int): IndexedSeq[NestedSemaphore[FullyQualifiedEntityName]] =
     IndexedSeq.fill(count)(new NestedSemaphore[FullyQualifiedEntityName](max))


### PR DESCRIPTION
Transport disk pressure info in ping protocol and extend `Offline` invoker state (if applicable) by substate, timestamp at which state changed and details about the disk space used in case of disk pressure.

## Description

For `Offline` invoker state the `varz` endpoint will show the following info depending on whether the invoker is disabled, has disk pressure or is offline because of other reasons (e.g. state timeout).

```
{"invoker2/10.x/invoker-xxxxx":"down"}
{"invoker2/10.x/invoker-xxxxx":"down/disabled(1648713488516)"}
{"invoker2/10.x/invoker-xxxxx":"down/diskpressure(43,91,1648713488516)"}
```
 
## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation