### PR TITLE
Always calculate half of the capacity (cont.)

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -586,6 +586,7 @@ case class ShardingContainerPoolBalancerState(
     if (clusterSize != actualSize) {
       val oldSize = clusterSize
       _clusterSize = actualSize
+      // we now keep cluster state (invoker slots) in case of a cluster change
       //_invokerSlots = _invokers.map { invoker =>
       //  new NestedSemaphore[FullyQualifiedEntityName](getInvokerSlot(invoker.id.userMemory).toMB.toInt)
       //}

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -306,7 +306,7 @@ class ShardingContainerPoolBalancer(
             s"mem limit ${memoryLimit.megabytes} MB (${memoryLimitInfo}), " +
             s"time limit ${timeLimit.duration.toMillis} ms (${timeLimitInfo}) " +
             s"to ${invoker} " +
-            s"(${schedulingState.invokerSlots(invoker.instance).availablePermits} of ${invoker.userMemory.toMB / schedulingState.clusterSize} MB free)")
+            s"(${schedulingState.invokerSlots(invoker.instance).availablePermits} of ${invoker.userMemory.toMB / (schedulingState.clusterSize max 2)} MB free)")
         val activationResult = setupActivation(msg, action, invoker)
         sendActivationToInvoker(messageProducer, msg, invoker).map(_ => activationResult)
       }
@@ -506,12 +506,12 @@ case class ShardingContainerPoolBalancerState(
    * @return calculated invoker slot
    */
   private def getInvokerSlot(memory: ByteSize): ByteSize = {
-    val invokerShardMemorySize = memory / (_clusterSize max 2) // if cluster size < 2 calculate half of the invoker capacity anyway
+    val invokerShardMemorySize = memory / (clusterSize max 2) // if cluster size < 2 calculate half of the invoker capacity anyway
     val newTreshold = if (invokerShardMemorySize < MemoryLimit.MIN_MEMORY) {
       logging.error(
         this,
         s"registered controllers: calculated controller's invoker shard memory size falls below the min memory of one action. "
-          + s"Setting to min memory. Expect invoker overloads. Cluster size ${_clusterSize}, invoker user memory size ${memory.toMB.MB}, "
+          + s"Setting to min memory. Expect invoker overloads. Cluster size ${clusterSize}, invoker user memory size ${memory.toMB.MB}, "
           + s"min action memory size ${MemoryLimit.MIN_MEMORY.toMB.MB}, calculated shard size ${invokerShardMemorySize.toMB.MB}.")(
         TransactionId.loadbalancer)
       MemoryLimit.MIN_MEMORY
@@ -574,7 +574,7 @@ case class ShardingContainerPoolBalancerState(
   }
 
   /**
-   * Updates the size of a cluster. Throws away all state for simplicity.
+   * Do not updates the size of a cluster and especially do not throws away all state for simplicity.
    *
    * This is okay to not happen atomically, since a dirty read of the values set are not dangerous. At worst the
    * scheduler works on outdated invoker-load data which is acceptable.
@@ -583,16 +583,18 @@ case class ShardingContainerPoolBalancerState(
    */
   def updateCluster(newSize: Int): Unit = {
     val actualSize = newSize max 1 // if a cluster size < 1 is reported, falls back to a size of 1 (alone)
-    if (_clusterSize != actualSize) {
-      val oldSize = _clusterSize
+    if (clusterSize != actualSize) {
+      val oldSize = clusterSize
       _clusterSize = actualSize
-      _invokerSlots = _invokers.map { invoker =>
-        new NestedSemaphore[FullyQualifiedEntityName](getInvokerSlot(invoker.id.userMemory).toMB.toInt)
-      }
+      //_invokerSlots = _invokers.map { invoker =>
+      //  new NestedSemaphore[FullyQualifiedEntityName](getInvokerSlot(invoker.id.userMemory).toMB.toInt)
+      //}
       // Directly after startup, no invokers have registered yet. This needs to be handled gracefully.
       val invokerCount = _invokers.size
       val totalInvokerMemory =
         _invokers.foldLeft(0L)((total, invoker) => total + getInvokerSlot(invoker.id.userMemory).toMB).MB
+      val availableInvokerMemory =
+        _invokers.foldLeft(0L)((available, invoker) => available + _invokerSlots(invoker.id.instance).availablePermits)
       val averageInvokerMemory =
         if (totalInvokerMemory.toMB > 0 && invokerCount > 0) {
           (totalInvokerMemory / invokerCount).toMB.MB
@@ -601,7 +603,9 @@ case class ShardingContainerPoolBalancerState(
         }
       logging.info(
         this,
-        s"loadbalancer cluster size changed from $oldSize to $actualSize active nodes. ${invokerCount} invokers with ${averageInvokerMemory} average memory size - total invoker memory ${totalInvokerMemory}.")(
+        s"loadbalancer cluster size changed from $oldSize to $actualSize active nodes. " +
+          s"${invokerCount} invokers with ${averageInvokerMemory} average memory size - " +
+          s"total invoker memory ${totalInvokerMemory} - available memory ${availableInvokerMemory} MB.")(
         TransactionId.loadbalancer)
     }
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -212,8 +212,12 @@ class ShardingContainerPoolBalancerTests
     state.invokerSlots(1).availablePermits shouldBe memory.toMB * 2 / 2 - memoryPerSlot.toMB
 
     state.updateCluster(2)
-    state.invokerSlots.head.availablePermits shouldBe memory.toMB / 2 // state reset + divided by 2
-    state.invokerSlots(1).availablePermits shouldBe memory.toMB
+    // org.scalatest.exceptions.TestFailedException: 512 was not equal to 640
+    // adapt test to changed behaviour (no state reset)
+    state.invokerSlots.head.availablePermits shouldBe (memory / 2 - memoryPerSlot).toMB
+    //state.invokerSlots.head.availablePermits shouldBe memory.toMB / 2 // state reset + divided by 2
+    state.invokerSlots(1).availablePermits shouldBe memory.toMB * 2 / 2 - memoryPerSlot.toMB
+    //state.invokerSlots(1).availablePermits shouldBe memory.toMB
   }
 
   it should "fallback to a size of 1 (alone) if cluster size is < 1" in {
@@ -246,7 +250,10 @@ class ShardingContainerPoolBalancerTests
 
     state.updateCluster(20)
 
-    state.invokerSlots.head.availablePermits shouldBe MemoryLimit.MIN_MEMORY.toMB
+    // org.scalatest.exceptions.TestFailedException: 640 was not equal to 128
+    // adapt test to changed behaviour (no state reset)
+    state.invokerSlots.head.availablePermits shouldBe memory.toMB / 2
+    //state.invokerSlots.head.availablePermits shouldBe MemoryLimit.MIN_MEMORY.toMB
   }
   val namespace = EntityPath("testspace")
   val name = EntityName("testname")


### PR DESCRIPTION
Consider always half the invoker slot capacity

## Description
Consider only half of the invoker slot capacity also if akka cluster is temporary fallen apart (split brain). Intention is to avoid that both controller work with the full invoker capacity in case of a split brain situation which leads to invoker overloads (rescheduling run messages).

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation