### PR TITLE
Set source and target to url values to avoid local_endpoints_not_supported error

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ReplicatorTests.scala
@@ -460,11 +460,23 @@ class ReplicatorTests
           try {
             // Create a database that is already expired
             val expiredClient = createDatabase(expiredName, Some(designDocPath))
-            replicatorClient.putDoc(expiredName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
+            replicatorClient
+              .putDoc(
+                expiredName,
+                JsObject(
+                  "source" -> "https://account.cloudant.com".toJson,
+                  "target" -> "https://account.cloudant.com".toJson))
+              .futureValue
 
             // Create a database that is not yet expired
             val notExpiredClient = createDatabase(notExpiredName, Some(designDocPath))
-            replicatorClient.putDoc(notExpiredName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
+            replicatorClient
+              .putDoc(
+                notExpiredName,
+                JsObject(
+                  "source" -> "https://account.cloudant.com".toJson,
+                  "target" -> "https://account.cloudant.com".toJson))
+              .futureValue
 
             // Trigger replication and verify the expired database is deleted while the unexpired one is kept
             val (createdDatabases, deletedReplicationDocs, deletedDatabases) =
@@ -515,12 +527,22 @@ class ReplicatorTests
             // Create a database that is expired with correct prefix
             val correctPrefixClient = createDatabase(correctPrefixName, Some(designDocPath))
             replicatorClient
-              .putDoc(correctPrefixName, JsObject("source" -> "".toJson, "target" -> "".toJson))
+              .putDoc(
+                correctPrefixName,
+                JsObject(
+                  "source" -> "https://account.cloudant.com".toJson,
+                  "target" -> "https://account.cloudant.com".toJson))
               .futureValue
 
             // Create a database that is expired with wrong prefix
             val wrongPrefixClient = createDatabase(wrongPrefixName, Some(designDocPath))
-            replicatorClient.putDoc(wrongPrefixName, JsObject("source" -> "".toJson, "target" -> "".toJson)).futureValue
+            replicatorClient
+              .putDoc(
+                wrongPrefixName,
+                JsObject(
+                  "source" -> "https://account.cloudant.com".toJson,
+                  "target" -> "https://account.cloudant.com".toJson))
+              .futureValue
 
             // Trigger replication and verify the expired database with correct prefix is deleted while the db with the wrong prefix is kept
             val (createdDatabases, deletedReplicationDocs, deletedDatabases) =


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Set source and target for replication documents to URL like values to avoid `local_endpoints_not_supported` error on creation.
## Description
Set source and target for replication documents to URL like values to avoid `local_endpoints_not_supported` error on creation . Cloudant seems to has changed behavior and does not allow anymore the creation of replication documents with empty source and target fields. Cloudant rejects the create in this case with error `forbidden', 'local_endpoints_not_supported'.`

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).
