### PR TITLE
Allow OPTIONS response on web actions before checking for authentication

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
@@ -474,7 +474,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
           m(s"$testRoutePath/${path}.json") ~> addHeader("X-Require-Whisk-Auth", requireAuthenticationKey + "-bad") ~> Route
             .seal(routes(creds)) ~> check {
             if (m == Options) {
-              status should be(OK)
+              status should be(OK) // options should always respond
             } else {
               status should be(Unauthorized)
             }
@@ -483,7 +483,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
           // web action require-whisk-auth is set, but the header X-Require-Whisk-Auth value is not set
           m(s"$testRoutePath/${path}.json") ~> Route.seal(routes(creds)) ~> check {
             if (m == Options) {
-              status should be(OK)
+              status should be(OK) // options should always respond
             } else {
               status should be(Unauthorized)
             }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
@@ -473,12 +473,20 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
           // web action require-whisk-auth is set, but the header X-Require-Whisk-Auth value does not match
           m(s"$testRoutePath/${path}.json") ~> addHeader("X-Require-Whisk-Auth", requireAuthenticationKey + "-bad") ~> Route
             .seal(routes(creds)) ~> check {
-            status should be(Unauthorized)
+            if (m == Options) {
+              status should be(OK)
+            } else {
+              status should be(Unauthorized)
+            }
           }
         } else {
           // web action require-whisk-auth is set, but the header X-Require-Whisk-Auth value is not set
           m(s"$testRoutePath/${path}.json") ~> Route.seal(routes(creds)) ~> check {
-            status should be(Unauthorized)
+            if (m == Options) {
+              status should be(OK)
+            } else {
+              status should be(Unauthorized)
+            }
           }
         }
       }


### PR DESCRIPTION
Consider always half the invoker slot capacity

## Description
This patch fixes a bug whereby webactions cannot respond to OPTIONS even for default CORS responses because the handler check for authentication first, before checking if the requests if an OPTIONS request.

Actions which respond to OPTIONS explicitly will be invoked even if not authenticated yet but this should be acceptable since the action cannot respond to OPTIONS otherwise.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).
