### PR TITLE
Revert validate PUT payload for unexpected fields

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -108,9 +108,6 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
   /** JSON response formatter. */
   import RestApiCommons.jsonDefaultResponsePrinter
 
-  /** Allowed action request payload field names. */
-  protected[core] val ALLOWED_FIELDS = classOf[WhiskAction].getDeclaredFields.map(_.getName).toList ++ List("name")
-
   /**
    * Handles operations on action resources, which encompass these cases:
    *
@@ -207,33 +204,19 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
    */
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
-      //logging.debug(this, "checking if sequence components are accessible")
-      entity(as[Option[JsObject]]) { payload =>
-        val invalidFields = payload
-          .map(_.fields.keySet.filter(key => !ALLOWED_FIELDS.contains(key)))
-          .getOrElse(List())
+      entity(as[WhiskActionPut]) { content =>
+        val request = content.resolve(user.namespace)
+        val checkAdditionalPrivileges = entitleReferencedEntities(user, Privilege.READ, request.exec).flatMap {
+          case _ => entitlementProvider.check(user, content.exec)
+        }
 
-        if (invalidFields.isEmpty) {
-          entity(as[WhiskActionPut]) { content =>
-            val request = content.resolve(user.namespace)
-            val checkAdditionalPrivileges = entitleReferencedEntities(user, Privilege.READ, request.exec).flatMap {
-              case _ => entitlementProvider.check(user, content.exec)
-            }
-
-            onComplete(checkAdditionalPrivileges) {
-              case Success(_) =>
-                putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite, update(user, request) _, () => {
-                  make(user, entityName, request)
-                })
-              case Failure(f) =>
-                super.handleEntitlementFailure(f)
-            }
-          }
-        } else {
-          logging.error(
-            this,
-            s"[PUT] rejected because of ${invalidFields.size} invalid fields in request payload: ${invalidFields.head}")
-          terminate(BadRequest, Messages.errorExtractingRequestBody)
+        onComplete(checkAdditionalPrivileges) {
+          case Success(_) =>
+            putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite, update(user, request) _, () => {
+              make(user, entityName, request)
+            })
+          case Failure(f) =>
+            super.handleEntitlementFailure(f)
         }
       }
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -23,8 +23,6 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.{RequestContext, RouteResult}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import spray.json._
-import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.controller.RestApiCommons.{ListLimit, ListSkip}
 import org.apache.openwhisk.core.database.{CacheChangeNotification, DocumentTypeMismatchException, NoDocumentException}
@@ -54,9 +52,6 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
   /** Reserved package names. */
   protected[core] val RESERVED_NAMES = Set("default")
 
-  /** Allowed package request payload field names. */
-  protected[core] val ALLOWED_FIELDS = classOf[WhiskPackage].getDeclaredFields.map(_.getName).toList ++ List("name")
-
   /**
    * Creates or updates package/binding if it already exists. The PUT content is deserialized into a
    * WhiskPackagePut which is a subset of WhiskPackage (it eschews the namespace and entity name since
@@ -76,37 +71,24 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
       if (!RESERVED_NAMES.contains(entityName.name.asString)) {
-        entity(as[Option[JsObject]]) { payload =>
-          val invalidFields = payload
-            .map(_.fields.keySet.filter(key => !ALLOWED_FIELDS.contains(key)))
-            .getOrElse(List())
+        entity(as[WhiskPackagePut]) { content =>
+          val request = content.resolve(entityName.namespace)
+          request.binding.map { b =>
+            logging.debug(this, "checking if package is accessible")
+          }
+          val referencedentities = referencedEntities(request)
 
-          if (invalidFields.isEmpty) {
-            entity(as[WhiskPackagePut]) { content =>
-              val request = content.resolve(entityName.namespace)
-              request.binding.map { b =>
-                logging.debug(this, "checking if package is accessible")
-              }
-              val referencedentities = referencedEntities(request)
-
-              onComplete(entitlementProvider.check(user, Privilege.READ, referencedentities)) {
-                case Success(_) =>
-                  putEntity(
-                    WhiskPackage,
-                    entityStore,
-                    entityName.toDocId,
-                    overwrite,
-                    update(request) _,
-                    () => create(request, entityName))
-                case Failure(f) =>
-                  rewriteEntitlementFailure(f)
-              }
-            }
-          } else {
-            logging.error(
-              this,
-              s"[PUT] rejected because of ${invalidFields.size} invalid fields in request payload: ${invalidFields.head}")
-            terminate(BadRequest, Messages.errorExtractingRequestBody)
+          onComplete(entitlementProvider.check(user, Privilege.READ, referencedentities)) {
+            case Success(_) =>
+              putEntity(
+                WhiskPackage,
+                entityStore,
+                entityName.toDocId,
+                overwrite,
+                update(request) _,
+                () => create(request, entityName))
+            case Failure(f) =>
+              rewriteEntitlementFailure(f)
           }
         }
       } else {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
@@ -22,8 +22,6 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.StandardRoute
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import spray.json._
-import spray.json.DefaultJsonProtocol._
 import spray.json.DeserializationException
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.controller.RestApiCommons.{ListLimit, ListSkip}
@@ -58,11 +56,6 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
   /** Path to Rules REST API. */
   protected val rulesPath = "rules"
 
-  /** Allowed rule request payload field names. */
-  protected[core] val ALLOWED_FIELDS = classOf[WhiskRule].getDeclaredFields.map(_.getName).toList ++ List(
-    "name",
-    "status") // status is set in request playload by test code
-
   /**
    * Creates or updates rule if it already exists. The PUT content is deserialized into a WhiskRulePut
    * which is a subset of WhiskRule (it eschews the namespace, entity name and status since the former
@@ -88,50 +81,37 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
    */
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
-      entity(as[Option[JsObject]]) { payload =>
-        val invalidFields = payload
-          .map(_.fields.keySet.filter(key => !ALLOWED_FIELDS.contains(key)))
-          .getOrElse(List())
+      entity(as[WhiskRulePut]) { content =>
+        val request = content.resolve(entityName.namespace)
+        onComplete(entitlementProvider.check(user, Privilege.READ, referencedEntities(request))) {
+          case Success(_) =>
+            putEntity(
+              WhiskRule,
+              entityStore,
+              entityName.toDocId,
+              overwrite,
+              update(request) _,
+              () => {
+                create(request, entityName)
+              },
+              postProcess = Some { rule: WhiskRule =>
+                if (overwrite == true) {
+                  val getRuleWithStatus = getTrigger(rule.trigger) map { trigger =>
+                    getStatus(trigger, FullyQualifiedEntityName(rule.namespace, rule.name))
+                  } map { status =>
+                    rule.withStatus(status)
+                  }
 
-        if (invalidFields.isEmpty) {
-          entity(as[WhiskRulePut]) { content =>
-            val request = content.resolve(entityName.namespace)
-            onComplete(entitlementProvider.check(user, Privilege.READ, referencedEntities(request))) {
-              case Success(_) =>
-                putEntity(
-                  WhiskRule,
-                  entityStore,
-                  entityName.toDocId,
-                  overwrite,
-                  update(request) _,
-                  () => {
-                    create(request, entityName)
-                  },
-                  postProcess = Some { rule: WhiskRule =>
-                    if (overwrite == true) {
-                      val getRuleWithStatus = getTrigger(rule.trigger) map { trigger =>
-                        getStatus(trigger, FullyQualifiedEntityName(rule.namespace, rule.name))
-                      } map { status =>
-                        rule.withStatus(status)
-                      }
-
-                      onComplete(getRuleWithStatus) {
-                        case Success(r) => completeAsRuleResponse(rule, r.status)
-                        case Failure(t) => terminate(InternalServerError)
-                      }
-                    } else {
-                      completeAsRuleResponse(rule, Status.ACTIVE)
-                    }
-                  })
-              case Failure(f) =>
-                handleEntitlementFailure(f)
-            }
-          }
-        } else {
-          logging.error(
-            this,
-            s"[PUT] rejected because of ${invalidFields.size} invalid fields in request payload: ${invalidFields.head}")
-          terminate(BadRequest, errorExtractingRequestBody)
+                  onComplete(getRuleWithStatus) {
+                    case Success(r) => completeAsRuleResponse(rule, r.status)
+                    case Failure(t) => terminate(InternalServerError)
+                  }
+                } else {
+                  completeAsRuleResponse(rule, Status.ACTIVE)
+                }
+              })
+          case Failure(f) =>
+            handleEntitlementFailure(f)
         }
       }
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
@@ -46,7 +46,6 @@ import org.apache.openwhisk.core.entitlement.Collection
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.types.EntityStore
 import org.apache.openwhisk.http.ErrorResponse
-import org.apache.openwhisk.http.ErrorResponse.terminate
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.database.UserContext
 
@@ -61,9 +60,6 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
 
   /** Database service to CRUD triggers. */
   protected val entityStore: EntityStore
-
-  /** JSON response formatter. */
-  import RestApiCommons.jsonDefaultResponsePrinter
 
   /** Connection context for HTTPS */
   protected lazy val httpsConnectionContext = {
@@ -100,9 +96,6 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
   protected val triggersPath = "triggers"
   protected val url = Uri(s"${controllerProtocol}://localhost:${whiskConfig.servicePort}")
 
-  /** Allowed trigger request payload field names. */
-  protected[core] val ALLOWED_FIELDS = classOf[WhiskTrigger].getDeclaredFields.map(_.getName).toList ++ List("name")
-
   protected implicit val materializer: ActorMaterializer
 
   import RestApiCommons.emptyEntityToJsObject
@@ -122,25 +115,12 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
    */
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
-      entity(as[Option[JsObject]]) { payload =>
-        val invalidFields = payload
-          .map(_.fields.keySet.filter(key => !ALLOWED_FIELDS.contains(key)))
-          .getOrElse(List())
-
-        if (invalidFields.isEmpty) {
-          entity(as[WhiskTriggerPut]) { content =>
-            putEntity(WhiskTrigger, entityStore, entityName.toDocId, overwrite, update(content) _, () => {
-              create(content, entityName)
-            }, postProcess = Some { trigger =>
-              completeAsTriggerResponse(trigger)
-            })
-          }
-        } else {
-          logging.error(
-            this,
-            s"[PUT] rejected because of ${invalidFields.size} invalid fields in request payload: ${invalidFields.head}")
-          terminate(BadRequest, Messages.errorExtractingRequestBody)
-        }
+      entity(as[WhiskTriggerPut]) { content =>
+        putEntity(WhiskTrigger, entityStore, entityName.toDocId, overwrite, update(content) _, () => {
+          create(content, entityName)
+        }, postProcess = Some { trigger =>
+          completeAsTriggerResponse(trigger)
+        })
       }
     }
   }


### PR DESCRIPTION
Revert validate PUT playload for unexpected fields to reject with `400 Bad Request` for Action/Package/Trigger/Rule create/update requests.

## Description



## Related issue and scope
## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [x] Breaking change (a bug fix or enhancement which changes existing behavior).

