### PR TITLE
change base image to ibm-semeru-runtimes:open-8u332-b09-jdk-focal

### DIFF
--- a/common/scala/Dockerfile
+++ b/common/scala/Dockerfile
@@ -15,18 +15,17 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8-openj9:x86_64-alpine-jdk8u332-b09_openj9-0.32.0
+FROM ibm-semeru-runtimes:open-8u332-b09-jdk-focal
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-# get latest certificates for https
-RUN apk add --update ca-certificates
-
-# Switch to the HTTPS endpoint for the apk repositories as per https://github.com/gliderlabs/docker-alpine/issues/184
-RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
-
-RUN apk add --update sed curl bash && apk update && apk upgrade
+RUN apt update &&\
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    apt upgrade -y --no-install-recommends && \
+    apt install -y ca-certificates curl && \
+    # Cleanup apt data, we do not need them later on.
+    apt clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /logs
 

--- a/core/controller/Dockerfile
+++ b/core/controller/Dockerfile
@@ -30,7 +30,11 @@ ENV SWAGGER_UI_DOWNLOAD_SHA256=3d7ef5ddc59e10f132fe99771498f0f1ba7a2cbfb9585f986
 # If this cannot be guaranteed, set `invoker_use_runc: false` in the ansible env.
 ENV DOCKER_VERSION=18.06.3-ce
 
-RUN apk add --update openssl
+RUN apt update &&\
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    apt upgrade -y --no-install-recommends && \
+    apt install -y \
+     openssl
 
 # Uncomment to fetch latest version of docker instead: RUN wget -qO- https://get.docker.com | sh
 # Install docker client
@@ -55,8 +59,8 @@ ADD build/distributions/controller.tar /
 
 COPY init.sh /
 RUN chmod +x init.sh
+RUN adduser --disabled-password --uid ${UID} --home /home/${NOT_ROOT_USER} --shell /bin/bash ${NOT_ROOT_USER}
 
-RUN adduser -D -u ${UID} -h /home/${NOT_ROOT_USER} -s /bin/bash ${NOT_ROOT_USER}
 
 # It is possible to run as non root if you dont need invoker capabilities out of the controller today
 # When running it as a non-root user this has implications on the standard directory where runc stores its data.

--- a/core/cosmosdb/cache-invalidator/Dockerfile
+++ b/core/cosmosdb/cache-invalidator/Dockerfile
@@ -27,7 +27,7 @@ ADD build/distributions/cache-invalidator.tar /
 COPY init.sh /
 RUN chmod +x init.sh
 
-RUN adduser -D -u ${UID} -h /home/${NOT_ROOT_USER} -s /bin/bash ${NOT_ROOT_USER}
+RUN adduser --disabled-password --uid ${UID} --home /home/${NOT_ROOT_USER} --shell /bin/bash ${NOT_ROOT_USER}
 USER ${NOT_ROOT_USER}
 
 EXPOSE 8080

--- a/core/invoker/Dockerfile
+++ b/core/invoker/Dockerfile
@@ -25,8 +25,11 @@ ENV UID=1001 \
 # If this cannot be guaranteed, set `invoker_use_runc: false` in the ansible env.
 
 
-RUN apk add --update openssl
-
+RUN apt update &&\
+    # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
+    apt upgrade -y --no-install-recommends && \
+    apt install -y \
+     openssl
 # Uncomment to fetch latest version of docker instead: RUN wget -qO- https://get.docker.com | sh
 # Install docker client
 RUN curl -sSL -o docker-${DOCKER_VERSION}.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
@@ -43,7 +46,7 @@ RUN chmod +x init.sh
 
 # When running the invoker as a non-root user this has implications on the standard directory where runc stores its data.
 # The non-root user should have access on the directory and corresponding permission to make changes on it.
-RUN adduser -D -u ${UID} -h /home/${NOT_ROOT_USER} -s /bin/bash ${NOT_ROOT_USER}
+RUN adduser --disabled-password --uid ${UID} --home /home/${NOT_ROOT_USER} --shell /bin/bash ${NOT_ROOT_USER}
 
 EXPOSE 8080
 CMD ["./init.sh", "0"]

--- a/core/monitoring/user-events/Dockerfile
+++ b/core/monitoring/user-events/Dockerfile
@@ -26,7 +26,7 @@ ADD build/distributions/user-events.tar /
 COPY init.sh /
 RUN chmod +x init.sh
 
-RUN adduser -D -u ${UID} -h /home/${NOT_ROOT_USER} -s /bin/bash ${NOT_ROOT_USER}
+RUN adduser --disabled-password --uid ${UID} --home /home/${NOT_ROOT_USER} --shell /bin/bash ${NOT_ROOT_USER}
 USER ${NOT_ROOT_USER}
 
 # Prometheus port


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Given AdoptOpenJDK is deprecated,
we want to move to IBM Semeru Runtime Open Edition OpenJ9 images.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

