### PR TITLE
Docker images cleanup at github action start.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,6 +31,13 @@ jobs:
           distribution: 'temurin'
           java-version: 8
 
+      - name: Docker Images Cleanup
+        run: |
+          df -h
+          docker image ls
+          docker image rm $(docker image ls -q) -f
+          df -h
+
       - name: befor install -> docker.sh
         run:  ./tools/travis/docker.sh
 
@@ -53,7 +60,11 @@ jobs:
       #  run: ./tools/travis/runUnitTests.sh && ./tools/travis/checkAndUploadLogs.sh unit db
 
       - name: script -> System Tests
-        run: ./tools/travis/runSystemTests.sh && ./tools/travis/checkAndUploadLogs.sh system
+        run: |
+          df -h \
+          && ./tools/travis/runSystemTests.sh \
+          && df -h \
+          && ./tools/travis/checkAndUploadLogs.sh system
 
       #- name: script -> Multi-Runtime Tests
       #  run: ./tools/travis/runMultiRuntimeTests.sh && ./tools/travis/checkAndUploadLogs.sh multi-runtime

--- a/tools/travis/runSystemTests.sh
+++ b/tools/travis/runSystemTests.sh
@@ -18,6 +18,7 @@
 #
 
 set -e
+set -x
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../.."


### PR DESCRIPTION
- Cleanup docker images at start to free disk space. Otherwise it can happen that the invokers do not allow action execution as the free disk space is less than 85% during the tests.
- Output the invoker and controller logs in case there was an error during test execution. Allows easier debugging.


<!--- Provide a concise summary of your changes in the Title -->

## Description
- Cleanup docker images at start to free disk space. Otherwise it can happen that the invokers do not allow action execution as the free disk space is less than 85% during the tests.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] n/a

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

