### PR TITLE
Correct Scala format error in test class

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -121,7 +121,8 @@ class InvokerSupervisionTests
       invoker5.expectMsg(ping0)
 
       invoker5.send(supervisor, CurrentState(invoker5.ref, Healthy))
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Offline(), Offline(), Offline(), Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(
+        IndexedSeq(Offline(), Offline(), Offline(), Offline(), Offline(), Healthy))
 
       // create second invoker
       val ping1 = PingMessage(invoker2Instance)
@@ -130,17 +131,20 @@ class InvokerSupervisionTests
       invoker2.expectMsg(ping1)
 
       invoker2.send(supervisor, CurrentState(invoker2.ref, Healthy))
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Healthy, Offline(), Offline(), Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(
+        IndexedSeq(Offline(), Offline(), Healthy, Offline(), Offline(), Healthy))
 
       // ping the first invoker again
       supervisor ! ping0
       invoker5.expectMsg(ping0)
 
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Healthy, Offline(), Offline(), Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(
+        IndexedSeq(Offline(), Offline(), Healthy, Offline(), Offline(), Healthy))
 
       // one invoker goes offline
       invoker2.send(supervisor, Transition(invoker2.ref, Healthy, Offline()))
-      allStates(supervisor) shouldBe zipWithInstance(IndexedSeq(Offline(), Offline(), Offline(), Offline(), Offline(), Healthy))
+      allStates(supervisor) shouldBe zipWithInstance(
+        IndexedSeq(Offline(), Offline(), Offline(), Offline(), Offline(), Healthy))
     }
   }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
This is to fix an incorrectly formatted Scala test file (InvokerSupervisionTests.scala``).
## Description
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':bluemix:tests:checkTestScalafmt'.
> Files incorrectly formatted: /home/travis/build/BlueMix-Fabric/bluewhisk/open/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala

```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

