### PR TITLE
Update jdk parent image to tag 'open-8u402-b06-jdk-focal'.

### DIFF
--- a/common/scala/Dockerfile
+++ b/common/scala/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM ibm-semeru-runtimes:open-8u392-b08-jdk-focal
+FROM ibm-semeru-runtimes:open-8u402-b06-jdk-focal
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/tools/ow-utils/Dockerfile
+++ b/tools/ow-utils/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM ibm-semeru-runtimes:open-8u392-b08-jdk-focal
+FROM ibm-semeru-runtimes:open-8u402-b06-jdk-focal
 
 ENV DOCKER_VERSION 24.0.6
 ENV KUBECTL_VERSION v1.16.3


### PR DESCRIPTION
- Update jdk parent image to ibm-semeru-runtimes:open-8u402-b06-jdk-focal to get latest vulnerability fixes.

## Description
- Update jdk parent image to ibm-semeru-runtimes:open-8u402-b06-jdk-focal to get latest vulnerability fixes.

## Related issue and scope
- n/a

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.
