### PR TITLE
[Scala] Fix compile warnings

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -28,7 +28,6 @@ import akka.util.ByteString
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.core.entity.UUIDs
 import org.apache.openwhisk.http.PoolingRestClient
 import org.apache.openwhisk.http.PoolingRestClient._
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -68,11 +68,7 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
   private val cacheInvalidationProducer = msgProvider.getProducer(config)
 
   // config for controller cache invalidation
-  final case class CacheInvalidationConfig(enabled: Boolean,
-                                           initDelay: Int,
-                                           pollInterval: Int,
-                                           pageSize: Int,
-                                           maxPages: Int)
+  case class CacheInvalidationConfig(enabled: Boolean, initDelay: Int, pollInterval: Int, pageSize: Int, maxPages: Int)
   private val isController = sys.env.get("CONTROLLER_NAME").getOrElse("").equals("controller")
   private val cacheInvalidationConfigNamespace = "whisk.controller.cacheinvalidation"
   private val cacheInvalidationConfig = loadConfig[CacheInvalidationConfig](cacheInvalidationConfigNamespace).toOption


### PR DESCRIPTION
Fix Scala compile deprecation warnings:

## Description

```
[2022-03-14T20:56:13.947Z] > Task :common:scala:compileScala
[2022-03-14T20:56:13.947Z] Pruning sources from previous analysis, due to incompatible CompileSetup.
[2022-03-14T20:56:37.826Z] /home/cusina/workspace/Playground2-Fyre/
open/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala:31: 
Unused import
[2022-03-14T20:56:37.826Z] import org.apache.openwhisk.core.entity.UUIDs
[2022-03-14T20:56:37.826Z]                                         ^
[2022-03-14T20:57:11.270Z] /home/cusina/workspace/Playground2-Fyre/
open/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala:71: 
The outer reference in this type test cannot be checked at run time.
[2022-03-14T20:57:11.270Z]   final case class CacheInvalidationConfig(enabled: Boolean,
```

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

