### PR TITLE
Retry action activation post call in case of errors

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
@@ -439,7 +439,9 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
 
         singleRequest(request).recoverWith {
           case t if retries > 0 =>
-            logging.warn(this, s"trigger-fired action '${rule.action}' failed to invoke with $t, retry ($retries retries left)..")
+            logging.warn(
+              this,
+              s"trigger-fired action '${rule.action}' failed to invoke with $t, retry ($retries retries left)..")
             postActivation(user, rule, args, retries - 1)
         }
       }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
@@ -51,6 +51,8 @@ import org.apache.openwhisk.core.database.UserContext
 import org.apache.openwhisk.http.ErrorResponse.terminate
 import org.apache.openwhisk.http.Messages.errorExtractingRequestBody
 
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+
 /** A trait implementing the triggers API. */
 trait WhiskTriggersApi extends WhiskCollectionAPI {
   services: WhiskServices =>
@@ -411,6 +413,13 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
     Future.sequence(ruleResults)
   }
 
+  private def singleRequest4Test(request: HttpRequest, retries: Int): Future[HttpResponse] = {
+    if (retries == 0)
+      singleRequest(request)
+    else
+      Future.failed(new akka.stream.scaladsl.TcpIdleTimeoutException("TCP idle-timeout encountered on connection to [localhost:8080]", 60 seconds))
+  }
+
   /**
    * Posts an action activation. Currently done by posting internally to the controller.
    * TODO: use a proper path that does not route through HTTP.
@@ -419,7 +428,7 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
    * @param args the arguments to post to the action
    * @return a future with the HTTP response from the action activation
    */
-  private def postActivation(user: Identity, rule: ReducedRule, args: JsObject)(
+  private def postActivation(user: Identity, rule: ReducedRule, args: JsObject, retries: Int = 3)(
     implicit transid: TransactionId): Future[HttpResponse] = {
     // Build the url to invoke an action mapped to the rule
     val actionUrl = baseControllerPath / rule.action.path.root.asString / "actions"
@@ -436,7 +445,11 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
           headers = List(Authorization(creds), transid.toHeader),
           entity = HttpEntity(MediaTypes.`application/json`, args.compactPrint))
 
-        singleRequest(request)
+        singleRequest4Test(request, retries).recoverWith {
+          case t if retries > 0 =>
+            logging.warn(this, s"trigger-fired action '${rule.action}' failed to invoke with $t, retry ($retries retries left)..")
+            postActivation(user, rule, args, retries - 1)
+        }
       }
       .getOrElse(Future.failed(new NoCredentialsAvailable()))
   }


### PR DESCRIPTION
Retry action activation post call in case of errors.

## Description

Retry action activation post call in case of errors. This is to recover from `TcpIdleTimeoutException` which shows up regularly but not very frequent in the logs and which indicates a race condition in Akka Http.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).