### PR TITLE
Correct Scala format error in  class (cont.)

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -254,13 +254,19 @@ object AcknowledegmentMessage extends DefaultJsonProtocol {
   }
 }
 
-case class PingMessage(instance: InvokerInstanceId, isBlacklisted: Boolean = false, hasDiskPressure: Boolean = false, rootfspcent: Int = -1, logsfspcent: Int = -1) extends Message {
+case class PingMessage(instance: InvokerInstanceId,
+                       isBlacklisted: Boolean = false,
+                       hasDiskPressure: Boolean = false,
+                       rootfspcent: Int = -1,
+                       logsfspcent: Int = -1)
+    extends Message {
   override def serialize = PingMessage.serdes.write(this).compactPrint
 }
 
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
-  implicit val serdes = jsonFormat(PingMessage.apply, "name", "isBlacklisted", "hasDiskPressure", "rootfspcent", "logsfspcent")
+  implicit val serdes =
+    jsonFormat(PingMessage.apply, "name", "isBlacklisted", "hasDiskPressure", "rootfspcent", "logsfspcent")
 }
 
 trait EventMessageBody extends Message {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
This is to fix an incorrectly formatted Scala file (`Message.scala`).
## Description
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':common:scala:checkScalafmt'.
> Files incorrectly formatted: /home/travis/build/BlueMix-Fabric/bluewhisk/open/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

