### PR TITLE
Blacklist on account level (cont.)

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/NamespaceBlacklist.scala
@@ -81,6 +81,9 @@ class NamespaceBlacklist(authStore: AuthStore) {
         newBlacklist
       }
   }
+
+  /** This is so that we can easily log the blacklist for debugging. */
+  override def toString() = blacklist.toString()
 }
 
 object NamespaceBlacklist {


### PR DESCRIPTION
Blacklist on account level

## Description
This code change enables the blacklisting on account level. By doing so invokes on all namespaces of the blacklisted account will be rejected (`error: Unable to invoke action.. Too many requests in the last minute (count: 1, allowed: 0).`)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation