### PR TITLE
Update image ow-utils to python3-pip.

### DIFF
--- a/tools/ow-utils/Dockerfile
+++ b/tools/ow-utils/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
   nodejs \
   npm \
   python \
-  python-pip \
+  python3-pip \
   wget \
   zip \
   locales \


### PR DESCRIPTION
- The updated semeru java runtime does not contain python-pip anymore. Therefore moving to python3-pip instead.
