### PR TITLE
Image monitor (cont.)

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/ImageMonitor.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/ImageMonitor.scala
@@ -302,7 +302,8 @@ class ImageMonitor(cluster: String,
           if (build != docbuild || ip != docip || pod != docpod) {
             // write doc to image store to update metadata (eg invoker ip) if changed. after a new deployment
             // zookeeper persistent store is deleted and each invoker will most likely get a new identity (ip)
-            imageStore.putDoc(id, rev, toJson(images)).flatMap {
+            // filter out outdates images on sync with image store
+            imageStore.putDoc(id, rev, toJson(images, true)).flatMap {
               case Right(res) if (ip != docip || build != docbuild) =>
                 waitForEntriesToAppearInView(images.size).flatMap {
                   case count =>


### PR DESCRIPTION
Record all invoked docker images and related actions and put them in store. Make sure the couchdb view is updated accordingly. Filter out outdated images on initial sync with image store.

## Description

Record all invoked docker images and related actions and put them in store.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).