### PR TITLE
Consider busy pool size and waiting messages in ping protocol

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -259,8 +259,7 @@ case class PingMessage(instance: InvokerInstanceId,
                        hasDiskPressure: Boolean = false,
                        rootfspcent: Int = -1,
                        logsfspcent: Int = -1,
-                       busyPoolSize: Int = -1,
-                       waitingMessages: Int = -1)
+                       scheduled: Int = -1)
     extends Message {
   override def serialize = PingMessage.serdes.write(this).compactPrint
 }
@@ -275,8 +274,7 @@ object PingMessage extends DefaultJsonProtocol {
       "hasDiskPressure",
       "rootfspcent",
       "logsfspcent",
-      "busyPoolSize",
-      "waitingMessages")
+      "scheduled")
 }
 
 trait EventMessageBody extends Message {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -259,7 +259,7 @@ case class PingMessage(instance: InvokerInstanceId,
                        hasDiskPressure: Boolean = false,
                        rootfspcent: Int = -1,
                        logsfspcent: Int = -1,
-                       scheduled: Int = -1)
+                       running: Int = -1)
     extends Message {
   override def serialize = PingMessage.serdes.write(this).compactPrint
 }
@@ -267,7 +267,7 @@ case class PingMessage(instance: InvokerInstanceId,
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
   implicit val serdes =
-    jsonFormat(PingMessage.apply, "name", "isBlacklisted", "hasDiskPressure", "rootfspcent", "logsfspcent", "scheduled")
+    jsonFormat(PingMessage.apply, "name", "isBlacklisted", "hasDiskPressure", "rootfspcent", "logsfspcent", "running")
 }
 
 trait EventMessageBody extends Message {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -258,7 +258,9 @@ case class PingMessage(instance: InvokerInstanceId,
                        isBlacklisted: Boolean = false,
                        hasDiskPressure: Boolean = false,
                        rootfspcent: Int = -1,
-                       logsfspcent: Int = -1)
+                       logsfspcent: Int = -1,
+                       busyPoolSize: Int = -1,
+                       waitingMessages: Int = -1)
     extends Message {
   override def serialize = PingMessage.serdes.write(this).compactPrint
 }
@@ -266,7 +268,15 @@ case class PingMessage(instance: InvokerInstanceId,
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
   implicit val serdes =
-    jsonFormat(PingMessage.apply, "name", "isBlacklisted", "hasDiskPressure", "rootfspcent", "logsfspcent")
+    jsonFormat(
+      PingMessage.apply,
+      "name",
+      "isBlacklisted",
+      "hasDiskPressure",
+      "rootfspcent",
+      "logsfspcent",
+      "busyPoolSize",
+      "waitingMessages")
 }
 
 trait EventMessageBody extends Message {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -267,14 +267,7 @@ case class PingMessage(instance: InvokerInstanceId,
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
   implicit val serdes =
-    jsonFormat(
-      PingMessage.apply,
-      "name",
-      "isBlacklisted",
-      "hasDiskPressure",
-      "rootfspcent",
-      "logsfspcent",
-      "scheduled")
+    jsonFormat(PingMessage.apply, "name", "isBlacklisted", "hasDiskPressure", "rootfspcent", "logsfspcent", "scheduled")
 }
 
 trait EventMessageBody extends Message {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -389,7 +389,7 @@ class InvokerReactive(
           hasDiskPressure = rootfspcent >= rootfspecentmax || logsfspcent >= fspecentmax,
           rootfspcent = rootfspcent,
           logsfspcent = logsfspcent,
-          scheduled = poolState.busy + poolState.waiting))
+          running = poolState.busy + poolState.waiting))
       .andThen {
         case Failure(t) => logging.error(this, s"failed to ping the controller: $t")
       }


### PR DESCRIPTION
Transport container pool info in ping protocol and extend `Offline` invoker state (if applicable) by substate, timestamp at which state changed and the number of scheduled activations (sum of busy containers and waiting messages) in case the invoker is disabled. This allows to programmatically determine if an invoker is free of work if it is disabled.

## Description

For `Offline` invoker state the `varz` endpoint will show the following info depending on whether the invoker is disabled, has disk pressure or is offline because of other reasons (e.g. state timeout).

```
{"invoker2/10.x/invoker-xxxxx":"down"}
{"invoker0/10.x/invoker-xxxxx":"down/disabled(running=19,rootfs=36%,logsfs=17%,time=1648713488516)"}
{"invoker2/10.x/invoker-xxxxx":"down/diskpressure(running=0,rootfs=91%,logsfs=43%,time=1648713488516)"}
```
 
## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation