### PR TITLE
Increase toStrictTimeout value to omit intermittent timeout exceptions

### DIFF
--- a/tests/src/test/scala/common/rest/WskRestOperations.scala
+++ b/tests/src/test/scala/common/rest/WskRestOperations.scala
@@ -1132,7 +1132,7 @@ trait RunRestCmd extends Matchers with ScalaFutures with SwaggerValidator {
 
   val protocol: String = loadConfigOrThrow[String]("whisk.controller.protocol")
   val idleTimeout: FiniteDuration = 90 seconds
-  val toStrictTimeout: FiniteDuration = 30 seconds
+  val toStrictTimeout: FiniteDuration = 60 seconds
   val queueSize = 10
   val maxOpenRequest = 1024
   val basePath = Path("/api/v1")


### PR DESCRIPTION
In our tests we encounter every now and then failing tests that fail because the HttpEntity.toStrict timed out after 30 seconds. In order to avoid these timeouts I propose to increase the defined timeout from 30 to 60 seconds.

## Description
This code change increases the timeout value `toStrictTimeout` from 30 to 60 seconds. Intention is to avoid the following error: 

```
ERROR: deleting asset failed for big-hello: org.scalatest.exceptions.TestFailedException: The future returned an exception of type: java.util.concurrent.TimeoutException, with message: HttpEntity.toStrict timed out after 30 seconds while still waiting for outstanding data.

system.basic.WskActionTests > Whisk actions should invoke action with large code FAILED
```

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).